### PR TITLE
Fix memory leaks in utility functions

### DIFF
--- a/tpm2/src/util/tls_util.c
+++ b/tpm2/src/util/tls_util.c
@@ -393,5 +393,6 @@ int get_key_from_kmip_server(BIO * bio,
 
   *key_size = (size_t) key_len;
 
+  kmip_destroy(&kmip_context);
   return 0;
 }

--- a/tpm2/src/util/tpm2_kmyth_io.c
+++ b/tpm2/src/util/tpm2_kmyth_io.c
@@ -775,6 +775,7 @@ int tpm2_kmyth_read_ski_file(char *input_path,
     }
   }
 
+  free(raw_seal_input_fname_data);
   free(raw_cipher_str_data);
   free(decoded_pcr_select_list_data);
   free(decoded_sk_pub_data);


### PR DESCRIPTION
This change fixes two memory leaks in the utils library, freeing the libkmip context when retrieving a key from a KMIP server and freeing the filename block used when reading in .ski files.

Partially addresses #25