### PR TITLE
Updated seal/unseal parameters to require auth sizes

### DIFF
--- a/tpm2/include/kmyth.h
+++ b/tpm2/include/kmyth.h
@@ -22,30 +22,36 @@
  * @param[in]  output_path       Path to .ski file where the kmyth-seal output
  *                               will be written
  *
- * @param[in]  auth_string       Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization string to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               wrapping key) created by kmyth-seal
+ *
+ * @param[in]  auth_bytes_len    length of auth_string
+ *
+ * @param[in]  owner_auth_bytes  TPM owner (storage) hierarchy password.
+ *                               EmptyAuth by default, but, if it has been
+ *                               changed (e.g., by tpm2_takeownership), user
+ *                               must provide via this parameter.
+ *
+ * @param[in]  oa_bytes_len      number of bytes in owner_auth_passwd
  *
  * @param[in]  pcrs_string       String indicating which PCRs, if any, to apply
  *                               to the authorization policy for Kmyth TPM
  *                               objects created by kmyth-seal.
  *                               (i.e., storage key and sealed wrapping key)
- *
- * @param[in]  owner_auth_passwd TPM owner (storage) hierarchy password.
- *                               EmptyAuth by default, but, if it has been
- *                               changed (e.g., by tpm2_takeownership), user
- *                               must provide via this parameter.
+ *                               Must be NULL or '\0' terminated
  *
  * @param[in]  cipher_string     String indicating the symmetric cipher to use
- *                               for encrypting the input data.
+ *                               for encrypting the input data. Must be NULL 
+ *                               or '\0' terminated
  *
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
                     uint8_t ** output, size_t *output_len,
-                    char *auth_string,
-                    char *pcrs_string,
-                    char *owner_auth_passwd, char *cipher_string);
+                    uint8_t * auth_bytes, size_t auth_bytes_len,
+                    uint8_t * owner_auth_bytes, size_t oa_bytes_len,
+                    char *pcrs_string, char *cipher_string);
 
 /**
  * @brief High-level function implementing kmyth-unseal
@@ -59,21 +65,25 @@ int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
  *
  * @param[out] output_len        The size of the output data
  *
- * @param[in]  auth_string       Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization string to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               data) created by kmyth-seal
  *
- * @param[in]  owner_auth_passwd TPM owner (storage) hierarchy password.
+ * @param[in]  auth_bytes_len    Number of bytes in auth_bytes
+ *
+ * @param[in]  owner_auth_bytes  TPM owner (storage) hierarchy password.
  *                               EmptyAuth by default, but, if it has been
  *                               changed (e.g., by tpm2_takeownership), user
- *                               must provide via this parameter. (passed as
- *                               a string)
+ *                               must provide via this parameter.
+ *
+ * @param[in] oa_bytes_len       Number of bytes in owner_auth_bytes
  *
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
                       uint8_t ** output, size_t *output_len,
-                      char *auth_string, char *owner_auth_passwd);
+                      uint8_t * auth_bytes, size_t auth_bytes_len,
+                      uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 
 /**
  * @brief High-level function implementing kmyth-seal for files
@@ -83,31 +93,38 @@ int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
  * @param[out] output            The result of tpm2_kmyth_seal as bytes in
  *                               .ski format
  *
- * @param[out] output_length     The length, in bytes, of output
+ * @param[out] output_len        The length, in bytes, of output
  *
- * @param[in]  auth_string       Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization string to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               wrapping key) created by kmyth-seal
  *
- * @param[in]  pcrs_string       String indicating which PCRs, if any, to apply
- *                               to the authorization policy for Kmyth TPM
- *                               objects created by kmyth-seal.
- *                               (i.e., storage key and sealed wrapping key)
+ * @param[in]  auth_bytes_len    length of auth_string
  *
- * @param[in]  owner_auth_passwd TPM owner (storage) hierarchy password.
+ * @param[in]  owner_auth_bytes  TPM owner (storage) hierarchy password.
  *                               EmptyAuth by default, but, if it has been
  *                               changed (e.g., by tpm2_takeownership), user
  *                               must provide via this parameter.
  *
+ * @param[in]  oa_bytes_len      number of bytes in owner_auth_passwd
+ *
+ * @param[in]  pcrs_string       String indicating which PCRs, if any, to apply
+ *                               to the authorization policy for Kmyth TPM
+ *                               objects created by kmyth-seal.
+ *                               (i.e., storage key and sealed wrapping key
+ *                               Must be NULL or '\0' terminated
+ *
  * @param[in]  cipher_string     String indicating the symmetric cipher to use
- *                               for encrypting the input data.
+ *                               for encrypting the input data. Must be NULL
+ *                               or '\0' terminated
  *
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal_file(char *input_path,
-                         uint8_t ** output, size_t *output_length,
-                         char *auth_string, char *pcrs_string,
-                         char *owner_auth_passwd, char *cipher_string);
+                         uint8_t ** output, size_t *output_len,
+                         uint8_t * auth_bytes, size_t auth_bytes_len,
+                         uint8_t * owner_auth_bytes, size_t oa_bytes_len,
+                         char *pcrs_string, char *cipher_string);
 
 /**
  * @brief High-level function implementing kmyth-unseal for files
@@ -120,19 +137,23 @@ int tpm2_kmyth_seal_file(char *input_path,
  * @param[out] output_size       Size (in bytes) of decrypted result
  *                               (passed as pointer to size value)
  *
- * @param[in]  auth_string       Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization string to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               data) created by kmyth-seal
  *
- * @param[in]  owner_auth_passwd TPM owner (storage) hierarchy password.
+ * @param[in]  auth_bytes_len    Number of bytes in auth_bytes
+ *
+ * @param[in]  owner_auth_bytes  TPM owner (storage) hierarchy password.
  *                               EmptyAuth by default, but, if it has been
  *                               changed (e.g., by tpm2_takeownership), user
- *                               must provide via this parameter. (passed as
- *                               a string)
+ *                               must provide via this parameter.
+ *
+ * @param[in]  oa_bytes_len      Number of bytes in owner_auth_bytes
  *
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal_file(char *input_path,
                            uint8_t ** output, size_t *output_length,
-                           char *auth_string, char *owner_auth_passwd);
+                           uint8_t * auth_bytes, size_t auth_bytes_len,
+                           uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 #endif /* KMYTH_H */

