### PR TITLE
Added tests applying AES/GCM decryption test vectors

### DIFF
--- a/tpm2/src/cipher/aes_gcm.c
+++ b/tpm2/src/cipher/aes_gcm.c
@@ -29,10 +29,10 @@ int aes_gcm_encrypt(unsigned char *key,
     return 1;
   }
 
-  // validate non-NULL and non-empty input plaintext buffer specified
-  if (inData == NULL || inData_len == 0)
+  // validate non-NULL input plaintext buffer specified
+  if (inData == NULL)
   {
-    kmyth_log(LOG_ERR, "no input data ... exiting");
+    kmyth_log(LOG_ERR, "null input data pointer ... exiting");
     return 1;
   }
 
@@ -186,7 +186,7 @@ int aes_gcm_decrypt(unsigned char *key,
     kmyth_log(LOG_ERR, "no input data ... exiting");
     return 1;
   }
-  if (inData_len <= GCM_IV_LEN + GCM_TAG_LEN)
+  if (inData_len < GCM_IV_LEN + GCM_TAG_LEN)
   {
     kmyth_log(LOG_ERR, "input data incomplete (must be %d bytes, was %lu "
               "bytes) ... exiting", GCM_IV_LEN + GCM_TAG_LEN + 1, inData_len);

--- a/tpm2/test/include/cipher/aes_gcm_test.h
+++ b/tpm2/test/include/cipher/aes_gcm_test.h
@@ -5,8 +5,93 @@
  * implemented in tpm2/src/cipher/aes_gcm.c
  */
 
+#include <stdint.h>
+#include <stdbool.h>
+
 #ifndef AES_GCM_TEST_H
 #define AES_GCM_TEST_H
+
+
+//--------------------- Test Utilities ---------------------------------------
+
+/**
+ * Return a single AES GCM decrypt test vector to be applied to (validate)
+ * kmyth's AEC GCM decryption functionality.
+ *
+ * IMPORTANT NOTE: Parses only NIST AES GCM decrypt test vector files (or
+ * other test vector files that adhere strictly to this format.
+ *
+ * The test vector values in the file are specified by groupings of lines
+ * containing, as the first line:
+ *     'Key = [string representing hexadecimal byte array value]'
+ *     'IV = [string representing hexadecimal byte array value]'
+ *     'CT = [string representing hexadecimal byte array value]'
+ *     'AAD = [string representing hexadecimal byte array value]'
+ *     'Tag = [string representing hexadecimal byte array value]'
+ *     'PT = [string representing hexadecimal byte array value]'
+ *
+ * If the expected result is decryption failure, the last (PT) line is
+ * replaced by:
+ *     'FAIL'
+ *
+ * In parsing the file, we look for these groupings and, upon finding the
+ * first line of one, process that set of lines from the file. Any lines in the
+ * file that are not part of one of these test vector groupings are ignored.
+ *
+ * Further, for kmyth, the only applicable test vectors are those:
+ *     - without additional authenticated data (AAD component is empty)
+ *     - with a initialization vector (IV) component of length 12
+ *     - with a tag (Tag) component of length 16
+ * Therefore, we filter out all test vectors not meeting this criteria, which
+ * is actually the majority of them.
+ *
+ * Finally, kmyth's AES GCM decryption API expects the input data as a
+ * concatenation of the IV, CT, and Tag components. Thus, we return the test
+ * vector in this format to facilitate passing it as a parameter to kmyth's
+ * aes_gcm_decrypt() function.
+ *
+ * @param[in]  fid            - pointer to file descriptor for test vector file
+ *
+ * @param[out] key_vec       - pointer to byte array used to return 'Key'
+ *                             component of test vector
+ *
+ * @param[out] key_vec_len   - pointer to length (in bytes) of value being
+ *                             returned in 'key_out' byte array
+ *
+ * @param[out] input_vec     - pointer to byte array used to return
+ *                             concatenated 'IV', 'CT', and 'Tag' (in that
+ *                             order) of test vector
+ *
+ * @param[out] input_vec_len - pointer to length (in bytes) of value being
+ *                             returned in 'input_data' byte array
+ *
+ * @param[out] result_vec    - pointer to byte array used to return 'PT'
+ *                             component (expected decryption result) of test
+ *                             vector - if the expected result is decryption
+ *                             failure the string 'FAIL' is returned.
+ *
+ * @param[out] result_vec_len - pointer to length (in bytes) of value being
+ *                              returned in 'result' byte array
+ *
+ * @param[out] expect_pass    - pointer to boolean indicating whether
+ *                              application of the test vector should produce
+ *                              a PASS result (i.e., if true, the vector should
+ *                              not produce an error, if false, the vector is
+ *                              expected to produce an error)
+ *
+ * @return     0 on success, 1 on error
+ */
+int get_aes_gcm_vector_from_file(FILE * fid,
+                                 uint8_t ** key_vec,
+                                 size_t * key_vec_len,
+                                 uint8_t ** input_vec,
+                                 size_t * input_vec_len,
+                                 uint8_t ** result_vec,
+                                 size_t * result_vec_len,
+                                 bool * expect_pass);
+
+
+//---------------------- Test Suite Setup ------------------------------------
 
 /**
  * This function adds all of the tests contained in
@@ -21,7 +106,14 @@
  */
 int aes_gcm_add_tests(CU_pSuite suite);
 
-//Tests
+
+//---------------------- Tests -----------------------------------------------
+
+/**
+ * Tests the AES/GCM decryption implementation by validating it against the
+ * NIST published set of test vectors
+ */
+void test_aes_gcm_decrypt_vectors(void);
 
 /**
  * Tests of the basic AES/GCM encryption and decryption functionality

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -22,10 +22,11 @@
  * Specify the maximum length (in chars) of a test vector component
  * This is needed to appropriately size the buffers used to parse and
  * process test vector components read from a file. For example, a
- * 1024 hexadecimal character string can specify a 512-byte or 4096-bit
- * test vector component.
+ * value of 2176 (2048 + 128) supports up to a 2048 hexadecimal character
+ * string that can specify a 1024-byte or 8192-bit test vector component,
+ * as well as up to 128 leading trailing characters.
  */
-#define MAX_TEST_VECTOR_COMPONENT_LENGTH 1024
+#define MAX_TEST_VECTOR_COMPONENT_LENGTH 2176
 
 typedef struct cipher_vector_set
 {

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -24,7 +24,7 @@
  * process test vector components read from a file. For example, a
  * value of 2176 (2048 + 128) supports up to a 2048 hexadecimal character
  * string that can specify a 1024-byte or 8192-bit test vector component,
- * as well as up to 128 leading trailing characters.
+ * as well as up to 128 leading/trailing characters.
  */
 #define MAX_TEST_VECTOR_COMPONENT_LENGTH 2176
 

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -1,0 +1,62 @@
+/**
+ * @file  kmyth_cipher_test.h
+ */
+
+#ifndef KMYTH_CIPHER_TEST_H
+#define KMYTH_CIPHER_TEST_H
+
+/**
+ * Specify maximum number of test vector sets (vector files) that can be
+ * contained within a "vector set compilation" (used to size that array).
+ */
+#define MAX_VECTOR_SETS_IN_COMPILATION 20
+
+/**
+ * Specify maximum number of test vectors to process when parsing
+ * a test vector file.
+ */
+#define MAX_KEYWRAP_TEST_VECTOR_COUNT 500
+#define MAX_GCM_TEST_VECTOR_COUNT 7875
+
+/**
+ * Specify the maximum length (in chars) of a test vector component
+ * This is needed to appropriately size the buffers used to parse and
+ * process test vector components read from a file. For example, a
+ * 1024 hexadecimal character string can specify a 512-byte or 4096-bit
+ * test vector component.
+ */
+#define MAX_TEST_VECTOR_COMPONENT_LENGTH 1024
+
+typedef struct cipher_vector_set
+{
+  char * desc;
+  char * func_to_test;
+  char * path;
+} cipher_vector_set;
+
+typedef struct cipher_vector_compilation
+{
+  size_t count;
+  cipher_vector_set sets[MAX_VECTOR_SETS_IN_COMPILATION];
+} cipher_vector_compilation;
+
+
+/**
+ * As the NIST test vectors are specified as hexadecimal values, the
+ * bytes encrypted or decrypted by the kmyth keywrap cipher
+ * implementation must be converted into a hex format for comparison
+ * with the expected result. This simple utility provides that
+ * functionality.
+ *
+ * @param[out] result  - Byte array corresponding to input hex string value
+ *
+ * @param[in]  hex_str - hexadecimal string to be converted
+ *
+ * @param[in]  size    - length (in hex chars) of input string
+ *
+ * @return     0 on success, 1 on error
+ */
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size);
+
+#endif
+

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -130,7 +130,6 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         {
           key_str[--key_str_len] = '\0';  // strip any trailing '\n' or 'r'
         }
-        Key_len = key_str_len / 2;  // 2 hex chars map to a byte of key
         convert_HexString_to_ByteArray((char **) &Key,
                                        key_str,
                                        key_str_len);

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -329,12 +329,6 @@ void test_aes_gcm_decrypt_vectors(void)
   // array of file pointers for test vector files
   FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
 
-  // counter to track number of test vectors applied from a file
-  int test_vector_count = 0;
-
-  // flag used to signal end of processing for a given test vector file
-  bool done_with_test_vector_file = false;
-
   // check that number of test vector files complies with specified maximum
   if (gcm_decrypt_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
   {
@@ -363,6 +357,12 @@ void test_aes_gcm_decrypt_vectors(void)
     test_vector_fd[i] = fopen(gcm_decrypt_vectors.sets[i].path, "r");
     if (test_vector_fd[i] != NULL)
     {
+      // counter to track number of test vectors applied from a file
+      int test_vector_count = 0;
+
+      // flag used to signal end of processing for a given test vector file
+      bool done_with_test_vector_file = false;
+
       while ((!done_with_test_vector_file) &&
              (test_vector_count <= MAX_GCM_TEST_VECTOR_COUNT))
       {

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -168,7 +168,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
           ct_str[--ct_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
         convert_HexString_to_ByteArray((char **) &CT, ct_str, ct_str_len);
-        CT_len = ct_str_len / 2;  // 2 hex chars map to a byte of key
+        CT_len = ct_str_len / 2;  // 2 hex chars map to a byte of CT
         step = 4;
       }
 
@@ -187,7 +187,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         convert_HexString_to_ByteArray((char **) &AAD,
                                        aad_str,
                                        aad_str_len);
-        AAD_len = aad_str_len / 2;  // 2 hex chars map to a byte of key
+        AAD_len = aad_str_len / 2;  // 2 hex chars map to a byte of AAD
         step = 5;
       }
 
@@ -206,7 +206,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         convert_HexString_to_ByteArray((char **) &Tag,
                                        tag_str,
                                        tag_str_len);
-        Tag_len = tag_str_len / 2;  // 2 hex chars map to a byte of key
+        Tag_len = tag_str_len / 2;  // 2 hex chars map to a byte of Tag
         step = 6;
       }
 
@@ -225,7 +225,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         convert_HexString_to_ByteArray((char **) &PT,
                                                  pt_str,
                                                  pt_str_len);
-        PT_len = pt_str_len / 2;    // 2 hex chars map to a byte of key
+        PT_len = pt_str_len / 2;    // 2 hex chars map to a byte of PT
         pass_result = true;
 
         // check applicability of parsed vector to kmyth implementation

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -6,17 +6,24 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <CUnit/CUnit.h>
 
 #include "aes_gcm_test.h"
+#include "kmyth_cipher_test.h"
 #include "aes_gcm.h"
+
 
 //----------------------------------------------------------------------------
 // aes_gcm_add_tests()
 //----------------------------------------------------------------------------
 int aes_gcm_add_tests(CU_pSuite suite)
 {
+  if(NULL == CU_add_test(suite, "Test AES/GCM decryption vectors",
+                         test_aes_gcm_decrypt_vectors))
+  {
+    return 1;
+  }
+
   if(NULL == CU_add_test(suite, "Test AES/GCM encryption/decryption",
                          test_gcm_encrypt_decrypt))
   {
@@ -54,6 +61,411 @@ int aes_gcm_add_tests(CU_pSuite suite)
   }
 
   return 0;
+}
+
+//----------------------------------------------------------------------------
+// get_aes_gcm_vector_from_file()
+//----------------------------------------------------------------------------
+int get_aes_gcm_vector_from_file(FILE * fid,
+                                 uint8_t ** key_vec,
+                                 size_t * key_vec_len,
+                                 uint8_t ** input_vec,
+                                 size_t * input_vec_len,
+                                 uint8_t ** result_vec,
+                                 size_t * result_vec_len,
+                                 bool * expect_pass)
+{
+  // create buffer to hold vector data read in from file a line at a time
+  // specify buffer size to handle largest vector component (must include
+  // some extra space for leading and/or trailing characters that get
+  // stripped off
+  char buffer[MAX_TEST_VECTOR_COMPONENT_LENGTH];
+
+  // create stack variables to buffer the components in a single test vector
+  uint8_t  * Key = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t Key_len = 0;
+  uint8_t * IV = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t IV_len = 0;
+  uint8_t * CT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t CT_len = 0;
+  uint8_t * AAD = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t AAD_len = 0;
+  uint8_t * Tag = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t Tag_len = 0;
+  uint8_t * PT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t PT_len = 0;
+  bool pass_result = false;
+
+  // create/initialize a flag to report that an applicable kmyth vector found
+  bool test_vector_found = false;
+
+  // create/initialize a counter to track progress (ensure that test vector
+  // components are read and parsed in expected sequence)
+  //     step = 1: looking for a 'Key' vector component
+  //     step = 2: expecting 'IV' vector component
+  //     step = 3: expecting 'CT' vector component
+  //     step = 4: expecting 'AAD' vector component
+  //     step = 5: expecting 'Tag' vector component
+  //     step = 6: expecting 'PT' vector component or 'FAIL'
+  //               check kmyth applicability of test vector
+  // any other parsing sequence values are invalid - failure or unexepected
+  // file data at any step restarts the process (reset to first step)
+  int step = 1;
+
+  // test vector file is read a line at a time until either EOF is reached
+  // or a test vector grouping applicable to kmyth is successfully parsed.
+  while (!feof(fid) && !test_vector_found)
+  {
+    if (fgets(buffer, MAX_TEST_VECTOR_COMPONENT_LENGTH, fid) != NULL)
+    {
+      if ((strncmp(buffer, "Key = ", 6) == 0) &&
+          (step == 1))
+      {
+        // process 'Key' component of this test vector
+        char * key_str = buffer + 6;  // strip preceding 'Key = ' sub-string
+        int key_str_len = strlen(key_str);
+        while ( (key_str_len > 0) &&
+                ((key_str[key_str_len-1] == '\n') ||
+                 (key_str[key_str_len-1] == '\r')) )
+        {
+          key_str[--key_str_len] = '\0';  // strip any trailing '\n' or 'r'
+        }
+        Key_len = key_str_len / 2;  // 2 hex chars map to a byte of key
+        convert_HexString_to_ByteArray((char **) &Key,
+                                       key_str,
+                                       key_str_len);
+        Key_len = key_str_len / 2;  // 2 hex chars map to a byte of key
+        step = 2;
+      }
+      
+      else if ((strncmp(buffer, "IV = ", 5) == 0) &&
+               (step == 2))
+      {
+        // process IV component of test vector
+        char * iv_str = buffer + 5; // strip preceding 'IV = ' sub-string
+        int iv_str_len = strlen(iv_str);
+        while ( (iv_str_len > 0) &&
+                ((iv_str[iv_str_len-1] == '\n') ||
+                 (iv_str[iv_str_len-1] == '\r')) )
+        {
+          iv_str[--iv_str_len] = '\0';  // strip any trailing '\n' or '\r'
+        }
+        convert_HexString_to_ByteArray((char **) &IV, iv_str, iv_str_len);
+        IV_len = iv_str_len / 2;  // 2 hex chars map to a byte of key
+        step = 3;
+      }
+
+      else if ((strncmp(buffer, "CT = ", 5) == 0) &&
+               (step == 3))
+      {
+        // process 'CT' component of test vector
+        char * ct_str = buffer + 5;  // strip preceding 'CT = ' sub-string
+        int ct_str_len = strlen(ct_str);
+        while ( (ct_str_len > 0) &&
+                ((ct_str[ct_str_len-1] == '\n') ||
+                 (ct_str[ct_str_len-1] == '\r')) )
+        {
+          ct_str[--ct_str_len] = '\0';  // strip any trailing '\n' or '\r'
+        }
+        convert_HexString_to_ByteArray((char **) &CT, ct_str, ct_str_len);
+        CT_len = ct_str_len / 2;  // 2 hex chars map to a byte of key
+        step = 4;
+      }
+
+      else if ((strncmp(buffer, "AAD = ", 6) == 0) &&
+               (step == 4))
+      {
+        // process 'AAD' component of test vector
+        char * aad_str = buffer + 6;  // strip preceding 'AAD = ' sub-string
+        int aad_str_len = strlen(aad_str);
+        while ( (aad_str_len > 0) &&
+                ((aad_str[aad_str_len-1] == '\n') ||
+                 (aad_str[aad_str_len-1] == '\r')) )
+        {
+          aad_str[--aad_str_len] = '\0';  // strip any trailing '\n' or '\r'
+        }
+        convert_HexString_to_ByteArray((char **) &AAD,
+                                       aad_str,
+                                       aad_str_len);
+        AAD_len = aad_str_len / 2;  // 2 hex chars map to a byte of key
+        step = 5;
+      }
+
+      else if ((strncmp(buffer, "Tag = ", 6) == 0) &&
+               (step == 5))
+      {
+        // process 'Tag' component of test vector
+        char * tag_str = buffer + 6;  // strip preceding 'Tag = ' sub-string
+        int tag_str_len = strlen(tag_str);
+        while ( (tag_str_len > 0) &&
+                ((tag_str[tag_str_len-1] == '\n') ||
+                 (tag_str[tag_str_len-1] == '\r')) )
+        {
+          tag_str[--tag_str_len] = '\0'; // strip any trailing '\n' or '\r'
+        }
+        convert_HexString_to_ByteArray((char **) &Tag,
+                                       tag_str,
+                                       tag_str_len);
+        Tag_len = tag_str_len / 2;  // 2 hex chars map to a byte of key
+        step = 6;
+      }
+
+      else if ((strncmp(buffer, "PT = ", 5) == 0) &&
+               (step == 6))
+      {
+        // process 'PT' component of test vector
+        char * pt_str = buffer + 5;  // strip preceding 'PT = ' sub-string
+        int pt_str_len = strlen(pt_str);
+        while ((pt_str_len > 0) &&
+               ((pt_str[pt_str_len-1] == '\n') ||
+                (pt_str[pt_str_len-1] == '\r')))
+        {
+          pt_str[--pt_str_len] = '\0';  // strip any trailing '\n' of '\r'
+        }
+        convert_HexString_to_ByteArray((char **) &PT,
+                                                 pt_str,
+                                                 pt_str_len);
+        PT_len = pt_str_len / 2;    // 2 hex chars map to a byte of key
+        pass_result = true;
+
+        // check applicability of parsed vector to kmyth implementation
+        //   - kmyth does not support additional authenticated data (AAD)
+        //   - kmyth uses hard-coded IV length (GCM_IV_LEN)
+        //   - kmyth uses hard-coded Tag length (GCM_TAG_LEN)
+        if ((AAD_len == 0) &&
+            (IV_len == GCM_IV_LEN) &&
+            (Tag_len == GCM_TAG_LEN))
+        {
+            test_vector_found = true;
+        }
+
+        // after either completing the six-step parsing procedure or
+        // encountering an unexpected input line, return to initial step
+        step = 1;
+      }
+      else if ((strncmp(buffer, "FAIL", 4) == 0) &&
+               (step == 6))
+      {
+        // process 'FAIL' result component of vector
+        PT_len = 0;
+        pass_result = false;
+
+        // check applicability of parsed vector to kmyth implementation
+        //   - kmyth does not support additional authenticated data (AAD)
+        //   - kmyth uses hard-coded IV length (GCM_IV_LEN)
+        //   - kmyth uses hard-coded Tag length (GCM_TAG_LEN)
+        if ((AAD_len == 0) &&
+            (IV_len == GCM_IV_LEN) &&
+            (Tag_len == GCM_TAG_LEN))
+        {
+            test_vector_found = true;
+        }
+        // after either completing the six-step parsing procedure or
+        // encountering an unexpected input line, return to initial step
+        step = 1;
+      }
+      else
+      {
+        step = 1;
+      }
+    }
+  }
+
+  if (test_vector_found)
+  {
+    // copy parsed and validated test vector information to output parameters
+    memcpy(*key_vec, Key, Key_len);
+    *key_vec_len = Key_len;
+    memcpy(*input_vec, IV, IV_len);
+    memcpy(*input_vec + IV_len, CT, CT_len);
+    memcpy(*input_vec + IV_len + CT_len, Tag, Tag_len);
+    *input_vec_len = IV_len + CT_len + Tag_len;
+    memcpy(*result_vec, PT, PT_len);
+    *result_vec_len = PT_len;
+    *expect_pass = pass_result;
+  }
+
+  // clean-up memory allocated to buffer test vector(s)
+  free(Key);
+  free(IV);
+  free(AAD);
+  free(Tag);
+  free(CT);
+  free(PT);
+
+  // if while loop exit due to EOF, return unsuccessful result
+  if (!test_vector_found)
+  {
+    return 1;
+  }
+
+  return 0;
+}
+
+
+//----------------------------------------------------------------------------
+// test_aes_gcm_decrypt_vectors()
+//----------------------------------------------------------------------------
+void test_aes_gcm_decrypt_vectors(void)
+{
+  // specify the compilation of test vector mappings for kmyth AES GCM
+  // decrypt cipher testing.
+  const cipher_vector_compilation gcm_decrypt_vectors = {
+    .count = 3,
+    .sets = 
+    {
+      { .desc = "AES-128, Galois Counter Mode (GCM), decryption",
+        .func_to_test = "aes_gcm_decrypt",
+        .path = "./test/data/gcmtestvectors/gcmDecrypt128.rsp" },
+      { .desc = "AES-192, Galois Counter Mode (GCM), decryption",
+        .func_to_test = "aes_gcm_decrypt",
+        .path = "./test/data/gcmtestvectors/gcmDecrypt192.rsp" },
+      { .desc = "AES-256, Galois Counter Mode (GCM), decryption",
+        .func_to_test = "aes_gcm_decrypt",
+        .path = "./test/data/gcmtestvectors/gcmDecrypt256.rsp" }
+    }
+  };
+
+  // array of file pointers for test vector files
+  FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
+
+  // counter to track number of test vectors applied from a file
+  int test_vector_count = 0;
+
+  // flag used to signal end of processing for a given test vector file
+  bool done_with_test_vector_file = false;
+
+  // check that number of test vector files complies with specified maximum
+  if (gcm_decrypt_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
+  {
+    fprintf(stderr,
+            "ERROR: too many (%ld) vector set mappings (%d max)",
+            gcm_decrypt_vectors.count,
+            MAX_VECTOR_SETS_IN_COMPILATION);
+    CU_FAIL("AES GCM Decrypt Test Vector File Count Exceeds Limit");
+    return;
+  }
+
+  // allocate memory to hold a single test vector - re-use these buffers
+  // for all test vectors used during these tests
+  unsigned char * key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t key_data_len = 0;
+  unsigned char * input_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH +
+                                      GCM_IV_LEN + GCM_TAG_LEN, 1);
+  size_t input_data_len = 0;
+  unsigned char * result_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t result_data_len = 0;
+  bool result_bool = false;
+
+  for (int i = 0; i < gcm_decrypt_vectors.count; i++)
+  {
+    // open test vector file
+    test_vector_fd[i] = fopen(gcm_decrypt_vectors.sets[i].path, "r");
+    if (test_vector_fd[i] != NULL)
+    {
+      while ((!done_with_test_vector_file) &&
+             (test_vector_count <= MAX_GCM_TEST_VECTOR_COUNT))
+      {
+        // Parse next vector from file
+        if (get_aes_gcm_vector_from_file(test_vector_fd[i],
+                                         &key_data,
+                                         &key_data_len,
+                                         &input_data,
+                                         &input_data_len,
+                                         &result_data,
+                                         &result_data_len,
+                                         &result_bool) == 0)
+        {
+          // Create a new buffer to hold the decryption result for each vector
+          // applied. This is necessary because on an error condition, the
+          // aes_gcm_decrypt() function clears and frees this memory.
+          unsigned char * output_data = NULL;
+          output_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+          size_t output_data_len = 0;
+
+          // apply test vector
+          test_vector_count++;
+          int rc = aes_gcm_decrypt(key_data,
+                                   key_data_len,
+                                   input_data,
+                                   input_data_len,
+                                   &output_data,
+                                   &output_data_len);
+
+          // consolidate results of applying test vector into a single assertion
+          bool vector_passed = true;
+
+          if (result_bool == false)
+          {
+            // check if a test vector expected to fail, passed
+            if (rc == 0)
+            { 
+              vector_passed = false;
+            }
+          }
+          else
+          {
+            // check if a test vector expected to pass, failed
+            if (rc != 0)
+            {
+              vector_passed = false;
+            }
+
+            // check for unexpected size of decrypted result
+            if (output_data_len != result_data_len)
+            {
+              vector_passed = false;
+            }
+
+            // check that expected result matches (byte for byte)
+            for (int j = 0; j < output_data_len; j++)
+            {
+              if (output_data[j] != result_data[j])
+              {
+                vector_passed = false;
+              }
+            }
+          }
+
+          CU_ASSERT(vector_passed);
+
+          // clean-up output_data byte array
+          if (rc == 0)
+          {
+            free(output_data);
+          }
+        }
+
+        else
+        {
+          // get_aes_gcm_test_vector_from_file() returned error - must be done
+          done_with_test_vector_file = true;
+        }
+      }
+
+      // Done with the test vector file (processed all vectors or reached max)
+      fclose(test_vector_fd[i]);
+
+      // Provide INFO: message indicating how many test vectors were applied
+      printf("INFO: %s - %d test vectors applied\n",
+              gcm_decrypt_vectors.sets[i].path, test_vector_count);
+
+      // reset flag/counters for potential processing of new test vector file
+      done_with_test_vector_file = false;
+      test_vector_count = 0;
+    }
+    else
+    {
+      printf("INFO: test vector file (%s) not installed ... ",
+              gcm_decrypt_vectors.sets[i].path);
+      printf("skipping these tests\n");
+    }
+  }
+
+  // clean-up memory allocated for test vector
+  free(key_data);
+  free(input_data);
+  free(result_data);
 }
 
 //----------------------------------------------------------------------------
@@ -250,9 +662,9 @@ void test_gcm_cipher_modification(void)
 
 void test_gcm_parameter_limits(void)
 {
-  unsigned char* key     = NULL;
-  unsigned char* inData  = NULL;
-  unsigned char* outData = NULL;
+  unsigned char * key     = NULL;
+  unsigned char * inData  = NULL;
+  unsigned char * outData = NULL;
   
   // check that null keys produce an error
   int    key_len     = 16;
@@ -283,24 +695,38 @@ void test_gcm_parameter_limits(void)
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
                             &outData, &outData_len) == 1);
   
-  // check that an input data length being too short produces an error
-  inData_len = 32;
-  inData = malloc(inData_len);
+  // check that an empty (zero length) PT data input to encrypt succeeds
+  // output data should be concatenation of IV and tag
+  inData = malloc(GCM_IV_LEN + GCM_TAG_LEN);
   inData_len = 0;
   CU_ASSERT(inData != NULL);
   CU_ASSERT(aes_gcm_encrypt(key, key_len, inData, inData_len,
-                            &outData, &outData_len) == 1);
+                            &outData, &outData_len) == 0);
+  CU_ASSERT(outData_len == (GCM_IV_LEN + GCM_TAG_LEN));
+
+  // check decryption of empty (zero length) CT result succeeds and
+  // produces empty (zero length) plaintext result
+  inData_len = outData_len;
+  memcpy(inData, outData, outData_len);
+  free(outData);
+  outData = NULL;
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
-                            &outData, &outData_len) == 1);
-  inData_len = GCM_IV_LEN + GCM_TAG_LEN;
+                            &outData, &outData_len) == 0);
+  CU_ASSERT(outData_len == 0);
+  free(outData);
+  outData = NULL;
+
+  // check that a completely empty (but non-NULL) data input to decrypt errors
+  inData_len = 0;
+  CU_ASSERT(inData != NULL);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
                             &outData, &outData_len) == 1);
 
   // check that a key of a non-zero but unacceptable length errors
   inData_len += 1;
   key_len = 12;
