### PR TITLE
Improved ski file parsing.

### DIFF
--- a/tpm2.0/include/tpm2_kmyth_io.h
+++ b/tpm2.0/include/tpm2_kmyth_io.h
@@ -282,11 +282,13 @@ int decodeBase64Data(unsigned char *base64_data,
  * @param[in]  delim        String value representing the expected delimiter (the
  *                          delimiter value for the block type being retrieved)
  *
+ * @param[in] next_delim    String value representing the next expected
+ *                          delimiter.
  * @return
  */
 int kmyth_getSkiBlock(char **contents,
                       size_t *remaining, unsigned char **block,
-                      size_t *blocksize, char *delim);
+                      size_t *blocksize, char *delim, char *next_delim);
 
 /**
  * @brief Prints a string to the specified file.


### PR DESCRIPTION
Modified kmyth_getSkiBlock to take the expected next delimiter as an argument and use that to check for the end of the block. This also takes care of the problem when the original filename contains `-`.