### PR TITLE
Fixed segfaults caused by failing to check values are non-NULL.

### DIFF
--- a/tpm2.0/src/seal/main.c
+++ b/tpm2.0/src/seal/main.c
@@ -160,7 +160,10 @@ int main(int argc, char **argv)
   if (inPath == NULL)
   {
     kmyth_log(LOG_ERR, "no input (file to be sealed) specified ... exiting");
-    kmyth_clear(authString, strlen(authString));
+    if (authString != NULL)
+    {
+      kmyth_clear(authString, strlen(authString));
+    }
     kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
     free(outPath);
     return 1;
@@ -170,7 +173,10 @@ int main(int argc, char **argv)
   if (verifyInputFilePath(inPath))
   {
     kmyth_log(LOG_ERR, "input path (%s) is not valid ... exiting", inPath);
-    kmyth_clear(authString, strlen(authString));
+    if (authString != NULL)
+    {
+      kmyth_clear(authString, strlen(authString));
+    }
     kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
     free(outPath);
     return 1;
@@ -203,7 +209,10 @@ int main(int argc, char **argv)
     {
       kmyth_log(LOG_ERR, "invalid default filename derived ... exiting");
       free(temp_str);
-      kmyth_clear(authString, strlen(authString));
+      if (authString != NULL)
+      {
+        kmyth_clear(authString, strlen(authString));
+      }
       kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
       return 1;
     }
@@ -230,7 +239,10 @@ int main(int argc, char **argv)
   {
     kmyth_log(LOG_ERR, "output path (%s) is not valid ... exiting", outPath);
     free(outPath);
-    kmyth_clear(authString, strlen(authString));
+    if (authString != NULL)
+    {
+      kmyth_clear(authString, strlen(authString));
+    }
     kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
     return 1;
   }
@@ -242,7 +254,10 @@ int main(int argc, char **argv)
   {
     kmyth_log(LOG_ERR, "kmyth-seal error ... exiting");
     free(outPath);
-    kmyth_clear(authString, strlen(authString));
+    if (authString != NULL)
+    {
+      kmyth_clear(authString, strlen(authString));
+    }
     kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
     return 1;
   }

--- a/tpm2.0/src/util/tpm2_config_tools.c
+++ b/tpm2.0/src/util/tpm2_config_tools.c
@@ -202,6 +202,12 @@ int tpm2_init_sapi(TSS2_SYS_CONTEXT ** sapi_ctx, TSS2_TCTI_CONTEXT * tcti_ctx)
 //############################################################################
 int tpm2_free_resources(TSS2_SYS_CONTEXT ** sapi_ctx)
 {
+  // If the input context is null there's nothing to do.
+  if ((sapi_ctx == NULL) || (*sapi_ctx == NULL))
+  {
+    return 0;
+  }
+
   int retval = 0;
 
   // flush any remaining loaded or active session handle values


### PR DESCRIPTION
This should fix #7 and possibly some other segfault conditions we haven't seen yet.