### PR TITLE
Add error checks for Kmyth seal utility functions

### DIFF
--- a/tpm2/src/tpm/kmyth_seal_unseal_impl.c
+++ b/tpm2/src/tpm/kmyth_seal_unseal_impl.c
@@ -217,10 +217,21 @@ int tpm2_kmyth_seal(uint8_t * input,
   size_t wrapKey_size = get_key_len_from_cipher(ski.cipher) / 8;
   unsigned char *wrapKey = calloc(wrapKey_size, sizeof(unsigned char));
 
+  if (wrapKey == NULL)
+  {
+    kmyth_log(LOG_ERR,
+              "unable to allocate memory for the wrapping key ... exiting");
+    kmyth_clear(objAuthVal.buffer, objAuthVal.size);
+    free_tpm2_resources(&sapi_ctx);
+    return 1;
+  }
+
   // validate non-empty plaintext buffer specified
   if (input_len == 0 || input == NULL)
   {
     kmyth_log(LOG_ERR, "no input data ... exiting");
+    kmyth_clear(objAuthVal.buffer, objAuthVal.size);
+    free_tpm2_resources(&sapi_ctx);
     return 1;
   }
 
@@ -230,6 +241,8 @@ int tpm2_kmyth_seal(uint8_t * input,
                          &wrapKey, &wrapKey_size))
   {
     kmyth_log(LOG_ERR, "unable to encrypt (wrap) data ... exiting");
+    kmyth_clear(objAuthVal.buffer, objAuthVal.size);
+    free_tpm2_resources(&sapi_ctx);
     return 1;
   }
 


### PR DESCRIPTION
This change adds error checking and minor updates to the Kmyth seal utility function suite. These updates include memory allocation error checking, additional memory freeing statements, and more argument checking.

Partially addresses #25