### PR TITLE
Missing format specification for asprintf() call

### DIFF
--- a/tpm2/src/util/file_io.c
+++ b/tpm2/src/util/file_io.c
@@ -72,7 +72,7 @@ int verifyOutputFilePath(char *path)
   // check that specified output path directory exists
   char *path_copy = "\0";
 
-  if (asprintf(&path_copy, path) < 0)
+  if (asprintf(&path_copy, "%s", path) < 0)
   {
     kmyth_log(LOG_ERR, "unable to copy output file path ... exiting");
     return 1;


### PR DESCRIPTION
A compiler warning was being generated due to a missing format specification in an 'asprintf()' call in tpm2/src/util/file_io.c. This pull request fixes that error.