### PR TITLE
Fixed missing format specification in asprintf

### DIFF
--- a/tpm2/include/kmyth.h
+++ b/tpm2/include/kmyth.h
@@ -49,7 +49,7 @@
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
-                    uint8_t ** output, size_t *output_len,
+                    uint8_t ** output, size_t * output_len,
                     uint8_t * auth_bytes, size_t auth_bytes_len,
                     uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                     int *pcrs, size_t pcrs_len, char *cipher_string);
@@ -82,7 +82,7 @@ int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
-                      uint8_t ** output, size_t *output_len,
+                      uint8_t ** output, size_t * output_len,
                       uint8_t * auth_bytes, size_t auth_bytes_len,
                       uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 
@@ -124,7 +124,7 @@ int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal_file(char *input_path,
-                         uint8_t ** output, size_t *output_len,
+                         uint8_t ** output, size_t * output_len,
                          uint8_t * auth_bytes, size_t auth_bytes_len,
                          uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                          int *pcrs, size_t pcrs_len, char *cipher_string);
@@ -157,7 +157,7 @@ int tpm2_kmyth_seal_file(char *input_path,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal_file(char *input_path,
-                           uint8_t ** output, size_t *output_length,
+                           uint8_t ** output, size_t * output_length,
                            uint8_t * auth_bytes, size_t auth_bytes_len,
                            uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 

--- a/tpm2/src/cipher/aes_gcm.c
+++ b/tpm2/src/cipher/aes_gcm.c
@@ -18,7 +18,7 @@
 int aes_gcm_encrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData, size_t inData_len,
-                    unsigned char **outData, size_t *outData_len)
+                    unsigned char **outData, size_t * outData_len)
 {
   kmyth_log(LOG_DEBUG, "AES/GCM encryption starting");
 
@@ -169,7 +169,7 @@ int aes_gcm_encrypt(unsigned char *key,
 int aes_gcm_decrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData, size_t inData_len,
-                    unsigned char **outData, size_t *outData_len)
+                    unsigned char **outData, size_t * outData_len)
 {
   kmyth_log(LOG_DEBUG, "AES/GCM decryption starting");
 

--- a/tpm2/src/cipher/aes_keywrap_3394nopad.c
+++ b/tpm2/src/cipher/aes_keywrap_3394nopad.c
@@ -17,7 +17,7 @@ int aes_keywrap_3394nopad_encrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len)
+                                  size_t * outData_len)
 {
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
@@ -153,7 +153,7 @@ int aes_keywrap_3394nopad_decrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len)
+                                  size_t * outData_len)
 {
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)

--- a/tpm2/src/cipher/aes_keywrap_5649pad.c
+++ b/tpm2/src/cipher/aes_keywrap_5649pad.c
@@ -17,7 +17,7 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len)
+                                size_t * outData_len)
 {
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
@@ -158,7 +158,7 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len)
+                                size_t * outData_len)
 {
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)

