### PR TITLE
Add Tests for AES Key Wrap Cipher Functionality

### DIFF
--- a/tpm2/include/kmyth.h
+++ b/tpm2/include/kmyth.h
@@ -49,7 +49,7 @@
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
-                    uint8_t ** output, size_t *output_len,
+                    uint8_t ** output, size_t * output_len,
                     uint8_t * auth_bytes, size_t auth_bytes_len,
                     uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                     int *pcrs, size_t pcrs_len, char *cipher_string);
@@ -82,7 +82,7 @@ int tpm2_kmyth_seal(uint8_t * input, size_t input_len,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
-                      uint8_t ** output, size_t *output_len,
+                      uint8_t ** output, size_t * output_len,
                       uint8_t * auth_bytes, size_t auth_bytes_len,
                       uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 
@@ -124,7 +124,7 @@ int tpm2_kmyth_unseal(uint8_t * input, size_t input_len,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_seal_file(char *input_path,
-                         uint8_t ** output, size_t *output_len,
+                         uint8_t ** output, size_t * output_len,
                          uint8_t * auth_bytes, size_t auth_bytes_len,
                          uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                          int *pcrs, size_t pcrs_len, char *cipher_string);
@@ -157,7 +157,7 @@ int tpm2_kmyth_seal_file(char *input_path,
  * @return 0 on success, 1 on error
  */
 int tpm2_kmyth_unseal_file(char *input_path,
-                           uint8_t ** output, size_t *output_length,
+                           uint8_t ** output, size_t * output_length,
                            uint8_t * auth_bytes, size_t auth_bytes_len,
                            uint8_t * owner_auth_bytes, size_t oa_bytes_len);
 

--- a/tpm2/src/cipher/aes_gcm.c
+++ b/tpm2/src/cipher/aes_gcm.c
@@ -18,7 +18,7 @@
 int aes_gcm_encrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData, size_t inData_len,
-                    unsigned char **outData, size_t *outData_len)
+                    unsigned char **outData, size_t * outData_len)
 {
   kmyth_log(LOG_DEBUG, "AES/GCM encryption starting");
 
@@ -169,7 +169,7 @@ int aes_gcm_encrypt(unsigned char *key,
 int aes_gcm_decrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData, size_t inData_len,
-                    unsigned char **outData, size_t *outData_len)
+                    unsigned char **outData, size_t * outData_len)
 {
   kmyth_log(LOG_DEBUG, "AES/GCM decryption starting");
 

--- a/tpm2/src/cipher/aes_keywrap_3394nopad.c
+++ b/tpm2/src/cipher/aes_keywrap_3394nopad.c
@@ -17,7 +17,7 @@ int aes_keywrap_3394nopad_encrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len)
+                                  size_t * outData_len)
 {
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
@@ -153,7 +153,7 @@ int aes_keywrap_3394nopad_decrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len)
+                                  size_t * outData_len)
 {
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)

--- a/tpm2/src/cipher/aes_keywrap_3394nopad.c
+++ b/tpm2/src/cipher/aes_keywrap_3394nopad.c
@@ -130,7 +130,7 @@ int aes_keywrap_3394nopad_encrypt(unsigned char *key,
 
   // verify that the resultant CT length matches expected (input PT length plus
   // eight bytes for prepended integrity check value)
-  if (ciphertext_len != *outData_len)
+  if (ciphertext_len != (int) *outData_len)
   {
     kmyth_log(LOG_ERR,
               "CT length error (expected %lu, actual %d) bytes ... exiting",

--- a/tpm2/src/cipher/aes_keywrap_5649pad.c
+++ b/tpm2/src/cipher/aes_keywrap_5649pad.c
@@ -17,7 +17,7 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len)
+                                size_t * outData_len)
 {
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
@@ -158,7 +158,7 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len)
+                                size_t * outData_len)
 {
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)

