### PR TITLE
Add error checking to tpm2_unpack_uint32_to_str

### DIFF
--- a/tpm2/include/tpm2_info_tools.h
+++ b/tpm2/include/tpm2_info_tools.h
@@ -66,8 +66,10 @@ int tpm2_get_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator);
  * 
  * @param[out] str_repr   String representation output -
  *                        passed as pointer to the string
+ *
+ * @return 0 if success, 1 if error
  */
-void tpm2_unpack_uint32_to_str(uint32_t uint_value, char **str_repr);
+int tpm2_unpack_uint32_to_str(uint32_t uint_value, char **str_repr);
 
 /**
  * @brief Translates error string from hex into human readable.

--- a/tpm2/src/util/tpm2_info_tools.c
+++ b/tpm2/src/util/tpm2_info_tools.c
@@ -86,8 +86,12 @@ int tpm2_get_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator)
   // obtain string representation of TPM2_PT_MANUFACTURER property
   char *manufacturer_str;
 
-  tpm2_unpack_uint32_to_str(capData.data.tpmProperties.tpmProperty[0].value,
-                            &manufacturer_str);
+  if (tpm2_unpack_uint32_to_str(capData.data.tpmProperties.tpmProperty[0].value,
+                                &manufacturer_str))
+  {
+    kmyth_log(LOG_ERR, "unable to get vendor string ... exiting");
+    return 1;
+  }
 
   // Check the manufacturer string against the known simulator manufacturer strings.
   size_t i = 0;
@@ -113,11 +117,19 @@ int tpm2_get_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator)
 //############################################################################
 // tpm2_unpack_uint32_to_str()
 //############################################################################
-void tpm2_unpack_uint32_to_str(uint32_t uint_value, char **str_repr)
+int tpm2_unpack_uint32_to_str(uint32_t uint_value, char **str_repr)
 {
-  asprintf(str_repr, "%c%c%c%c", ((uint8_t *) & uint_value)[3],
-           ((uint8_t *) & uint_value)[2], ((uint8_t *) & uint_value)[1],
-           ((uint8_t *) & uint_value)[0]);
+  if (asprintf(str_repr, "%c%c%c%c",
+               ((uint8_t *) & uint_value)[3],
+               ((uint8_t *) & uint_value)[2],
+               ((uint8_t *) & uint_value)[1],
+               ((uint8_t *) & uint_value)[0]) < 0)
+  {
+    kmyth_log(LOG_ERR, "error unpacking uint32 to string ... exiting");
+    return 1;
+  }
+
+  return 0;
 }
 
 //############################################################################


### PR DESCRIPTION
This change updates the tpm2_unpack_uint32_to_str utility function to support error checking the asprintf call. The function now returns an int status code for success or failure and logs an error when it occurs. The usage of this function in tpm2_get_impl_type has been updated to also handle the new error... handling.

Partially addresses #25