### PR TITLE
Add error checking to various Kmyth object utility functions

### DIFF
--- a/tpm2/include/tpm/object_tools.h
+++ b/tpm2/include/tpm/object_tools.h
@@ -43,12 +43,12 @@
  *                             creation of a Kmyth object - passed as a
  *                             pointer to this struct
  *
- * @return None 
+ * @return 0 if success, 1 if error.
  */
-void tpm2_init_kmyth_object_sensitive(TPM2B_AUTH object_auth,
-                                      uint8_t * object_data,
-                                      size_t object_dataSize,
-                                      TPM2B_SENSITIVE_CREATE * sensitiveArea);
+int tpm2_init_kmyth_object_sensitive(TPM2B_AUTH object_auth,
+                                     uint8_t * object_data,
+                                     size_t object_dataSize,
+                                     TPM2B_SENSITIVE_CREATE * sensitiveArea);
 
 /**
  * @brief Fill in public template used to create Kmyth object.
@@ -96,9 +96,9 @@ int tpm2_init_kmyth_object_template(bool isKey, TPM2B_DIGEST auth_policy,
  * @param[out] objectAttrib Object attributes struct (TPMA_OBJECT) to
  *                          be configured - passed as a pointer to this buffer
  *
- * @return None
+ * @return 0 if success, 1 if error.
  */
-void tpm2_init_kmyth_object_attributes(bool isKey, TPMA_OBJECT * objectAttrib);
+int tpm2_init_kmyth_object_attributes(bool isKey, TPMA_OBJECT * objectAttrib);
 
 /**
  * @brief Set parameters for Kmyth objects (SRK, SK, or sealed data).

--- a/tpm2/src/tpm/kmyth_seal_unseal_impl.c
+++ b/tpm2/src/tpm/kmyth_seal_unseal_impl.c
@@ -518,8 +518,12 @@ int tpm2_kmyth_seal_data(TSS2_SYS_CONTEXT * sapi_ctx,
   sdo_sensitive.sensitive.userAuth.size = 0;  // and empty userAuth buffers
 
   // Populate buffer with data to be sealed and set size to its length in bytes
-  tpm2_init_kmyth_object_sensitive(sdo_authVal,
-                                   sdo_data, sdo_dataSize, &sdo_sensitive);
+  if (tpm2_init_kmyth_object_sensitive(sdo_authVal,
+                                       sdo_data, sdo_dataSize, &sdo_sensitive))
+  {
+    kmyth_log(LOG_ERR, "error populating data to be sealed ... exiting");
+    return 1;
+  }
 
   // Create (empty) and setup public area of "template" for sealed data object
   TPM2B_PUBLIC sdo_template;

--- a/tpm2/src/tpm/object_tools.c
+++ b/tpm2/src/tpm/object_tools.c
@@ -42,7 +42,15 @@ int tpm2_init_kmyth_object_sensitive(TPM2B_AUTH object_auth,
   sensitiveArea->sensitive.data.size = object_dataSize;
   // TODO: Calling memcpy with either source or dest addresses set to NULL
   // is technically undefined behavior. However, object_data is expected
-  // to be NULL in certain conditions.
+if ( (object_dataSize == 0) || (object_data == NULL) )
+{
+   sensitiveArea->sensitive.data.size = 0;
+}
+else
+{
+    sensitiveArea->sensitive.data.size = object_dataSize;
+    memcpy(&sensitiveArea.sensitive.data.buffer, object_data, sensitiveArea.sensitive.data.size);
+}
   memcpy(&sensitiveArea->sensitive.data.buffer, object_data,
          sensitiveArea->sensitive.data.size);
   if (object_dataSize > 0)

--- a/tpm2/src/tpm/object_tools.c
+++ b/tpm2/src/tpm/object_tools.c
@@ -40,21 +40,14 @@ int tpm2_init_kmyth_object_sensitive(TPM2B_AUTH object_auth,
   // For data, the data buffer size cannot be zero - we must populate the
   // buffer with data to be sealed and set the size to its length in bytes.
   sensitiveArea->sensitive.data.size = object_dataSize;
-  // TODO: Calling memcpy with either source or dest addresses set to NULL
-  // is technically undefined behavior. However, object_data is expected
-if ( (object_dataSize == 0) || (object_data == NULL) )
-{
-   sensitiveArea->sensitive.data.size = 0;
-}
-else
-{
-    sensitiveArea->sensitive.data.size = object_dataSize;
-    memcpy(&sensitiveArea.sensitive.data.buffer, object_data, sensitiveArea.sensitive.data.size);
-}
-  memcpy(&sensitiveArea->sensitive.data.buffer, object_data,
-         sensitiveArea->sensitive.data.size);
-  if (object_dataSize > 0)
+  if ( (object_dataSize == 0) || (object_data == NULL) )
   {
+    sensitiveArea->sensitive.data.size = 0;
+  }
+  else
+  {
+    sensitiveArea->sensitive.data.size = object_dataSize;
+    memcpy(&sensitiveArea->sensitive.data.buffer, object_data, sensitiveArea->sensitive.data.size);
     kmyth_log(LOG_DEBUG,
               "put %d-byte data field in sensitive area", object_dataSize);
   }

--- a/tpm2/src/tpm/storage_key_tools.c
+++ b/tpm2/src/tpm/storage_key_tools.c
@@ -313,8 +313,12 @@ int tpm2_kmyth_derive_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE srk_handle,
   srk_sensitive.sensitive.data.size = 0;
   srk_sensitive.sensitive.userAuth.size = 0;
 
-  tpm2_init_kmyth_object_sensitive(sps_auth, object_data, object_data_size,
-                                   &srk_sensitive);
+  if (tpm2_init_kmyth_object_sensitive(sps_auth, object_data, object_data_size,
+                                       &srk_sensitive))
+  {
+    kmyth_log(LOG_ERR, "error initializing sensitive data ... exiting");
+    return 1;
+  }
 
   // Create and setup public data "template" for the SRK
   TPM2B_PUBLIC srk_template;
@@ -373,7 +377,12 @@ int tpm2_kmyth_create_sk(TSS2_SYS_CONTEXT * sapi_ctx,
 
   sk_sensitive.sensitive.data.size = 0;
   sk_sensitive.sensitive.userAuth.size = 0;
-  tpm2_init_kmyth_object_sensitive(sk_authVal, skd, skd_size, &sk_sensitive);
+  if (tpm2_init_kmyth_object_sensitive
+      (sk_authVal, skd, skd_size, &sk_sensitive))
+  {
+    kmyth_log(LOG_ERR, "error initializing sensitive data ... exiting");
+    return 1;
+  }
 
   // Create empty and then set up public data "template" for storage key
   TPM2B_PUBLIC sk_template;


### PR DESCRIPTION
This changes adds a series of error checking updates and fixes to the Kmyth object utility function suite. It also updates the function signature of two utilities to support returning error codes. The usage of these two functions in other files have been updated to reflect the new function signatures.

Partially addresses #25