### PR TITLE
Update libkmip error handling to catch all possible errors

### DIFF
--- a/tpm2/src/util/tls_util.c
+++ b/tpm2/src/util/tls_util.c
@@ -479,7 +479,7 @@ int get_key_from_kmip_server(BIO * bio,
                                                      bio,
                                                      message, message_len,
                                                      (char **) key, &key_len);
-    if (0 > result)
+    if (0 != result)
     {
       // NOTE: There is more error information available on the KMIP context
       // that may be useful here (e.g., stack trace, string version of the


### PR DESCRIPTION
This changes updates the error check in get_key_from_kmip_server to properly detect all possible error codes from libkmip. Only libkmip errors were previously handled; now errors from the KMIP server will also be detected.