--- a/tpm2/include/kmyth.h
+++ b/tpm2/include/kmyth.h
@@ -22,7 +22,7 @@
  * @param[in]  output_path       Path to .ski file where the kmyth-seal output
  *                               will be written
  *
- * @param[in]  auth_bytes        Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization bytes to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               wrapping key) created by kmyth-seal
  *
@@ -65,7 +65,7 @@ int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
  *
  * @param[out] output_len        The size of the output data
  *
- * @param[in]  auth_bytes        Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization bytes to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               data) created by kmyth-seal
  *
@@ -95,7 +95,7 @@ int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
  *
  * @param[out] output_len        The length, in bytes, of output
  *
- * @param[in]  auth_bytes        Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization bytes to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               wrapping key) created by kmyth-seal
  *
@@ -137,7 +137,7 @@ int tpm2_kmyth_seal_file(char *input_path,
  * @param[out] output_size       Size (in bytes) of decrypted result
  *                               (passed as pointer to size value)
  *
- * @param[in]  auth_bytes        Authorization string to be applied to the
+ * @param[in]  auth_bytes        Authorization bytes to be applied to the
  *                               Kmyth TPM objects (i.e, storage key and sealed
  *                               data) created by kmyth-seal
  *

--- a/tpm2/include/tpm2_kmyth_key.h
+++ b/tpm2/include/tpm2_kmyth_key.h
@@ -94,8 +94,8 @@ int tpm2_kmyth_derive_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE srk_handle,
  * @param[in]  sk_authVal    Authorization value (authVal) for storage key
  *                           to be created (put into the new storage key
  *                           object's sensitive data). Should be either hash
- *                           of the authorization string passed in by the user
- *                           on the command line or the default all-zero hash.
+ *                           of the authorization bytes passed in or the
+ *                           default all-zero hash.
  *
  * @param[in]  sk_pcrList    PCR Selection List struct indicating the set of
  *                           PCRs to which the storage key should be sealed

--- a/tpm2/include/tpm2_kmyth_object.h
+++ b/tpm2/include/tpm2_kmyth_object.h
@@ -228,8 +228,8 @@ int tpm2_init_kmyth_object_unique(TPMI_ALG_PUBLIC objectType,
  *                                              <LI> all-zero hash (hash of
  *                                                   default emptyAuth)
  *                                              </LI>
- *                                              <LI> hash of user supplied
- *                                                   authorization string,
+ *                                              <LI> hash of the supplied
+ *                                                   authorization bytes,
  *                                                   if applicable
  *                                              </LI>
  *                                            </UL>
@@ -365,8 +365,8 @@ int tpm2_kmyth_create_object(TSS2_SYS_CONTEXT * sapi_ctx,
  *                                   respresent the password for the owner
  *                                   (storage) hierarchy. Alternatively,
  *                                   if the parent is an SK, this should be
- *                                   the hash of the authorization string,
- *                                   which is empty (all-zero hash) by default.
+ *                                   the hash of the authorization bytes,
+ *                                   which are empty (all-zero hash) by default.
  *
  * @param[in]  parent_pcrList        PCR List structure indicating the PCR
  *                                   values that the parent (SRK if a SK is
@@ -416,9 +416,9 @@ int tpm2_kmyth_load_object(TSS2_SYS_CONTEXT * sapi_ctx,
  * @param[in]  object_auth                Authorization value associated with
  *                                        the data object when it was created
  *                                        and now needed to unseal it. Should
- *                                        be hash of an authorization string or
+ *                                        be hash of the authorization bytes or
  *                                        the default all-zero hash associated
- *                                        with an empty authorization string.
+ *                                        with empty authorization bytes.
  *
  * @param[in]  object_pcrList             PCR List structure indicating the PCR
  *                                        values to which the data object was

--- a/tpm2/include/tpm2_kmyth_seal.h
+++ b/tpm2/include/tpm2_kmyth_seal.h
@@ -90,8 +90,8 @@ int tpm2_kmyth_seal_data(TSS2_SYS_CONTEXT * sapi_ctx,
  * @param[in]  authVal        Authorization value required to load and then
  *                            unseal the input 'data' blob. This is the hash
  *                            of either the emptyAuth by default (all-zero
- *                            hash) or the hash of the user supplied
- *                            authorization string.
+ *                            hash) or the hash of the supplied authorization
+ *                            bytes.
  *
  * @param[in]  pcrList        PCR Selection structure indicating which PCR
  *                            values must be included to authorize loading

--- a/tpm2/include/tpm2_kmyth_session.h
+++ b/tpm2/include/tpm2_kmyth_session.h
@@ -216,27 +216,29 @@ int tpm2_kmyth_check_response_auth(SESSION * authSession,
  * TPM 2.0 supports two types of "password" authorization. In the first, and
  * simplest, a plaintext password can be used directly. In the second the
  * password is used as an input to HMAC-based authorization. This code
- * supports an implementation of the second. The user passes in a plaintext
- * password (e.g., as a command line parameter), which is referred to here
- * as an authorization string. This function computes the hash of this
- * password and that result is referred to as the authorization value
- * (authVal). When authorizing TPM commands, this authVal is used as the
- * key for a keyed hash (HMAC) computation.
+ * supports an implementation of the second. The user passes in bytes
+ * (e.g., as a command line parameter), which is referred to here as the 
+ * auth_bytes. This function computes the hash of these bytes and that result 
+ * is referred to as the authorization value (authVal). When authorizing TPM 
+ * commands, this authVal is used as the key for a keyed hash (HMAC) computation.
  * 
- * @param[in]  authStringIn Authorization string to use in creating the authVal
- *                          used in the authorization policy applied to Kmyth
- *                          ordinary (storage key and sealed data) objects.
+ * @param[in]  auth_bytes     Authorization string to use in creating the authVal
+ *                            used in the authorization policy applied to Kmyth
+ *                            ordinary (storage key and sealed data) objects.
  *
- * @param[out] authValOut   TPM 2.0 authorization value (digest) structure to
- *                          contain the result computed by this function:
- *                          <UL>
- *                            <LI> all-zero digest if input string is NULL
- *                            <LI> hash of input string otherwise
- *                          </UL>
+ * @param[in]  auth_bytes_len length of authStringIn
+ *
+ * @param[out] authValOut     TPM 2.0 authorization value (digest) structure to
+ *                            contain the result computed by this function:
+ *                            <UL>
+ *                              <LI> all-zero digest if input string is NULL
+ *                              <LI> hash of input string otherwise
+ *                            </UL>
  *
  * @return None
  */
-void tpm2_kmyth_create_authVal(char *authStringIn, TPM2B_AUTH * authValOut);
+void tpm2_kmyth_create_authVal(uint8_t * auth_bytes, size_t auth_bytes_len,
+                               TPM2B_AUTH * authValOut);
 
 /**
  * @brief Creates a random initial nonce value that the caller can send to the

--- a/tpm2/include/tpm2_kmyth_session.h
+++ b/tpm2/include/tpm2_kmyth_session.h
@@ -211,7 +211,7 @@ int tpm2_kmyth_check_response_auth(SESSION * authSession,
 
 /**
  * @brief Creates an authorization value digest from an input authorization
- *        string (all-zero digest if the authorization string is NULL)
+ *        string (all-zero digest if the authorization bytes are NULL)
  *
  * TPM 2.0 supports two types of "password" authorization. In the first, and
  * simplest, a plaintext password can be used directly. In the second the
@@ -222,7 +222,7 @@ int tpm2_kmyth_check_response_auth(SESSION * authSession,
  * is referred to as the authorization value (authVal). When authorizing TPM 
  * commands, this authVal is used as the key for a keyed hash (HMAC) computation.
  * 
- * @param[in]  auth_bytes     Authorization string to use in creating the authVal
+ * @param[in]  auth_bytes     Authorization bytes to use in creating the authVal
  *                            used in the authorization policy applied to Kmyth
  *                            ordinary (storage key and sealed data) objects.
  *
@@ -352,7 +352,7 @@ void tpm2_kmyth_compute_rpHash(TPM2_RC rspCode,
  * @param[in]  auth_pHash             Command or response parameter hash
  *
  * @param[in]  auth_authValue         Authorization value (hash of
- *                                    authorization string) for authorization
+ *                                    authorization bytes) for authorization
  *                                    entity of command.
  *
  * @param[in]  auth_sessionAttributes Session attributes for current

--- a/tpm2/src/getkey/main.c
+++ b/tpm2/src/getkey/main.c
@@ -142,45 +142,38 @@ int main(int argc, char **argv)
       return 1;
     }
 
+  //Since these originate in main() we know they are null terminated
+  size_t auth_string_len = (authString == NULL) ? 0 : strlen(authString);
+  size_t oa_passwd_len =
+    (ownerAuthPasswd == NULL) ? 0 : strlen(ownerAuthPasswd);
+
   // Validate presence of required command line input parameters
   if (inPath == NULL)
   {
     kmyth_log(LOG_ERR, "no path to kmyth-sealed key ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
   if (clientCertPath == NULL)
   {
     kmyth_log(LOG_ERR, "no path to client certificate ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
   if (serverCertPath == NULL)
   {
     kmyth_log(LOG_ERR, "no path to server certificate ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
   if (address == NULL)
   {
     kmyth_log(LOG_ERR, "server address not specified ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
 
@@ -190,11 +183,8 @@ int main(int argc, char **argv)
     if (verifyOutputFilePath(outPath))
     {
       kmyth_log(LOG_ERR, "error verifying output path ... exiting");
-      if (authString != NULL)
-      {
-        kmyth_clear(authString, strlen(authString));
-      }
-      kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+      kmyth_clear(authString, auth_string_len);
+      kmyth_clear(ownerAuthPasswd, oa_passwd_len);
       return 1;
     }
   }
@@ -203,31 +193,22 @@ int main(int argc, char **argv)
   if (verifyInputFilePath(inPath))
   {
     kmyth_log(LOG_ERR, "verify error: input path ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
   if (verifyInputFilePath(clientCertPath))
   {
     kmyth_log(LOG_ERR, "verify error: client cert path ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
   if (verifyInputFilePath(serverCertPath))
   {
     kmyth_log(LOG_ERR, "verify error: server cert path ... exiting");
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
 
@@ -246,27 +227,22 @@ int main(int argc, char **argv)
 
   if (tpm2_kmyth_unseal_file(inPath,
                              &clientPrivateKey_data, &clientPrivateKey_size,
-                             authString, ownerAuthPasswd))
+                             (uint8_t *) authString, auth_string_len,
+                             (uint8_t *) ownerAuthPasswd, oa_passwd_len))
   {
     kmyth_log(LOG_ERR, "Unable to unseal the certificate's private key.");
     kmyth_clear_and_free(clientPrivateKey_data, clientPrivateKey_size);
     free(sdo_orig_fn);
-    if (authString != NULL)
-    {
-      kmyth_clear(authString, strlen(authString));
-    }
-    kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+    kmyth_clear(authString, auth_string_len);
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     return 1;
   }
 
   free(sdo_orig_fn);
 
   // We no longer need authString and ownerAuthPasswd, so clear them
-  if (authString != NULL)
-  {
-    kmyth_clear(authString, strlen(authString));
-  }
-  kmyth_clear(ownerAuthPasswd, strlen(ownerAuthPasswd));
+  kmyth_clear(authString, auth_string_len);
+  kmyth_clear(ownerAuthPasswd, oa_passwd_len);
 
   // Create TLS connection to the key server, using the CAPK
   BIO *bio = NULL;

--- a/tpm2/src/util/kmyth_cipher.c
+++ b/tpm2/src/util/kmyth_cipher.c
@@ -118,6 +118,7 @@ size_t get_key_len_from_cipher(cipher_t cipher)
   }
 
   int key_len = atoi(key_len_string);
+
   if (key_len <= 0)
   {
     kmyth_log(LOG_ERR, "Unable to convert key length to a positive integer");

--- a/tpm2/src/util/tpm2_kmyth_session.c
+++ b/tpm2/src/util/tpm2_kmyth_session.c
@@ -200,14 +200,15 @@ int tpm2_kmyth_check_response_auth(SESSION * authSession,
 //############################################################################
 // tpm2_kmyth_create_authVal()
 //############################################################################
-void tpm2_kmyth_create_authVal(char *authStringIn, TPM2B_AUTH * authValOut)
+void tpm2_kmyth_create_authVal(uint8_t * auth_bytes, size_t auth_bytes_len,
+                               TPM2B_AUTH * authValOut)
 {
   // Set authVal size to digest size produced by Kmyth hash algorithm
   authValOut->size = KMYTH_DIGEST_SIZE;
 
   // If no authorization string was specified by the user (NULL string passed
   // in), initialize authorization value to the default (all-zero digest)
-  if (authStringIn == NULL)
+  if (auth_bytes == NULL)
   {
     kmyth_log(LOG_DEBUG, "NULL authorization string");
     memset(authValOut->buffer, 0, authValOut->size);
@@ -217,15 +218,10 @@ void tpm2_kmyth_create_authVal(char *authStringIn, TPM2B_AUTH * authValOut)
   // authorization value digest as the hash of user specified string.
   else
   {
-    kmyth_log(LOG_DEBUG,
-              "user specified authorization string = \"%s\"", authStringIn);
-
     // use OpenSSL EVP_Digest() to compute hash
-    EVP_Digest(authStringIn, strlen(authStringIn), authValOut->buffer, NULL,
+    EVP_Digest((char *) auth_bytes, auth_bytes_len, authValOut->buffer, NULL,
                KMYTH_OPENSSL_HASH, NULL);
   }
-  kmyth_log(LOG_DEBUG, "authVal: 0x%02X..%02X", authValOut->buffer[0],
-            authValOut->buffer[authValOut->size - 1]);
 }
 
 //############################################################################


### PR DESCRIPTION
Seal/unseal now inputs auth values as uint8_t* and corresponding sizes  
Updated underlying code to use the input sizes  
Removed several NULL checks going into kmyth_clear because kmyth_clear returns immediately when NULL is input  