--- a/tpm2/src/cipher/cipher.c
+++ b/tpm2/src/cipher/cipher.c
@@ -137,8 +137,8 @@ int kmyth_encrypt_data(unsigned char *data,
                        size_t data_size,
                        cipher_t cipher_spec,
                        unsigned char **enc_data,
-                       size_t *enc_data_size,
-                       unsigned char **enc_key, size_t *enc_key_size)
+                       size_t * enc_data_size,
+                       unsigned char **enc_key, size_t * enc_key_size)
 {
   if (cipher_spec.cipher_name == NULL)
   {
@@ -198,7 +198,7 @@ int kmyth_decrypt_data(unsigned char *enc_data,
                        cipher_t cipher_spec,
                        unsigned char *key,
                        size_t key_size,
-                       unsigned char **result, size_t *result_size)
+                       unsigned char **result, size_t * result_size)
 {
   if (enc_data == NULL || enc_data_size == 0)
   {

--- a/tpm2/src/tpm/formatting_tools.c
+++ b/tpm2/src/tpm/formatting_tools.c
@@ -21,23 +21,23 @@
 //############################################################################
 int marshal_skiObjects(TPML_PCR_SELECTION * pcr_selection_struct,
                        uint8_t ** pcr_selection_struct_data,
-                       size_t *pcr_selection_struct_data_size,
+                       size_t * pcr_selection_struct_data_size,
                        size_t pcr_selection_struct_data_offset,
                        TPM2B_PUBLIC * storage_key_public_blob,
                        uint8_t ** storage_key_public_data,
-                       size_t *storage_key_public_data_size,
+                       size_t * storage_key_public_data_size,
                        size_t storage_key_public_data_offset,
                        TPM2B_PRIVATE * storage_key_private_blob,
                        uint8_t ** storage_key_private_data,
-                       size_t *storage_key_private_data_size,
+                       size_t * storage_key_private_data_size,
                        size_t storage_key_private_data_offset,
                        TPM2B_PUBLIC * sealed_key_public_blob,
                        uint8_t ** sealed_key_public_data,
-                       size_t *sealed_key_public_data_size,
+                       size_t * sealed_key_public_data_size,
                        size_t sealed_key_public_data_offset,
                        TPM2B_PRIVATE * sealed_key_private_blob,
                        uint8_t ** sealed_key_private_data,
-                       size_t *sealed_key_private_data_size,
+                       size_t * sealed_key_private_data_size,
                        size_t sealed_key_private_data_offset)
 {
   // Validate that all input data structures to be packed in preparation
@@ -651,7 +651,7 @@ int parse_ski_bytes(uint8_t * input, size_t input_length, Ski * output)
 //############################################################################
 // create_ski_bytes
 //############################################################################
-int create_ski_bytes(Ski input, uint8_t ** output, size_t *output_length)
+int create_ski_bytes(Ski input, uint8_t ** output, size_t * output_length)
 {
   // marshal data contained in TPM sized buffers (TPM2B_PUBLIC / TPM2B_PRIVATE)
   // and structs (TPML_PCR_SELECTION)
@@ -909,8 +909,8 @@ Ski get_default_ski(void)
 // get_ski_block_bytes()
 //############################################################################
 int get_ski_block_bytes(char **contents,
-                        size_t *remaining,
-                        uint8_t ** block, size_t *blocksize,
+                        size_t * remaining,
+                        uint8_t ** block, size_t * blocksize,
                         char *delim, size_t delim_len,
                         char *next_delim, size_t next_delim_len)
 {
@@ -979,7 +979,7 @@ int get_ski_block_bytes(char **contents,
 //############################################################################
 int encodeBase64Data(uint8_t * raw_data,
                      size_t raw_data_size,
-                     uint8_t ** base64_data, size_t *base64_data_size)
+                     uint8_t ** base64_data, size_t * base64_data_size)
 {
   // check that there is actually data to encode, return error if not
   if (raw_data == NULL || raw_data_size == 0)
@@ -1065,7 +1065,7 @@ int encodeBase64Data(uint8_t * raw_data,
 //############################################################################
 int decodeBase64Data(uint8_t * base64_data,
                      size_t base64_data_size,
-                     uint8_t ** raw_data, size_t *raw_data_size)
+                     uint8_t ** raw_data, size_t * raw_data_size)
 {
   // check that there is actually data to decode, return error if not
   if (base64_data == NULL || base64_data_size == 0)
@@ -1134,7 +1134,7 @@ int decodeBase64Data(uint8_t * base64_data,
 //############################################################################
 // concat()
 //############################################################################
-int concat(uint8_t ** dest, size_t *dest_length, uint8_t * input,
+int concat(uint8_t ** dest, size_t * dest_length, uint8_t * input,
            size_t input_length)
 {
   if (input == NULL || input_length == 0) //nothing to concat

--- a/tpm2/src/tpm/kmyth_seal_unseal_impl.c
+++ b/tpm2/src/tpm/kmyth_seal_unseal_impl.c
@@ -33,7 +33,7 @@ extern const cipher_t cipher_list[];
 int tpm2_kmyth_seal(uint8_t * input,
                     size_t input_len,
                     uint8_t ** output,
-                    size_t *output_len,
+                    size_t * output_len,
                     uint8_t * auth_bytes,
                     size_t auth_bytes_len,
                     uint8_t * owner_auth_bytes,
@@ -281,7 +281,7 @@ int tpm2_kmyth_seal(uint8_t * input,
 int tpm2_kmyth_unseal(uint8_t * input,
                       size_t input_len,
                       uint8_t ** output,
-                      size_t *output_len,
+                      size_t * output_len,
                       uint8_t * auth_bytes,
                       size_t auth_bytes_len,
                       uint8_t * owner_auth_bytes, size_t oa_bytes_len)
@@ -433,7 +433,7 @@ int tpm2_kmyth_unseal(uint8_t * input,
 //############################################################################
 int tpm2_kmyth_seal_file(char *input_path,
                          uint8_t ** output,
-                         size_t *output_len,
+                         size_t * output_len,
                          uint8_t * auth_bytes,
                          size_t auth_bytes_len,
                          uint8_t * owner_auth_bytes,
@@ -486,7 +486,7 @@ int tpm2_kmyth_seal_file(char *input_path,
 //############################################################################
 int tpm2_kmyth_unseal_file(char *input_path,
                            uint8_t ** output,
-                           size_t *output_length,
+                           size_t * output_length,
                            uint8_t * auth_bytes,
                            size_t auth_bytes_len,
                            uint8_t * owner_auth_bytes, size_t oa_bytes_len)
@@ -613,7 +613,7 @@ int tpm2_kmyth_unseal_data(TSS2_SYS_CONTEXT * sapi_ctx,
                            TPM2B_AUTH authVal,
                            TPML_PCR_SELECTION pcrList,
                            TPM2B_DIGEST authPolicy,
-                           uint8_t ** result, size_t *result_size)
+                           uint8_t ** result, size_t * result_size)
 {
   // Start a TPM 2.0 policy session that we will use to authorize the use of
   // storage key (SK) to:

--- a/tpm2/src/tpm/storage_key_tools.c
+++ b/tpm2/src/tpm/storage_key_tools.c
@@ -143,7 +143,7 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
 //############################################################################
 // check_if_srk()
 //############################################################################
-int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE handle, bool *isSRK)
+int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE handle, bool * isSRK)
 {
   // initialize 'isSRK' result to false - early termination should not result
   // in a true value passed back (even if the return code indicates an error)

--- a/tpm2/src/tpm/tpm2_interface.c
+++ b/tpm2/src/tpm/tpm2_interface.c
@@ -386,7 +386,7 @@ int get_tpm2_properties(TSS2_SYS_CONTEXT * sapi_ctx,
 //############################################################################
 // get_tpm2_impl_type()
 //############################################################################
-int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator)
+int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool * isEmulator)
 {
   TPMS_CAPABILITY_DATA capData;
 

--- a/tpm2/src/util/file_io.c
+++ b/tpm2/src/util/file_io.c
@@ -72,7 +72,7 @@ int verifyOutputFilePath(char *path)
   // check that specified output path directory exists
   char *path_copy = "\0";
 
-  if (asprintf(&path_copy, path) < 0)
+  if (asprintf(&path_copy, "%s", path) < 0)
   {
     kmyth_log(LOG_ERR, "unable to copy output file path ... exiting");
     return 1;
@@ -122,7 +122,8 @@ int verifyOutputFilePath(char *path)
 //############################################################################
 // read_bytes_from_file()
 //############################################################################
-int read_bytes_from_file(char *input_path, uint8_t ** data, size_t *data_length)
+int read_bytes_from_file(char *input_path, uint8_t ** data,
+                         size_t * data_length)
 {
 
   // Create a BIO for the input file

--- a/tpm2/src/util/tls_util.c
+++ b/tpm2/src/util/tls_util.c
@@ -390,7 +390,7 @@ int tls_set_context(unsigned char *client_private_key,
 //############################################################################
 int get_key_from_tls_server(BIO * bio,
                             char *message, size_t message_length,
-                            unsigned char **key, size_t *key_size)
+                            unsigned char **key, size_t * key_size)
 {
   // validate input
   if (bio == NULL)
@@ -454,7 +454,7 @@ int get_key_from_tls_server(BIO * bio,
 
 int get_key_from_kmip_server(BIO * bio,
                              char *message, size_t message_length,
-                             unsigned char **key, size_t *key_size)
+                             unsigned char **key, size_t * key_size)
 {
   // validate input
   if (bio == NULL)


### PR DESCRIPTION
A compiler warning was being generated due to a missing format specification in an 'asprintf()' call in tpm2/src/util/file_io.c. This pull request fixes that error.

Note: Although, I did not change the configuration for the indent utility in the makefile, a number of white-space edits were generated by building the code, and included in this very simple pull request.