+  CU_ASSERT(inData != NULL);
   CU_ASSERT(aes_gcm_encrypt(key, key_len, inData, inData_len,
             &outData, &outData_len) == 1);
-  CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
-                            &outData, &outData_len) == 1);
 }
+

--- a/tpm2/test/src/cipher/kmyth_cipher_test.c
+++ b/tpm2/test/src/cipher/kmyth_cipher_test.c
@@ -1,0 +1,38 @@
+//############################################################################
+// kmyth_test_cipher.c
+//
+// General utilities for kmyth cipher testing:
+//   - convert hexadecimal valued strings in vector files to byte arrays
+//############################################################################
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "kmyth_cipher_test.h"
+
+
+//----------------------------------------------------------------------------
+// convert_HexString_to_ByteArray()
+//----------------------------------------------------------------------------
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size)
+{
+  if((str_size % 2) != 0)
+  {
+    fprintf(stderr, "ERROR: Invalid hex string size, must be even.\n");
+    return 1; 
+  }
+
+  size_t bufSize = ((str_size) / 2);
+  char * buf = (char *) calloc(bufSize + 1, sizeof(char)); 
+  for (int i = 0; i < bufSize; i++)
+  {
+    sscanf(hex_str+(i*2), "%02hhx", &buf[i]);
+  }
+  buf[bufSize] = '\0';
+
+  *result = buf;
+
+  return 0;
+}
+


### PR DESCRIPTION
Added tests to apply applicable NIST AES/GCM decryption vectors to the kmyth AES/GCM decrypt cipher implementation (i.e., those with IV and tag implementations that match those used).

As part of this effort, it was discovered that kmyth implementation failed for vectors where the ciphertext input was the encryption of an empty plaintext (i.e, the decryption result should return a valid IV and tag, but an empty plaintext result). This pull request, therefore, also fixes this issue.