--- a/tpm2/src/cipher/cipher.c
+++ b/tpm2/src/cipher/cipher.c
@@ -137,8 +137,8 @@ int kmyth_encrypt_data(unsigned char *data,
                        size_t data_size,
                        cipher_t cipher_spec,
                        unsigned char **enc_data,
-                       size_t *enc_data_size,
-                       unsigned char **enc_key, size_t *enc_key_size)
+                       size_t * enc_data_size,
+                       unsigned char **enc_key, size_t * enc_key_size)
 {
   if (cipher_spec.cipher_name == NULL)
   {
@@ -198,7 +198,7 @@ int kmyth_decrypt_data(unsigned char *enc_data,
                        cipher_t cipher_spec,
                        unsigned char *key,
                        size_t key_size,
-                       unsigned char **result, size_t *result_size)
+                       unsigned char **result, size_t * result_size)
 {
   if (enc_data == NULL || enc_data_size == 0)
   {

--- a/tpm2/src/tpm/formatting_tools.c
+++ b/tpm2/src/tpm/formatting_tools.c
@@ -21,23 +21,23 @@
 //############################################################################
 int marshal_skiObjects(TPML_PCR_SELECTION * pcr_selection_struct,
                        uint8_t ** pcr_selection_struct_data,
-                       size_t *pcr_selection_struct_data_size,
+                       size_t * pcr_selection_struct_data_size,
                        size_t pcr_selection_struct_data_offset,
                        TPM2B_PUBLIC * storage_key_public_blob,
                        uint8_t ** storage_key_public_data,
-                       size_t *storage_key_public_data_size,
+                       size_t * storage_key_public_data_size,
                        size_t storage_key_public_data_offset,
                        TPM2B_PRIVATE * storage_key_private_blob,
                        uint8_t ** storage_key_private_data,
-                       size_t *storage_key_private_data_size,
+                       size_t * storage_key_private_data_size,
                        size_t storage_key_private_data_offset,
                        TPM2B_PUBLIC * sealed_key_public_blob,
                        uint8_t ** sealed_key_public_data,
-                       size_t *sealed_key_public_data_size,
+                       size_t * sealed_key_public_data_size,
                        size_t sealed_key_public_data_offset,
                        TPM2B_PRIVATE * sealed_key_private_blob,
                        uint8_t ** sealed_key_private_data,
-                       size_t *sealed_key_private_data_size,
+                       size_t * sealed_key_private_data_size,
                        size_t sealed_key_private_data_offset)
 {
   // Validate that all input data structures to be packed in preparation
@@ -651,7 +651,7 @@ int parse_ski_bytes(uint8_t * input, size_t input_length, Ski * output)
 //############################################################################
 // create_ski_bytes
 //############################################################################
-int create_ski_bytes(Ski input, uint8_t ** output, size_t *output_length)
+int create_ski_bytes(Ski input, uint8_t ** output, size_t * output_length)
 {
   // marshal data contained in TPM sized buffers (TPM2B_PUBLIC / TPM2B_PRIVATE)
   // and structs (TPML_PCR_SELECTION)
@@ -909,8 +909,8 @@ Ski get_default_ski(void)
 // get_ski_block_bytes()
 //############################################################################
 int get_ski_block_bytes(char **contents,
-                        size_t *remaining,
-                        uint8_t ** block, size_t *blocksize,
+                        size_t * remaining,
+                        uint8_t ** block, size_t * blocksize,
                         char *delim, size_t delim_len,
                         char *next_delim, size_t next_delim_len)
 {
@@ -979,7 +979,7 @@ int get_ski_block_bytes(char **contents,
 //############################################################################
 int encodeBase64Data(uint8_t * raw_data,
                      size_t raw_data_size,
-                     uint8_t ** base64_data, size_t *base64_data_size)
+                     uint8_t ** base64_data, size_t * base64_data_size)
 {
   // check that there is actually data to encode, return error if not
   if (raw_data == NULL || raw_data_size == 0)
@@ -1065,7 +1065,7 @@ int encodeBase64Data(uint8_t * raw_data,
 //############################################################################
 int decodeBase64Data(uint8_t * base64_data,
                      size_t base64_data_size,
-                     uint8_t ** raw_data, size_t *raw_data_size)
+                     uint8_t ** raw_data, size_t * raw_data_size)
 {
   // check that there is actually data to decode, return error if not
   if (base64_data == NULL || base64_data_size == 0)
@@ -1134,7 +1134,7 @@ int decodeBase64Data(uint8_t * base64_data,
 //############################################################################
 // concat()
 //############################################################################
-int concat(uint8_t ** dest, size_t *dest_length, uint8_t * input,
+int concat(uint8_t ** dest, size_t * dest_length, uint8_t * input,
            size_t input_length)
 {
   if (input == NULL || input_length == 0) //nothing to concat

--- a/tpm2/src/tpm/kmyth_seal_unseal_impl.c
+++ b/tpm2/src/tpm/kmyth_seal_unseal_impl.c
@@ -33,7 +33,7 @@ extern const cipher_t cipher_list[];
 int tpm2_kmyth_seal(uint8_t * input,
                     size_t input_len,
                     uint8_t ** output,
-                    size_t *output_len,
+                    size_t * output_len,
                     uint8_t * auth_bytes,
                     size_t auth_bytes_len,
                     uint8_t * owner_auth_bytes,
@@ -281,7 +281,7 @@ int tpm2_kmyth_seal(uint8_t * input,
 int tpm2_kmyth_unseal(uint8_t * input,
                       size_t input_len,
                       uint8_t ** output,
-                      size_t *output_len,
+                      size_t * output_len,
                       uint8_t * auth_bytes,
                       size_t auth_bytes_len,
                       uint8_t * owner_auth_bytes, size_t oa_bytes_len)
@@ -433,7 +433,7 @@ int tpm2_kmyth_unseal(uint8_t * input,
 //############################################################################
 int tpm2_kmyth_seal_file(char *input_path,
                          uint8_t ** output,
-                         size_t *output_len,
+                         size_t * output_len,
                          uint8_t * auth_bytes,
                          size_t auth_bytes_len,
                          uint8_t * owner_auth_bytes,
@@ -486,7 +486,7 @@ int tpm2_kmyth_seal_file(char *input_path,
 //############################################################################
 int tpm2_kmyth_unseal_file(char *input_path,
                            uint8_t ** output,
-                           size_t *output_length,
+                           size_t * output_length,
                            uint8_t * auth_bytes,
                            size_t auth_bytes_len,
                            uint8_t * owner_auth_bytes, size_t oa_bytes_len)
@@ -613,7 +613,7 @@ int tpm2_kmyth_unseal_data(TSS2_SYS_CONTEXT * sapi_ctx,
                            TPM2B_AUTH authVal,
                            TPML_PCR_SELECTION pcrList,
                            TPM2B_DIGEST authPolicy,
-                           uint8_t ** result, size_t *result_size)
+                           uint8_t ** result, size_t * result_size)
 {
   // Start a TPM 2.0 policy session that we will use to authorize the use of
   // storage key (SK) to:

--- a/tpm2/src/tpm/storage_key_tools.c
+++ b/tpm2/src/tpm/storage_key_tools.c
@@ -143,7 +143,7 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
 //############################################################################
 // check_if_srk()
 //############################################################################
-int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE handle, bool *isSRK)
+int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE handle, bool * isSRK)
 {
   // initialize 'isSRK' result to false - early termination should not result
   // in a true value passed back (even if the return code indicates an error)

--- a/tpm2/src/tpm/tpm2_interface.c
+++ b/tpm2/src/tpm/tpm2_interface.c
@@ -386,7 +386,7 @@ int get_tpm2_properties(TSS2_SYS_CONTEXT * sapi_ctx,
 //############################################################################
 // get_tpm2_impl_type()
 //############################################################################
-int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator)
+int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool * isEmulator)
 {
   TPMS_CAPABILITY_DATA capData;
 

--- a/tpm2/src/util/file_io.c
+++ b/tpm2/src/util/file_io.c
@@ -122,7 +122,8 @@ int verifyOutputFilePath(char *path)
 //############################################################################
 // read_bytes_from_file()
 //############################################################################
-int read_bytes_from_file(char *input_path, uint8_t ** data, size_t *data_length)
+int read_bytes_from_file(char *input_path, uint8_t ** data,
+                         size_t * data_length)
 {
 
   // Create a BIO for the input file

--- a/tpm2/src/util/tls_util.c
+++ b/tpm2/src/util/tls_util.c
@@ -390,7 +390,7 @@ int tls_set_context(unsigned char *client_private_key,
 //############################################################################
 int get_key_from_tls_server(BIO * bio,
                             char *message, size_t message_length,
-                            unsigned char **key, size_t *key_size)
+                            unsigned char **key, size_t * key_size)
 {
   // validate input
   if (bio == NULL)
@@ -454,7 +454,7 @@ int get_key_from_tls_server(BIO * bio,
 
 int get_key_from_kmip_server(BIO * bio,
                              char *message, size_t message_length,
-                             unsigned char **key, size_t *key_size)
+                             unsigned char **key, size_t * key_size)
 {
   // validate input
   if (bio == NULL)

--- a/tpm2/test/include/cipher/aes_keywrap_test.h
+++ b/tpm2/test/include/cipher/aes_keywrap_test.h
@@ -1,0 +1,127 @@
+/**
+ * @file  aes_keywrap_test.h
+ *
+ * Provides unit tests for the kmyth AES keywrap (RFC-3394 - no padding)
+ * cipher functionality implemented in:
+ *     - tpm2/src/cipher/aes_keywrap_3394nopad.c
+ *     - tpm2/src/cipher/aes_keywrap_5649pad.c
+ */
+
+#ifndef AES_KEYWRAP_TEST_H
+#define AES_KEYWRAP_TEST_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * This function adds all of the tests contained in
+ * tpm2/test/cipher/aes_keywrap_test.c to a test suite parameter passed in by
+ * the caller. This allows a top-level 'test-runner' application to include
+ * them in the set of tests that it runs.
+ *
+ * @param[in]  suite  CUnit test suite that this function will add all of
+ *                    the kmyth AES keywrap cipher functionality tests to.
+ *
+ * @return     0 on success, 1 on error
+ */
+int aes_keywrap_add_tests(CU_pSuite suite);
+
+//--------------------- Test Utilities -------------------------------
+
+/**
+ * Parses NIST AES key wrap/unwrap test vector files.
+ *
+ * NOTE: Designed to parse NIST AES key wrap/unwrap test vectors ONLY
+ *       Not guarenteed to work on other files
+ *
+ * @param[out] suite  CUnit test suite that this function will add all of
+ *                    the kmyth AES keywrap cipher functionality tests to.
+ *
+ * @return     0 on success, 1 on error
+ */
+
+/**
+ * Return a single AES Key Wrap test vector to be applied to (validate)
+ * kmyth's AEC Key Wrap cipher (RFC-3394 and RFC-5649) functionality.
+ *
+ * IMPORTANT NOTE: Parses only NIST AES KW/KWP test vector files (or
+ * other test vector files that adhere strictly to this format.
+ *
+ * The test vector values in the file are specified by groupings of lines
+ * containing:
+ *
+ *     'K = [string representing hexadecimal byte array value]'
+ *     'P = [string representing hexadecimal byte array value]'
+ *     'C = [string representing hexadecimal byte array value]'
+ *
+ * for the encrypt test vectors and
+ *
+ *     'K = [string representing hexadecimal byte array value]'
+ *     'C = [string representing hexadecimal byte array value]'
+ *     'P = [string representing hexadecimal byte array value]'
+ *
+ * for the decrypt test vectors. If the expected result is decryption failure,
+ * the last (P = ...) line is replaced by:
+ *
+ *     'FAIL'
+ *
+ * In parsing the file, we look for these groupings and, upon finding the
+ * first line of one, process that set of lines from the file. Any lines in the
+ * file that are not part of one of these test vector groupings are ignored.
+ *
+ * @param[in]  fid         - pointer to file descriptor for test vector file
+ *
+ * @param[out] K_vec       - pointer to byte array used to return 'K' (key)
+ *                           component of test vector
+ *
+ * @param[out] K_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'K_vec' byte array
+ *
+ * @param[out] P_vec       - pointer to byte array used to return 'P'
+ *                           (plaintext) component of test vector
+ *
+ * @param[out] P_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'P_vec' byte array
+ *
+ * @param[out] C_vec       - pointer to byte array used to return 'C'
+ *                           (ciphertext) component of test vector
+ *
+ * @param[out] C_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'C_vec' byte array
+ *
+ * @param[out] expect_pass - pointer to boolean indicating whether
+ *                           application of the test vector should produce
+ *                           a PASS result (i.e., if true, the vector should
+ *                           not produce an error, if false, the vector is
+ *                           expected to produce an error)
+ *
+ * @return     0 on success, 1 on error
+ */
+int get_aes_keywrap_vector_from_file(FILE * fid,
+                                     uint8_t ** K_vec,
+                                     size_t * K_vec_len,
+                                     uint8_t ** P_vec,
+                                     size_t * P_vec_len,
+                                     uint8_t ** C_vec,
+                                     size_t * C_vec_len,
+                                     bool * expect_pass);
+
+
+//--------------------- Tests ------------------------------------------------
+
+/**
+ * Test to verify parameter handling/enforcement by the kmyth AES key
+ * wrap/unwrap API (e.g., tests behavior when invalid parameters are
+ * provided, etc.)
+ */
+void test_aes_keywrap_parameters(void);
+
+/**
+ * Runs set of test vectors for AES key wrap/unwrap through kmyth
+ * implementation of this cipher functionality and validates
+ * that the results match those specified by the test vectors.
+ */
+void test_aes_keywrap_vectors(void);
+
+#endif
+

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -1,0 +1,62 @@
+/**
+ * @file  kmyth_cipher_test.h
+ */
+
+#ifndef KMYTH_CIPHER_TEST_H
+#define KMYTH_CIPHER_TEST_H
+
+/**
+ * Specify maximum number of test vector sets (vector files) that can be
+ * contained within a "vector set compilation" (used to size that array).
+ */
+#define MAX_VECTOR_SETS_IN_COMPILATION 20
+
+/**
+ * Specify maximum number of test vectors to process when parsing
+ * a test vector file.
+ */
+#define MAX_KEYWRAP_TEST_VECTOR_COUNT 500
+#define MAX_GCM_TEST_VECTOR_COUNT 7875
+
+/**
+ * Specify the maximum length (in chars) of a test vector component
+ * This is needed to appropriately size the buffers used to parse and
+ * process test vector components read from a file. For example, a
+ * 2048 hexadecimal character string can specify a 512-byte or
+ * 4096-bit test vector component.
+ */
+#define MAX_TEST_VECTOR_COMPONENT_LENGTH 2500
+
+typedef struct cipher_vector_set
+{
+  char * desc;
+  char * func_to_test;
+  char * path;
+} cipher_vector_set;
+
+typedef struct cipher_vector_compilation
+{
+  size_t count;
+  cipher_vector_set sets[MAX_VECTOR_SETS_IN_COMPILATION];
+} cipher_vector_compilation;
+
+
+/**
+ * As the NIST test vectors are specified as hexadecimal values, the
+ * bytes encrypted or decrypted by the kmyth keywrap cipher
+ * implementation must be converted into a hex format for comparison
+ * with the expected result. This simple utility provides that
+ * functionality.
+ *
+ * @param[out] result  - Byte array corresponding to input hex string value
+ *
+ * @param[in]  hex_str - hexadecimal string to be converted
+ *
+ * @param[in]  size    - length (in hex chars) of input string
+ *
+ * @return     0 on success, 1 on error
+ */
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size);
+
+#endif
+

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -380,7 +380,7 @@ void test_aes_keywrap_vectors(void)
 
           // create flag to aggregate pass/fail result
           // (initialize true but latch in false for any unexpected result)
-          bool vector_passed;
+          bool vector_passed = true;
 
           // create variable to hold response code from function being tested
           int rc = -1;

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -1,0 +1,539 @@
+//############################################################################
+// aes_keywrap_test.c
+//
+// Tests for kmyth AES keywrap functionality in:
+//   - tpm2/src/cipher/aes_keywrap_3394nopad.c
+//   - tpm2/src/cipher/aes_keywrap_5649pad.c
+//############################################################################
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <CUnit/CUnit.h>
+
+#include "aes_keywrap_test.h"
+#include "kmyth_cipher_test.h"
+#include "aes_keywrap_3394nopad.h"
+#include "aes_keywrap_5649pad.h"
+
+#define AES_KW_VECTOR_PATH "test/vectors/kwtestvectors"
+
+
+//---------------------- AES Key Wrap Cipher Test Configuration --------------
+
+//----------------------------------------------------------------------------
+// aes_keywrap_add_tests()
+//----------------------------------------------------------------------------
+int aes_keywrap_add_tests(CU_pSuite suite)
+{
+  if (NULL == CU_add_test(suite,
+                          "Test Kmyth AES key wrap/unwrap parameter handling",
+                          test_aes_keywrap_parameters))
+  {
+    return 1;
+  }
+
+  if (NULL == CU_add_test(suite,
+                          "Run AES key wrap test vectors",
+                          test_aes_keywrap_vectors))
+  {
+    return 1;
+  }
+
+
+  return 0;
+}
+
+//---------------------- AES Key Wrap Cipher Test Utilities --------------
+
+//----------------------------------------------------------------------------
+// get_aes_keywrap_vector_from_file()
+//----------------------------------------------------------------------------
+int get_aes_keywrap_vector_from_file(FILE * fid,
+                                     uint8_t ** K_vec,
+                                     size_t * K_vec_len,
+                                     uint8_t ** P_vec,
+                                     size_t * P_vec_len,
+                                     uint8_t ** C_vec,
+                                     size_t * C_vec_len,
+                                     bool * expect_pass)
+{
+  // create buffer to hold vector data read in from file a line at a time
+  // specify buffer size to handle largest vector component (must include
+  // some extra space for leading and/or trailing characters that get
+  // stripped off)
+  char buffer[MAX_TEST_VECTOR_COMPONENT_LENGTH];
+
+  // create variables to buffer the components in a single test vector
+  char  * K_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int K_str_len = 0;
+  char * P_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int P_str_len = 0;
+  char * C_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int C_str_len = 0;
+  bool pass_result = true;  // unless vector has a 'FAIL' line, should pass
+
+  // create/initialize a counter to track progress (ensure that test vector
+  // components are read and parsed in expected sequence)
+  //     step = 1: searching for a 'K' vector component (start of test vector)
+  //     step = 2: found a 'K' vector component
+  //               expecting 'P', 'C' vector component
+  //               finding another 'K' component in step 2 stays in step 2
+  //     step = 3: have 'K' and either 'P' or 'C' vector components
+  //               expecting 'P' or 'C' (whichever not yet found) or 'FAIL'
+  //               finding another 'K' component in step 3 returns to step 2
+  //     step = 4: found complete vector
+  // any other parsing sequence values are invalid - failure or unexepected
+  // file data at any step restarts the process (reset to first step)
+  int step = 1;
+
+  while ((!feof(fid)) && (step < 4))
+  {
+    // test vector file is read a line at a time until either EOF is reached
+    // or a test vector grouping is successfully parsed.
+    if (fgets(buffer, MAX_TEST_VECTOR_COMPONENT_LENGTH, fid) != NULL)
+    {
+      if (strncmp(buffer, "K = ", 4) == 0)
+      {
+        // If 'K = ' is found, we are at the start of a test vector
+        // Note: regardless of incoming step level (< 4), finding 'K = ' puts
+        //       the parsing process into step 2 (having 'K' but nothing else)
+        step = 2;
+        K_str_len = strlen(buffer) - 4;  // strip leading 'K = ' sub-string
+        memcpy(K_str, buffer + 4, K_str_len * sizeof(char));
+        while ((K_str_len > 0) &&
+               ((K_str[K_str_len - 1] == '\n') ||
+                (K_str[K_str_len - 1] == '\r')))
+        {
+          K_str[--K_str_len] = '\0';  // strip any trailing '\n' or '\r'
+        }
+      }
+  
+      else if (strncmp(buffer, "P = ", 4) == 0)
+      {
+        // found 'P' vector component before 'K' - reset
+        if ((step != 2) && (step != 3))
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+  
+        // correctly found 'P' component in step 2 or step 3
+        else
+        {
+          step++;
+          P_str_len = strlen(buffer) - 4;  // strip leading 'P = ' sub-string
+          memcpy(P_str, buffer + 4, P_str_len * sizeof(char));
+          while ((P_str_len > 0) &&
+                 ((P_str[P_str_len - 1] == '\n') ||
+                  (P_str[P_str_len - 1] == '\r')))
+          {
+            P_str[--P_str_len] = '\0';  // strip any trailing '\n' or '\r'
+          }
+        }
+      }
+  
+      else if (strncmp(buffer, "C = ", 4) == 0)
+      {
+        // found 'C' vector component before 'K' - reset
+        if ((step != 2) && (step != 3))
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+  
+        // correctly found 'C' component in step 2 or step 3
+        else
+        {
+          step++;
+          C_str_len = strlen(buffer) - 4;  // strip leading 'C = ' sub-string
+          memcpy(C_str, buffer + 4, C_str_len * sizeof(char));
+          while ((C_str_len > 0) &&
+                 ((C_str[C_str_len - 1] == '\n') ||
+                  (C_str[C_str_len - 1] == '\r')))
+          {
+            C_str[--C_str_len] = '\0';  // strip any trailing '\n' or '\r'
+          }
+        }
+      }
+  
+      else if (strncmp(buffer, "FAIL", 4) == 0)
+      {
+        // found expected 'FAIL' result, but incomplete vector - reset
+        if (step != 3)
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+
+        // found expected 'FAIL' result (should be in place of 'P' component)
+        else
+        {
+          step++;
+          pass_result = false;
+        }
+      }
+  
+      // found line in vector file that is not in one of the formats parsed by
+      // this function - reset (start over, looking for next vector)
+      else
+      {
+        P_str_len = 0;
+        C_str_len = 0;
+        step = 1;
+      }
+    }
+  }
+
+  // reaching step 4 means a vector has been successfully parsed
+  if (step == 4)
+  {
+    // use parsed results to populate output parameters
+    convert_HexString_to_ByteArray((char **) K_vec,
+                                             K_str,
+                                             K_str_len);
+    *K_vec_len = K_str_len / 2;  // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) P_vec,
+                                             P_str,
+                                             P_str_len);
+    *P_vec_len = P_str_len / 2;  // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) C_vec,
+                                             C_str,
+                                             C_str_len);
+    *C_vec_len = C_str_len / 2;  // 2 hex chars map to a byte of key
+    *expect_pass = pass_result;
+  }
+
+  // clean-up allocated memory
+  free(K_str);
+  free(P_str);
+  free(C_str);
+
+  // if while loop exit due to EOF, return unsuccessful result
+  if (step != 4)
+  {
+    return 1;
+  }
+
+  // normal termination
+  return 0;
+}
+
+//---------------------- AES Key Wrap Cipher Tests ---------------------------
+
+//----------------------------------------------------------------------------
+// test_aes_keywrap_parameters()
+//----------------------------------------------------------------------------
+void test_aes_keywrap_parameters(void)
+{
+  unsigned char* key = NULL;
+  int key_len = 0;
+  
+  unsigned char* inData = NULL;
+  size_t inData_len = 0;
+
+  unsigned char* outData = NULL;
+  size_t outData_len = 0;
+
+  // Test failure on null key
+  inData = malloc(16);
+  inData_len = 16;
+  key_len = 16;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure on key of length 0
+  key = malloc(16);
+  key_len = 0;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure on input data of length 0
+  key_len = 16;
+  inData_len = 0;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure with input data too short
+  inData_len = 8;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure with input data that's not a multiple of 8 bytes long
+  inData_len = 17;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  free(key);
+  free(inData);
+}
+
+
+//----------------------------------------------------------------------------
+// test_aes_keywrap_vectors()
+//----------------------------------------------------------------------------
+void test_aes_keywrap_vectors(void)
+{
+  // specify the compilation of test vector mappings for kmyth AES GCM
+  // decrypt cipher testing.
+  const cipher_vector_compilation aes_keywrap_vectors = {
+    .count = 12,
+    .sets = 
+    {
+      { .desc = "AES-128, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_128.txt" },
+      { .desc = "AES-128, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_128.txt" },
+      { .desc = "AES-192, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_192.txt" },
+      { .desc = "AES-192, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_192.txt" },
+      { .desc = "AES-256, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_256.txt" },
+      { .desc = "AES-256, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_256.txt" },
+      { .desc = "AES-128, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_128.txt" },
+      { .desc = "AES-128, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_128.txt" },
+      { .desc = "AES-192, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_192.txt" },
+      { .desc = "AES-192, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_192.txt" },
+      { .desc = "AES-256, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_256.txt" },
+      { .desc = "AES-256, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_256.txt" }
+    }
+  };
+
+  // array of file pointers for test vector files
+  FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
+
+  // counter to track number of test vectors applied from a file
+  int test_vector_count = 0;
+
+  // flag used to signal end of processing for a given test vector file
+  bool done_with_test_vector_file = false;
+
+  // check that number of test vector files complies with specified maximum
+  if (aes_keywrap_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
+  {
+    fprintf(stderr,
+            "ERROR: too many (%ld) vector set mappings (%d max)",
+            aes_keywrap_vectors.count,
+            MAX_VECTOR_SETS_IN_COMPILATION);
+    CU_FAIL("AES Key Wrap Test Vector File Count Exceeds Limit");
+    return;
+  }
+
+  // allocate memory to hold a single test vector - re-use these buffers
+  // for all test vectors used during these tests
+  unsigned char * key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t key_data_len = 0;
+  unsigned char * pt_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t pt_data_len = 0;
+  unsigned char * ct_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t ct_data_len = 0;
+  bool result_bool = false;
+
+  for (int i = 0; i < aes_keywrap_vectors.count; i++)
+  {
+    // open test vector file
+    test_vector_fd[i] = fopen(aes_keywrap_vectors.sets[i].path, "r");
+    if (test_vector_fd[i] != NULL)
+    {
+      while ((!done_with_test_vector_file) &&
+             (test_vector_count <= MAX_KEYWRAP_TEST_VECTOR_COUNT))
+      {
+        // Parse next vector from file
+        if (get_aes_keywrap_vector_from_file(test_vector_fd[i],
+                                             &key_data,
+                                             &key_data_len,
+                                             &pt_data,
+                                             &pt_data_len,
+                                             &ct_data,
+                                             &ct_data_len,
+                                             &result_bool) == 0)
+        {
+          // Create a new buffer to hold the result for each vector applied
+          unsigned char * out = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+          size_t out_len = 0;
+
+          // increment count of test vectors applied
+          test_vector_count++;
+
+          // create flag to aggregate pass/fail result
+          // (initialize true but latch in false for any unexpected result)
+          bool vector_passed;
+
+          // create variable to hold response code from function being tested
+          int rc = -1;
+
+          // create pointers to applicable result (i.e., ct_data and
+          // ct_data_len for encrypt, pt_data and pt_data_len for decrypt)
+          unsigned char * exp_result = NULL;
+          size_t exp_result_len = 0;
+
+          if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                      "aes_keywrap_3394nopad_encrypt",
+                      29) == 0)
+          {
+            rc = aes_keywrap_3394nopad_encrypt(key_data,
+                                               key_data_len,
+                                               pt_data,
+                                               pt_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = ct_data;
+            exp_result_len = ct_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_3394nopad_decrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_3394nopad_decrypt(key_data,
+                                               key_data_len,
+                                               ct_data,
+                                               ct_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = pt_data;
+            exp_result_len = pt_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_5649pad_encrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_5649pad_encrypt(key_data,
+                                               key_data_len,
+                                               pt_data,
+                                               pt_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = ct_data;
+            exp_result_len = ct_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_5649pad_decrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_5649pad_decrypt(key_data,
+                                               key_data_len,
+                                               ct_data,
+                                               ct_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = pt_data;
+            exp_result_len = pt_data_len;
+          }
+
+          else
+          {
+            printf("ERROR: test vector set for file (%s) associated with ",
+                   aes_keywrap_vectors.sets[i].path);
+            printf("function to test(%s)\n",
+                   aes_keywrap_vectors.sets[i].func_to_test);
+            CU_FAIL("Test vector file linked to invalid function to test");
+            // don't get any more vectors from this file - can't apply them
+            done_with_test_vector_file = true;
+          }
+
+          // if vector successfully applied
+          if (rc != -1)
+          {
+            // consolidate results of applying test vector into a single assertion
+            if (result_bool == false)
+            {
+              // check if a test vector expected to fail, passed
+              if (rc == 0)
+              { 
+                vector_passed = false;
+                printf("expected fail, passed: %d\n", test_vector_count);
+              }
+            }
+            else
+            {
+              // check if a test vector expected to pass, failed
+              if (rc != 0)
+              {
+                vector_passed = false;
+                printf("expected pass, failed: %d\n", test_vector_count);
+              }
+
+              // check for unexpected size of decrypted result
+              if (out_len != exp_result_len)
+              {
+                vector_passed = false;
+                printf("unexpected size for result: %d\n", test_vector_count);
+              }
+
+              // check that expected result matches (byte for byte)
+              for (int j = 0; j < out_len; j++)
+              {
+                if (out[j] != exp_result[j])
+                {
+                  vector_passed = false;
+                  printf("expected result mismatch at byte %d: %d\n", j, test_vector_count);
+                }
+              }
+            }
+
+            CU_ASSERT(vector_passed);
+
+            // clean-up output_data byte array
+            if (rc == 0)
+            {
+              free(out);
+            }
+          }
+        }
+
+        else
+        {
+          // get_aes_gcm_test_vector_from_file() returned error - must be done
+          done_with_test_vector_file = true;
+        }
+      }
+
+      // Done with the test vector file (processed all vectors or reached max)
+      fclose(test_vector_fd[i]);
+
+      // Provide INFO: message indicating how many test vectors were applied
+      printf("INFO: %s - %d test vectors applied\n",
+              aes_keywrap_vectors.sets[i].path, test_vector_count);
+
+      // reset flag/counters for processing of next (if any) test vector file
+      done_with_test_vector_file = false;
+      test_vector_count = 0;
+    }
+
+    else
+    {
+      printf("INFO: test vector file (%s) not installed ... ",
+              aes_keywrap_vectors.sets[i].path);
+      printf("skipping these tests\n");
+    }
+  }
+
+  // clean-up allocated test vector memory
+  free(key_data);
+  free(pt_data);
+  free(ct_data);
+}
+

--- a/tpm2/test/src/cipher/kmyth_cipher_test.c
+++ b/tpm2/test/src/cipher/kmyth_cipher_test.c
@@ -1,0 +1,38 @@
+//############################################################################
+// kmyth_test_cipher.c
+//
+// General utilities for kmyth cipher testing:
+//   - convert hexadecimal valued strings in vector files to byte arrays
+//############################################################################
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "kmyth_cipher_test.h"
+
+
+//----------------------------------------------------------------------------
+// convert_HexString_to_ByteArray()
+//----------------------------------------------------------------------------
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size)
+{
+  if((str_size % 2) != 0)
+  {
+    fprintf(stderr, "ERROR: Invalid hex string size, must be even.\n");
+    return 1; 
+  }
+
+  size_t bufSize = ((str_size) / 2);
+  char * buf = (char *) calloc(bufSize + 1, sizeof(char)); 
+  for (int i = 0; i < bufSize; i++)
+  {
+    sscanf(hex_str+(i*2), "%02hhx", &buf[i]);
+  }
+  buf[bufSize] = '\0';
+
+  *result = buf;
+
+  return 0;
+}
+

--- a/tpm2/test/src/kmyth-test.c
+++ b/tpm2/test/src/kmyth-test.c
@@ -19,6 +19,7 @@
 #include "formatting_tools_test.h"
 #include "tls_util_test.h"
 #include "aes_gcm_test.h"
+#include "aes_keywrap_test.h"
 #include "tpm2_interface_test.h"
 #include "storage_key_tools_test.h"
 #include "pcrs_test.h"
@@ -141,6 +142,21 @@ int main(int argc, char** argv)
     return CU_get_error();
   }
   if(aes_gcm_add_tests(aes_gcm_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+
+  // Create and configure the AES Key Wrap cipher test suite
+  CU_pSuite aes_keywrap_test_suite = NULL;
+  aes_keywrap_test_suite = CU_add_suite("AES Key Wrap Cipher Test Suite",
+				                                init_suite, clean_suite);
+  if (NULL == aes_keywrap_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if(aes_keywrap_add_tests(aes_keywrap_test_suite))
   {
     CU_cleanup_registry();
     return CU_get_error();


### PR DESCRIPTION
Added tests to apply NIST AES Key Wrap (RFC-3394 and RFC-5649) vectors to the kmyth AES Key Wrap cipher implementation.

Note: Although, I did not change the configuration for the indent utility in the makefile, a number of white-space edits were generated by building the code, and included in this very simple pull request.