### PR TITLE
Add error checks to the Kmyth session utility functions

### DIFF
--- a/tpm2/include/tpm/tpm2_interface.h
+++ b/tpm2/include/tpm/tpm2_interface.h
@@ -191,9 +191,6 @@ const char *getErrorString(TSS2_RC err);
  *        for the upcoming TPM interaction (TSS2 library call) using
  *        a password authorization session
  * 
- * @param[in]  sapi_ctx            System API (SAPI) context, initialized and
- *                                 passed in as pointer to the SAPI context
- *
  * @param[in]  authEntityAuthVal   Authorization value (hash of authorization
  *                                 string) for authorization entity of command.
  *
@@ -209,8 +206,7 @@ const char *getErrorString(TSS2_RC err);
  *
  * @return 0 if success, 1 if error
  */
-int init_password_cmd_auth(TSS2_SYS_CONTEXT * sapi_ctx,
-                           TPM2B_AUTH authEntityAuthVal,
+int init_password_cmd_auth(TPM2B_AUTH authEntityAuthVal,
                            TSS2L_SYS_AUTH_COMMAND * commandAuths,
                            TSS2L_SYS_AUTH_RESPONSE * responseAuths);
 
@@ -219,9 +215,6 @@ int init_password_cmd_auth(TSS2_SYS_CONTEXT * sapi_ctx,
  *        for the upcoming TPM interaction (TSS2 library call) using
  *        a policy authorization session
  * 
- * @param[in]  sapi_ctx            System API (SAPI) context, initialized and
- *                                 passed in as pointer to the SAPI context
- *
  * @param[in]  authSession         Pointer to authorization session parameters
  *                                 structure. A null pointer should be passed
  *                                 in if policy authorization is not being
@@ -270,8 +263,7 @@ int init_password_cmd_auth(TSS2_SYS_CONTEXT * sapi_ctx,
  *
  * @return 0 if success, 1 if error
  */
-int init_policy_cmd_auth(TSS2_SYS_CONTEXT * sapi_ctx,
-                         SESSION * authSession,
+int init_policy_cmd_auth(SESSION * authSession,
                          TPM2_CC authCmdCode,
                          TPM2B_NAME authEntityName,
                          TPM2B_AUTH authEntityAuthVal,
@@ -351,11 +343,11 @@ int check_response_auth(SESSION * authSession,
  *                              <LI> hash of input string otherwise
  *                            </UL>
  *
- * @return None
+ * @return 0 if success, 1 if error
  */
-void create_authVal(uint8_t * auth_bytes,
-                    size_t auth_bytes_len,
-                    TPM2B_AUTH * authValOut);
+int create_authVal(uint8_t * auth_bytes,
+                   size_t auth_bytes_len,
+                   TPM2B_AUTH * authValOut);
 
 /**
  * @brief Computes command parameter hash that is one of the inputs used for
@@ -390,11 +382,11 @@ void create_authVal(uint8_t * auth_bytes,
  *
  * @return 0 if success, 1 if error
  */
-void compute_cpHash(TPM2_CC cmdCode,
-                    TPM2B_NAME authEntityName,
-                    uint8_t * cmdParams,
-                    size_t cmdParams_size,
-                    TPM2B_DIGEST * cpHash_out);
+int compute_cpHash(TPM2_CC cmdCode,
+                   TPM2B_NAME authEntityName,
+                   uint8_t * cmdParams,
+                   size_t cmdParams_size,
+                   TPM2B_DIGEST * cpHash_out);
 
 /**
  * @brief Computes response parameter hash that is one of the inputs to the
@@ -427,11 +419,11 @@ void compute_cpHash(TPM2_CC cmdCode,
  *
  * @return 0 if success, 1 if error
  */
-void compute_rpHash(TPM2_RC rspCode,
-                    TPM2_CC cmdCode,
-                    uint8_t * cmdParams,
-                    size_t cmdParams_size,
-                    TPM2B_DIGEST * rpHash_out);
+int compute_rpHash(TPM2_RC rspCode,
+                   TPM2_CC cmdCode,
+                   uint8_t * cmdParams,
+                   size_t cmdParams_size,
+                   TPM2B_DIGEST * rpHash_out);
 
 /**
  * @brief Computes the authorization HMAC value required for command and
@@ -453,11 +445,11 @@ void compute_rpHash(TPM2_RC rspCode,
  *
  * @return 0 if success, 1 if error
  */
-void compute_authHMAC(SESSION auth_session,
-                      TPM2B_DIGEST auth_pHash,
-                      TPM2B_AUTH auth_authValue,
-                      TPMA_SESSION auth_sessionAttributes,
-                      TPM2B_AUTH * auth_HMAC);
+int compute_authHMAC(SESSION auth_session,
+                     TPM2B_DIGEST auth_pHash,
+                     TPM2B_AUTH auth_authValue,
+                     TPMA_SESSION auth_sessionAttributes,
+                     TPM2B_AUTH * auth_HMAC);
 
 /**
  * @brief Creates a trial policy (authorization session) and uses it to
@@ -571,6 +563,6 @@ int create_caller_nonce(TPM2B_NONCE * nonceOut);
  *
  * @return 0 if success, 1 if error. 
  */
-void rollNonces(SESSION * session, TPM2B_NONCE newNonce);
+int rollNonces(SESSION * session, TPM2B_NONCE newNonce);
 
 #endif /* TPM2_INTERFACE_H */

--- a/tpm2/src/tpm/kmyth_seal_unseal_impl.c
+++ b/tpm2/src/tpm/kmyth_seal_unseal_impl.c
@@ -100,7 +100,14 @@ int tpm2_kmyth_seal(uint8_t * input,
   //   - all-zero digest (like TPM 1.2 well-known secret) by default
   //   - hash of input authorization string if one is specified
   TPM2B_AUTH objAuthVal = {.size = 0, };
-  create_authVal(auth_bytes, auth_bytes_len, &objAuthVal);
+  if (create_authVal(auth_bytes, auth_bytes_len, &objAuthVal))
+  {
+    kmyth_log(LOG_ERR, "error creating authorization value ... exiting");
+    kmyth_clear(objAuthVal.buffer, objAuthVal.size);
+    kmyth_clear(ownerAuth.buffer, ownerAuth.size);
+    free_tpm2_resources(&sapi_ctx);
+    return 1;
+  }
 
   // Create a "PCR Selection" struct and populate it in accordance with
   // the PCR values specified in user input "PCR Selection" string, if any
@@ -333,7 +340,14 @@ int tpm2_kmyth_unseal(uint8_t * input,
   //   - hash of input authorization string if one is specified
   TPM2B_AUTH objAuthValue;
 
-  create_authVal(auth_bytes, auth_bytes_len, &objAuthValue);
+  if (create_authVal(auth_bytes, auth_bytes_len, &objAuthValue))
+  {
+    kmyth_log(LOG_ERR, "error creating authorization value ... exiting");
+    kmyth_clear(objAuthValue.buffer, objAuthValue.size);
+    kmyth_clear(ownerAuth.buffer, ownerAuth.size);
+    free_tpm2_resources(&sapi_ctx);
+    return 1;
+  }
 
   // The storage root key (SRK) is the primary key for the storage hierarchy
   // in the TPM.  We will first check to see if it is already loaded in

--- a/tpm2/src/tpm/object_tools.c
+++ b/tpm2/src/tpm/object_tools.c
@@ -371,8 +371,7 @@ int create_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
     // Set up NULL password authorization session for TPM commands used to
     // create the primary object (Tss2_Sys_CreatePrimary()) and load it at
     // a persistent handle (Tss2_Sys_EvictControl())
-    if (init_password_cmd_auth(sapi_ctx,
-                               parent_auth,
+    if (init_password_cmd_auth(parent_auth,
                                &createObjectCmdAuths, &createObjectRspAuths))
     {
       kmyth_log(LOG_ERR, "error setting up auth session ... exiting");
@@ -429,8 +428,7 @@ int create_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
       // If a NULL authorization session (indicating password authorization)
       // was passed in, the object being created is a storage key (SK)
       //   - TPM owner (storage) auth is required for use of the SRK to seal
-      if (init_password_cmd_auth(sapi_ctx,
-                                 parent_auth,
+      if (init_password_cmd_auth(parent_auth,
                                  &createObjectCmdAuths, &createObjectRspAuths))
       {
         kmyth_log(LOG_ERR, "error setting up auth session ... exiting");
@@ -537,8 +535,7 @@ int create_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
       }
 
       // prepare command and response authorization structures
-      if (init_policy_cmd_auth(sapi_ctx,
-                               createObjectAuthSession,
+      if (init_policy_cmd_auth(createObjectAuthSession,
                                create_object_command_code,
                                parent_name,
                                parent_auth,
@@ -705,8 +702,7 @@ int load_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
     // If a NULL authorization session (indicating password authorization)
     // was passed in, the object being loaded is a storage key (SK)
     //   - TPM owner (storage) auth is required to load under the SRK
-    if (init_password_cmd_auth(sapi_ctx,
-                               parent_auth,
+    if (init_password_cmd_auth(parent_auth,
                                &loadObjectCmdAuths, &loadObjectRspAuths))
     {
       kmyth_log(LOG_ERR, "error setting up auth session ... exiting");
@@ -783,8 +779,7 @@ int load_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
       return 1;
     }
     // prepare command and response authorization structures
-    if (init_policy_cmd_auth(sapi_ctx,
-                             loadObjectAuthSession,
+    if (init_policy_cmd_auth(loadObjectAuthSession,
                              load_object_command_code,
                              parent_name,
                              parent_auth,
@@ -975,8 +970,7 @@ int unseal_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
   }
 
   // prepare command and response authorization structures
-  if (init_policy_cmd_auth(sapi_ctx,
-                           unsealObjectAuthSession,
+  if (init_policy_cmd_auth(unsealObjectAuthSession,
                            unseal_object_command_code,
                            object_name,
                            object_auth,


### PR DESCRIPTION
This change adds error checking and minor updates to the Kmyth session utility function suite. Multiple function signatures have been updated to support returning error codes and all usage of these modified functions has been updated to reflect these changes. Unused function arguments have also been removed from two of the session utility functions.

Closes #25