### PR TITLE
More readable and modular get_srk_handle()

### DIFF
--- a/tpm2/include/tpm/storage_key_tools.h
+++ b/tpm2/include/tpm/storage_key_tools.h
@@ -39,6 +39,31 @@ int get_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
                    TPM2B_AUTH * storage_hierarchy_auth);
 
 /**
+ * @brief Try to get handle of a Storage Root Key (SRK) that is already loaded
+ *        into the TPM's persistent storage.
+ *
+ * @param[in]  sapi_ctx      System API (SAPI) context,
+ *                           must be initialized and
+ *                           passed in as pointer to the SAPI context
+ *
+ * @param[out] srkHandle     TPM 2.0 handle for SRK that this function
+ *                           gets - passed as pointer to SRK handle
+ *                           value
+ *
+ * @param[out] nextSrkHandle TPM 2.0 handle for the next available location
+ *                           in the TPM's persistent storage where the SRK
+ *                           could be put, in case it is not already present.
+ *                           If a current handle to the SRK is found, this
+ *                           parameter will still provide the next available
+ *                           location in persistent storage.
+ *
+ * @return 0 if success, 1 if error
+ */
+int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
+                            TPM2_HANDLE * srkHandle,
+                            TPM2_HANDLE * nextSrkHandle);
+
+/**
  * @brief Determines if handle points to a storage root key (SRK)
  *        generated with a template specifying the desired public
  *        key and hash algorithms.
@@ -67,16 +92,16 @@ int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx,
  *                        must be initialized and passed in
  *                        as pointer to the SAPI context
  *
- * @param[in]  srk_handle TPM 2.0 handle for SRK to be loaded under
+ * @param[in]  srkHandle TPM 2.0 handle for SRK to be loaded under
  *
  * @param[in]  sps_auth   TPM 2.0 Storage Primary Seed authentication
  *                        value (e.g., storage hierarchy password).     
  *
  * @return 0 if success, 1 if error. 
  */
-int derive_srk(TSS2_SYS_CONTEXT * sapi_ctx,
-               TPM2_HANDLE srk_handle,
-               TPM2B_AUTH sps_auth);
+int put_srk_into_persistent_storage(TSS2_SYS_CONTEXT * sapi_ctx,
+                                    TPM2_HANDLE srkHandle,
+                                    TPM2B_AUTH sps_auth);
 
 /**
  * @brief Creates a new storage key (SK) under the specified key hierarchy

--- a/tpm2/src/tpm/storage_key_tools.c
+++ b/tpm2/src/tpm/storage_key_tools.c
@@ -33,7 +33,11 @@ int get_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
   // available TPM persistent storage location where the SRK can be put.
   TPM2_HANDLE next_persistent_handle = 0;
 
-  get_existing_srk_handle(sapi_ctx, srk_handle, &next_persistent_handle);
+  if(get_existing_srk_handle(sapi_ctx, srk_handle, &next_persistent_handle))
+  {
+    kmyth_log(LOG_ERR, "error retrieving SRK handle from TPM ... exiting");
+    return 1;
+  }
 
   // If we reach here and the srk_handle value is still zero (empty handle),
   // a handle referencing the SRK is not already loaded in persistent storage.


### PR DESCRIPTION
This pull request proposes no real change to the underlying logic in get_srk_handle() but adds some abstraction in an attempt to make the get_srk_handle() function more readable and the code a little more modular.

Specifically, as a result of this proposed change, get_srk_handle() calls get_existing_srk_handle(), a new function where much of the get_srk_handle() code was copied and pasted.. It then checks the srk_handle parameter resulting from the call to get_existing_srk_handle(). if srk_handle is still zero, the SRK was not found already loaded into the TPM and put_srk_into_persistent_storage() to reestablish the SRK within the TPM. put_srk_into_persistent() storage is basically a renamed derive_srk().

This pull request addresses issue #94.