### PR TITLE
Sealing on empty file patch

### DIFF
--- a/tpm2/src/util/tpm2_kmyth_seal.c
+++ b/tpm2/src/util/tpm2_kmyth_seal.c
@@ -667,7 +667,7 @@ int kmyth_wrap_input(char *inPath,
   kmyth_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_length);
   
   // validate non-empty plaintext buffer specified
-  if (data_length == 0)
+  if (data_length == 0 || data == NULL)
   {
     kmyth_log(LOG_ERR, "no input data ... exiting");
     free(data);

--- a/tpm2/src/util/tpm2_kmyth_seal.c
+++ b/tpm2/src/util/tpm2_kmyth_seal.c
@@ -666,6 +666,7 @@ int kmyth_wrap_input(char *inPath,
   }
   kmyth_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_length);
   
+  // validate non-empty plaintext buffer specified
   if (data_length == 0)
   {
     kmyth_log(LOG_ERR, "no input data ... exiting");

--- a/tpm2/src/util/tpm2_kmyth_seal.c
+++ b/tpm2/src/util/tpm2_kmyth_seal.c
@@ -665,6 +665,13 @@ int kmyth_wrap_input(char *inPath,
     return 1;
   }
   kmyth_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_length);
+  
+  if (data_length == 0)
+  {
+    kmyth_log(LOG_ERR, "no input data ... exiting");
+    free(data);
+    return 1;
+  }
 
   // encrypt (wrap) input data read in (e.g., client certificate private .pem)
   if (kmyth_encrypt_data(data,


### PR DESCRIPTION
Added a check in `kmyth_wrap_input` in `src/util/tpm2_kmyth_seal.c` to validate that the file being sealed is not empty.