### PR TITLE
Add Tests for AES Key Wrap Cipher Functionality

### DIFF
--- a/tpm2/test/include/cipher/aes_gcm_test.h
+++ b/tpm2/test/include/cipher/aes_gcm_test.h
@@ -11,7 +11,6 @@
 #ifndef AES_GCM_TEST_H
 #define AES_GCM_TEST_H
 
-
 //--------------------- Test Utilities ---------------------------------------
 
 /**
@@ -87,9 +86,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
                                  uint8_t ** input_vec,
                                  size_t * input_vec_len,
                                  uint8_t ** result_vec,
-                                 size_t * result_vec_len,
-                                 bool * expect_pass);
-
+                                 size_t * result_vec_len, bool * expect_pass);
 
 //---------------------- Test Suite Setup ------------------------------------
 
@@ -105,7 +102,6 @@ int get_aes_gcm_vector_from_file(FILE * fid,
  * @return     0 on success, 1 on error
  */
 int aes_gcm_add_tests(CU_pSuite suite);
-
 
 //---------------------- Tests -----------------------------------------------
 

--- a/tpm2/test/include/cipher/aes_keywrap_test.h
+++ b/tpm2/test/include/cipher/aes_keywrap_test.h
@@ -103,9 +103,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
                                      uint8_t ** P_vec,
                                      size_t * P_vec_len,
                                      uint8_t ** C_vec,
-                                     size_t * C_vec_len,
-                                     bool * expect_pass);
-
+                                     size_t * C_vec_len, bool * expect_pass);
 
 //--------------------- Tests ------------------------------------------------
 
@@ -124,4 +122,3 @@ void test_aes_keywrap_parameters(void);
 void test_aes_keywrap_vectors(void);
 
 #endif
-

--- a/tpm2/test/include/cipher/aes_keywrap_test.h
+++ b/tpm2/test/include/cipher/aes_keywrap_test.h
@@ -1,0 +1,127 @@
+/**
+ * @file  aes_keywrap_test.h
+ *
+ * Provides unit tests for the kmyth AES keywrap (RFC-3394 - no padding)
+ * cipher functionality implemented in:
+ *     - tpm2/src/cipher/aes_keywrap_3394nopad.c
+ *     - tpm2/src/cipher/aes_keywrap_5649pad.c
+ */
+
+#ifndef AES_KEYWRAP_TEST_H
+#define AES_KEYWRAP_TEST_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * This function adds all of the tests contained in
+ * tpm2/test/cipher/aes_keywrap_test.c to a test suite parameter passed in by
+ * the caller. This allows a top-level 'test-runner' application to include
+ * them in the set of tests that it runs.
+ *
+ * @param[in]  suite  CUnit test suite that this function will add all of
+ *                    the kmyth AES keywrap cipher functionality tests to.
+ *
+ * @return     0 on success, 1 on error
+ */
+int aes_keywrap_add_tests(CU_pSuite suite);
+
+//--------------------- Test Utilities -------------------------------
+
+/**
+ * Parses NIST AES key wrap/unwrap test vector files.
+ *
+ * NOTE: Designed to parse NIST AES key wrap/unwrap test vectors ONLY
+ *       Not guarenteed to work on other files
+ *
+ * @param[out] suite  CUnit test suite that this function will add all of
+ *                    the kmyth AES keywrap cipher functionality tests to.
+ *
+ * @return     0 on success, 1 on error
+ */
+
+/**
+ * Return a single AES Key Wrap test vector to be applied to (validate)
+ * kmyth's AEC Key Wrap cipher (RFC-3394 and RFC-5649) functionality.
+ *
+ * IMPORTANT NOTE: Parses only NIST AES KW/KWP test vector files (or
+ * other test vector files that adhere strictly to this format.
+ *
+ * The test vector values in the file are specified by groupings of lines
+ * containing:
+ *
+ *     'K = [string representing hexadecimal byte array value]'
+ *     'P = [string representing hexadecimal byte array value]'
+ *     'C = [string representing hexadecimal byte array value]'
+ *
+ * for the encrypt test vectors and
+ *
+ *     'K = [string representing hexadecimal byte array value]'
+ *     'C = [string representing hexadecimal byte array value]'
+ *     'P = [string representing hexadecimal byte array value]'
+ *
+ * for the decrypt test vectors. If the expected result is decryption failure,
+ * the last (P = ...) line is replaced by:
+ *
+ *     'FAIL'
+ *
+ * In parsing the file, we look for these groupings and, upon finding the
+ * first line of one, process that set of lines from the file. Any lines in the
+ * file that are not part of one of these test vector groupings are ignored.
+ *
+ * @param[in]  fid         - pointer to file descriptor for test vector file
+ *
+ * @param[out] K_vec       - pointer to byte array used to return 'K' (key)
+ *                           component of test vector
+ *
+ * @param[out] K_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'K_vec' byte array
+ *
+ * @param[out] P_vec       - pointer to byte array used to return 'P'
+ *                           (plaintext) component of test vector
+ *
+ * @param[out] P_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'P_vec' byte array
+ *
+ * @param[out] C_vec       - pointer to byte array used to return 'C'
+ *                           (ciphertext) component of test vector
+ *
+ * @param[out] C_vec_len   - pointer to length (in bytes) of value being
+ *                           returned in 'C_vec' byte array
+ *
+ * @param[out] expect_pass - pointer to boolean indicating whether
+ *                           application of the test vector should produce
+ *                           a PASS result (i.e., if true, the vector should
+ *                           not produce an error, if false, the vector is
+ *                           expected to produce an error)
+ *
+ * @return     0 on success, 1 on error
+ */
+int get_aes_keywrap_vector_from_file(FILE * fid,
+                                     uint8_t ** K_vec,
+                                     size_t * K_vec_len,
+                                     uint8_t ** P_vec,
+                                     size_t * P_vec_len,
+                                     uint8_t ** C_vec,
+                                     size_t * C_vec_len,
+                                     bool * expect_pass);
+
+
+//--------------------- Tests ------------------------------------------------
+
+/**
+ * Test to verify parameter handling/enforcement by the kmyth AES key
+ * wrap/unwrap API (e.g., tests behavior when invalid parameters are
+ * provided, etc.)
+ */
+void test_aes_keywrap_parameters(void);
+
+/**
+ * Runs set of test vectors for AES key wrap/unwrap through kmyth
+ * implementation of this cipher functionality and validates
+ * that the results match those specified by the test vectors.
+ */
+void test_aes_keywrap_vectors(void);
+
+#endif
+

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -1,0 +1,62 @@
+/**
+ * @file  kmyth_cipher_test.h
+ */
+
+#ifndef KMYTH_CIPHER_TEST_H
+#define KMYTH_CIPHER_TEST_H
+
+/**
+ * Specify maximum number of test vector sets (vector files) that can be
+ * contained within a "vector set compilation" (used to size that array).
+ */
+#define MAX_VECTOR_SETS_IN_COMPILATION 20
+
+/**
+ * Specify maximum number of test vectors to process when parsing
+ * a test vector file.
+ */
+#define MAX_KEYWRAP_TEST_VECTOR_COUNT 500
+#define MAX_GCM_TEST_VECTOR_COUNT 7875
+
+/**
+ * Specify the maximum length (in chars) of a test vector component
+ * This is needed to appropriately size the buffers used to parse and
+ * process test vector components read from a file. For example, a
+ * 2048 hexadecimal character string can specify a 512-byte or
+ * 4096-bit test vector component.
+ */
+#define MAX_TEST_VECTOR_COMPONENT_LENGTH 2500
+
+typedef struct cipher_vector_set
+{
+  char * desc;
+  char * func_to_test;
+  char * path;
+} cipher_vector_set;
+
+typedef struct cipher_vector_compilation
+{
+  size_t count;
+  cipher_vector_set sets[MAX_VECTOR_SETS_IN_COMPILATION];
+} cipher_vector_compilation;
+
+
+/**
+ * As the NIST test vectors are specified as hexadecimal values, the
+ * bytes encrypted or decrypted by the kmyth keywrap cipher
+ * implementation must be converted into a hex format for comparison
+ * with the expected result. This simple utility provides that
+ * functionality.
+ *
+ * @param[out] result  - Byte array corresponding to input hex string value
+ *
+ * @param[in]  hex_str - hexadecimal string to be converted
+ *
+ * @param[in]  size    - length (in hex chars) of input string
+ *
+ * @return     0 on success, 1 on error
+ */
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size);
+
+#endif
+

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -24,7 +24,7 @@
  * process test vector components read from a file. For example, a
  * value of 2176 (2048 + 128) supports up to a 2048 hexadecimal character
  * string that can specify a 1024-byte or 8192-bit test vector component,
- * as well as up to 128 leading trailing characters.
+ * as well as up to 128 leading/trailing characters.
  */
 #define MAX_TEST_VECTOR_COMPONENT_LENGTH 2176
 

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -30,9 +30,9 @@
 
 typedef struct cipher_vector_set
 {
-  char * desc;
-  char * func_to_test;
-  char * path;
+  char *desc;
+  char *func_to_test;
+  char *path;
 } cipher_vector_set;
 
 typedef struct cipher_vector_compilation
@@ -40,7 +40,6 @@ typedef struct cipher_vector_compilation
   size_t count;
   cipher_vector_set sets[MAX_VECTOR_SETS_IN_COMPILATION];
 } cipher_vector_compilation;
-
 
 /**
  * As the NIST test vectors are specified as hexadecimal values, the
@@ -60,4 +59,3 @@ typedef struct cipher_vector_compilation
 int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size);
 
 #endif
-

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -22,10 +22,11 @@
  * Specify the maximum length (in chars) of a test vector component
  * This is needed to appropriately size the buffers used to parse and
  * process test vector components read from a file. For example, a
- * 2048 hexadecimal character string can specify a 512-byte or
- * 4096-bit test vector component.
+ * value of 2176 (2048 + 128) supports up to a 2048 hexadecimal character
+ * string that can specify a 1024-byte or 8192-bit test vector component,
+ * as well as up to 128 leading trailing characters.
  */
-#define MAX_TEST_VECTOR_COMPONENT_LENGTH 2500
+#define MAX_TEST_VECTOR_COMPONENT_LENGTH 2176
 
 typedef struct cipher_vector_set
 {

--- a/tpm2/test/include/cipher/kmyth_cipher_test.h
+++ b/tpm2/test/include/cipher/kmyth_cipher_test.h
@@ -42,11 +42,13 @@ typedef struct cipher_vector_compilation
 } cipher_vector_compilation;
 
 /**
- * As the NIST test vectors are specified as hexadecimal values, the
- * bytes encrypted or decrypted by the kmyth keywrap cipher
- * implementation must be converted into a hex format for comparison
- * with the expected result. This simple utility provides that
- * functionality.
+ * The NIST test vectors are specified as strings representing hexadecimal
+ * values. These hex strings, read from the test vector files, must be
+ * converted to byte arrays with the corresponding value, in order to
+ * comply with kmyth's cipher API. This simple utility provides the
+ * hexadecimal string to byte array format conversion required to pass the
+ * specified input parameters to kmyth cipher functions and/or compare
+ * resultant output parameters to the expected result.
  *
  * @param[out] result  - Byte array corresponding to input hex string value
  *

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -12,21 +12,20 @@
 #include "kmyth_cipher_test.h"
 #include "aes_gcm.h"
 
-
 //----------------------------------------------------------------------------
 // aes_gcm_add_tests()
 //----------------------------------------------------------------------------
 int aes_gcm_add_tests(CU_pSuite suite)
 {
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM decryption vectors",
-                         test_aes_gcm_decrypt_vectors))
+  if (NULL == CU_add_test(suite, "Test AES/GCM decryption vectors",
+                          test_aes_gcm_decrypt_vectors))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM encryption/decryption",
-                         test_gcm_encrypt_decrypt))
+  if (NULL == CU_add_test(suite, "Test AES/GCM encryption/decryption",
+                          test_gcm_encrypt_decrypt))
   {
     return 1;
   }
@@ -73,8 +72,7 @@ int get_aes_gcm_vector_from_file(FILE * fid,
                                  uint8_t ** input_vec,
                                  size_t * input_vec_len,
                                  uint8_t ** result_vec,
-                                 size_t * result_vec_len,
-                                 bool * expect_pass)
+                                 size_t * result_vec_len, bool * expect_pass)
 {
   // create buffer to hold vector data read in from file a line at a time
   // specify buffer size to handle largest vector component (must include
@@ -83,17 +81,17 @@ int get_aes_gcm_vector_from_file(FILE * fid,
   char buffer[MAX_TEST_VECTOR_COMPONENT_LENGTH];
 
   // create stack variables to buffer the components in a single test vector
-  uint8_t  * Key = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *Key = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t Key_len = 0;
-  uint8_t * IV = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *IV = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t IV_len = 0;
-  uint8_t * CT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *CT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t CT_len = 0;
-  uint8_t * AAD = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *AAD = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t AAD_len = 0;
-  uint8_t * Tag = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *Tag = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t Tag_len = 0;
-  uint8_t * PT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  uint8_t *PT = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t PT_len = 0;
   bool pass_result = false;
 
@@ -119,34 +117,32 @@ int get_aes_gcm_vector_from_file(FILE * fid,
   {
     if (fgets(buffer, MAX_TEST_VECTOR_COMPONENT_LENGTH, fid) != NULL)
     {
-      if ((strncmp(buffer, "Key = ", 6) == 0) &&
-          (step == 1))
+      if ((strncmp(buffer, "Key = ", 6) == 0) && (step == 1))
       {
         // process 'Key' component of this test vector
-        char * key_str = buffer + 6;  // strip preceding 'Key = ' sub-string
+        char *key_str = buffer + 6; // strip preceding 'Key = ' sub-string
         int key_str_len = strlen(key_str);
-        while ( (key_str_len > 0) &&
-                ((key_str[key_str_len-1] == '\n') ||
-                 (key_str[key_str_len-1] == '\r')) )
+
+        while ((key_str_len > 0) &&
+               ((key_str[key_str_len - 1] == '\n') ||
+                (key_str[key_str_len - 1] == '\r')))
         {
           key_str[--key_str_len] = '\0';  // strip any trailing '\n' or 'r'
         }
-        convert_HexString_to_ByteArray((char **) &Key,
-                                       key_str,
-                                       key_str_len);
+        convert_HexString_to_ByteArray((char **) &Key, key_str, key_str_len);
         Key_len = key_str_len / 2;  // 2 hex chars map to a byte of key
         step = 2;
       }
-      
-      else if ((strncmp(buffer, "IV = ", 5) == 0) &&
-               (step == 2))
+
+      else if ((strncmp(buffer, "IV = ", 5) == 0) && (step == 2))
       {
         // process IV component of test vector
-        char * iv_str = buffer + 5; // strip preceding 'IV = ' sub-string
+        char *iv_str = buffer + 5;  // strip preceding 'IV = ' sub-string
         int iv_str_len = strlen(iv_str);
-        while ( (iv_str_len > 0) &&
-                ((iv_str[iv_str_len-1] == '\n') ||
-                 (iv_str[iv_str_len-1] == '\r')) )
+
+        while ((iv_str_len > 0) &&
+               ((iv_str[iv_str_len - 1] == '\n') ||
+                (iv_str[iv_str_len - 1] == '\r')))
         {
           iv_str[--iv_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
@@ -155,15 +151,15 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         step = 3;
       }
 
-      else if ((strncmp(buffer, "CT = ", 5) == 0) &&
-               (step == 3))
+      else if ((strncmp(buffer, "CT = ", 5) == 0) && (step == 3))
       {
         // process 'CT' component of test vector
-        char * ct_str = buffer + 5;  // strip preceding 'CT = ' sub-string
+        char *ct_str = buffer + 5;  // strip preceding 'CT = ' sub-string
         int ct_str_len = strlen(ct_str);
-        while ( (ct_str_len > 0) &&
-                ((ct_str[ct_str_len-1] == '\n') ||
-                 (ct_str[ct_str_len-1] == '\r')) )
+
+        while ((ct_str_len > 0) &&
+               ((ct_str[ct_str_len - 1] == '\n') ||
+                (ct_str[ct_str_len - 1] == '\r')))
         {
           ct_str[--ct_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
@@ -172,60 +168,54 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         step = 4;
       }
 
-      else if ((strncmp(buffer, "AAD = ", 6) == 0) &&
-               (step == 4))
+      else if ((strncmp(buffer, "AAD = ", 6) == 0) && (step == 4))
       {
         // process 'AAD' component of test vector
-        char * aad_str = buffer + 6;  // strip preceding 'AAD = ' sub-string
+        char *aad_str = buffer + 6; // strip preceding 'AAD = ' sub-string
         int aad_str_len = strlen(aad_str);
-        while ( (aad_str_len > 0) &&
-                ((aad_str[aad_str_len-1] == '\n') ||
-                 (aad_str[aad_str_len-1] == '\r')) )
+
+        while ((aad_str_len > 0) &&
+               ((aad_str[aad_str_len - 1] == '\n') ||
+                (aad_str[aad_str_len - 1] == '\r')))
         {
           aad_str[--aad_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
-        convert_HexString_to_ByteArray((char **) &AAD,
-                                       aad_str,
-                                       aad_str_len);
+        convert_HexString_to_ByteArray((char **) &AAD, aad_str, aad_str_len);
         AAD_len = aad_str_len / 2;  // 2 hex chars map to a byte of AAD
         step = 5;
       }
 
-      else if ((strncmp(buffer, "Tag = ", 6) == 0) &&
-               (step == 5))
+      else if ((strncmp(buffer, "Tag = ", 6) == 0) && (step == 5))
       {
         // process 'Tag' component of test vector
-        char * tag_str = buffer + 6;  // strip preceding 'Tag = ' sub-string
+        char *tag_str = buffer + 6; // strip preceding 'Tag = ' sub-string
         int tag_str_len = strlen(tag_str);
-        while ( (tag_str_len > 0) &&
-                ((tag_str[tag_str_len-1] == '\n') ||
-                 (tag_str[tag_str_len-1] == '\r')) )
+
+        while ((tag_str_len > 0) &&
+               ((tag_str[tag_str_len - 1] == '\n') ||
+                (tag_str[tag_str_len - 1] == '\r')))
         {
-          tag_str[--tag_str_len] = '\0'; // strip any trailing '\n' or '\r'
+          tag_str[--tag_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
-        convert_HexString_to_ByteArray((char **) &Tag,
-                                       tag_str,
-                                       tag_str_len);
+        convert_HexString_to_ByteArray((char **) &Tag, tag_str, tag_str_len);
         Tag_len = tag_str_len / 2;  // 2 hex chars map to a byte of Tag
         step = 6;
       }
 
-      else if ((strncmp(buffer, "PT = ", 5) == 0) &&
-               (step == 6))
+      else if ((strncmp(buffer, "PT = ", 5) == 0) && (step == 6))
       {
         // process 'PT' component of test vector
-        char * pt_str = buffer + 5;  // strip preceding 'PT = ' sub-string
+        char *pt_str = buffer + 5;  // strip preceding 'PT = ' sub-string
         int pt_str_len = strlen(pt_str);
+
         while ((pt_str_len > 0) &&
-               ((pt_str[pt_str_len-1] == '\n') ||
-                (pt_str[pt_str_len-1] == '\r')))
+               ((pt_str[pt_str_len - 1] == '\n') ||
+                (pt_str[pt_str_len - 1] == '\r')))
         {
           pt_str[--pt_str_len] = '\0';  // strip any trailing '\n' of '\r'
         }
-        convert_HexString_to_ByteArray((char **) &PT,
-                                                 pt_str,
-                                                 pt_str_len);
-        PT_len = pt_str_len / 2;    // 2 hex chars map to a byte of PT
+        convert_HexString_to_ByteArray((char **) &PT, pt_str, pt_str_len);
+        PT_len = pt_str_len / 2;  // 2 hex chars map to a byte of PT
         pass_result = true;
 
         // check applicability of parsed vector to kmyth implementation
@@ -233,18 +223,16 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         //   - kmyth uses hard-coded IV length (GCM_IV_LEN)
         //   - kmyth uses hard-coded Tag length (GCM_TAG_LEN)
         if ((AAD_len == 0) &&
-            (IV_len == GCM_IV_LEN) &&
-            (Tag_len == GCM_TAG_LEN))
+            (IV_len == GCM_IV_LEN) && (Tag_len == GCM_TAG_LEN))
         {
-            test_vector_found = true;
+          test_vector_found = true;
         }
 
         // after either completing the six-step parsing procedure or
         // encountering an unexpected input line, return to initial step
         step = 1;
       }
-      else if ((strncmp(buffer, "FAIL", 4) == 0) &&
-               (step == 6))
+      else if ((strncmp(buffer, "FAIL", 4) == 0) && (step == 6))
       {
         // process 'FAIL' result component of vector
         PT_len = 0;
@@ -255,10 +243,9 @@ int get_aes_gcm_vector_from_file(FILE * fid,
         //   - kmyth uses hard-coded IV length (GCM_IV_LEN)
         //   - kmyth uses hard-coded Tag length (GCM_TAG_LEN)
         if ((AAD_len == 0) &&
-            (IV_len == GCM_IV_LEN) &&
-            (Tag_len == GCM_TAG_LEN))
+            (IV_len == GCM_IV_LEN) && (Tag_len == GCM_TAG_LEN))
         {
-            test_vector_found = true;
+          test_vector_found = true;
         }
         // after either completing the six-step parsing procedure or
         // encountering an unexpected input line, return to initial step
@@ -302,7 +289,6 @@ int get_aes_gcm_vector_from_file(FILE * fid,
   return 0;
 }
 
-
 //----------------------------------------------------------------------------
 // test_aes_gcm_decrypt_vectors()
 //----------------------------------------------------------------------------
@@ -312,42 +298,40 @@ void test_aes_gcm_decrypt_vectors(void)
   // decrypt cipher testing.
   const cipher_vector_compilation gcm_decrypt_vectors = {
     .count = 3,
-    .sets = 
-    {
-      { .desc = "AES-128, Galois Counter Mode (GCM), decryption",
-        .func_to_test = "aes_gcm_decrypt",
-        .path = "./test/data/gcmtestvectors/gcmDecrypt128.rsp" },
-      { .desc = "AES-192, Galois Counter Mode (GCM), decryption",
-        .func_to_test = "aes_gcm_decrypt",
-        .path = "./test/data/gcmtestvectors/gcmDecrypt192.rsp" },
-      { .desc = "AES-256, Galois Counter Mode (GCM), decryption",
-        .func_to_test = "aes_gcm_decrypt",
-        .path = "./test/data/gcmtestvectors/gcmDecrypt256.rsp" }
-    }
+    .sets = {
+             {.desc = "AES-128, Galois Counter Mode (GCM), decryption",
+              .func_to_test = "aes_gcm_decrypt",
+              .path = "./test/data/gcmtestvectors/gcmDecrypt128.rsp"},
+             {.desc = "AES-192, Galois Counter Mode (GCM), decryption",
+              .func_to_test = "aes_gcm_decrypt",
+              .path = "./test/data/gcmtestvectors/gcmDecrypt192.rsp"},
+             {.desc = "AES-256, Galois Counter Mode (GCM), decryption",
+              .func_to_test = "aes_gcm_decrypt",
+              .path = "./test/data/gcmtestvectors/gcmDecrypt256.rsp"}
+             }
   };
 
   // array of file pointers for test vector files
-  FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
+  FILE *test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = { NULL };
 
   // check that number of test vector files complies with specified maximum
   if (gcm_decrypt_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
   {
     fprintf(stderr,
             "ERROR: too many (%ld) vector set mappings (%d max)",
-            gcm_decrypt_vectors.count,
-            MAX_VECTOR_SETS_IN_COMPILATION);
+            gcm_decrypt_vectors.count, MAX_VECTOR_SETS_IN_COMPILATION);
     CU_FAIL("AES GCM Decrypt Test Vector File Count Exceeds Limit");
     return;
   }
 
   // allocate memory to hold a single test vector - re-use these buffers
   // for all test vectors used during these tests
-  unsigned char * key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  unsigned char *key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t key_data_len = 0;
-  unsigned char * input_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH +
-                                      GCM_IV_LEN + GCM_TAG_LEN, 1);
+  unsigned char *input_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH +
+                                     GCM_IV_LEN + GCM_TAG_LEN, 1);
   size_t input_data_len = 0;
-  unsigned char * result_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  unsigned char *result_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t result_data_len = 0;
   bool result_bool = false;
 
@@ -373,13 +357,13 @@ void test_aes_gcm_decrypt_vectors(void)
                                          &input_data,
                                          &input_data_len,
                                          &result_data,
-                                         &result_data_len,
-                                         &result_bool) == 0)
+                                         &result_data_len, &result_bool) == 0)
         {
           // Create a new buffer to hold the decryption result for each vector
           // applied. This is necessary because on an error condition, the
           // aes_gcm_decrypt() function clears and frees this memory.
-          unsigned char * output_data = NULL;
+          unsigned char *output_data = NULL;
+
           output_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
           size_t output_data_len = 0;
 
@@ -399,7 +383,7 @@ void test_aes_gcm_decrypt_vectors(void)
           {
             // check if a test vector expected to fail, passed
             if (rc == 0)
-            { 
+            {
               vector_passed = false;
             }
           }
@@ -448,7 +432,7 @@ void test_aes_gcm_decrypt_vectors(void)
 
       // Provide INFO: message indicating how many test vectors were applied
       printf("INFO: %s - %d test vectors applied\n",
-              gcm_decrypt_vectors.sets[i].path, test_vector_count);
+             gcm_decrypt_vectors.sets[i].path, test_vector_count);
 
       // reset flag/counters for potential processing of new test vector file
       done_with_test_vector_file = false;
@@ -457,7 +441,7 @@ void test_aes_gcm_decrypt_vectors(void)
     else
     {
       printf("INFO: test vector file (%s) not installed ... ",
-              gcm_decrypt_vectors.sets[i].path);
+             gcm_decrypt_vectors.sets[i].path);
       printf("skipping these tests\n");
     }
   }
@@ -665,10 +649,10 @@ void test_gcm_cipher_modification(void)
 void test_gcm_parameter_limits(void)
 {
 
-  unsigned char * key     = NULL;
-  unsigned char * inData  = NULL;
-  unsigned char * outData = NULL;
-  
+  unsigned char *key = NULL;
+  unsigned char *inData = NULL;
+  unsigned char *outData = NULL;
+
   // check that null keys produce an error
   int key_len = 16;
   size_t inData_len = 16;
@@ -698,7 +682,7 @@ void test_gcm_parameter_limits(void)
                             &outData, &outData_len) == 1);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
                             &outData, &outData_len) == 1);
-  
+
   // check that an empty (zero length) PT data input to encrypt succeeds
   // output data should be concatenation of IV and tag
   inData = malloc(GCM_IV_LEN + GCM_TAG_LEN);
@@ -731,6 +715,5 @@ void test_gcm_parameter_limits(void)
   key_len = 12;
   CU_ASSERT(inData != NULL);
   CU_ASSERT(aes_gcm_encrypt(key, key_len, inData, inData_len,
-            &outData, &outData_len) == 1);
+                            &outData, &outData_len) == 1);
 }
-

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -18,7 +18,6 @@
 
 #define AES_KW_VECTOR_PATH "test/vectors/kwtestvectors"
 
-
 //---------------------- AES Key Wrap Cipher Test Configuration --------------
 
 //----------------------------------------------------------------------------
@@ -40,7 +39,6 @@ int aes_keywrap_add_tests(CU_pSuite suite)
     return 1;
   }
 
-
   return 0;
 }
 
@@ -55,8 +53,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
                                      uint8_t ** P_vec,
                                      size_t * P_vec_len,
                                      uint8_t ** C_vec,
-                                     size_t * C_vec_len,
-                                     bool * expect_pass)
+                                     size_t * C_vec_len, bool * expect_pass)
 {
   // create buffer to hold vector data read in from file a line at a time
   // specify buffer size to handle largest vector component (must include
@@ -65,13 +62,13 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
   char buffer[MAX_TEST_VECTOR_COMPONENT_LENGTH];
 
   // create variables to buffer the components in a single test vector
-  char  * K_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  char *K_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   int K_str_len = 0;
-  char * P_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  char *P_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   int P_str_len = 0;
-  char * C_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  char *C_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   int C_str_len = 0;
-  bool pass_result = true;  // unless vector has a 'FAIL' line, should pass
+  bool pass_result = true;      // unless vector has a 'FAIL' line, should pass
 
   // create/initialize a counter to track progress (ensure that test vector
   // components are read and parsed in expected sequence)
@@ -99,7 +96,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
         // Note: regardless of incoming step level (< 4), finding 'K = ' puts
         //       the parsing process into step 2 (having 'K' but nothing else)
         step = 2;
-        K_str_len = strlen(buffer) - 4;  // strip leading 'K = ' sub-string
+        K_str_len = strlen(buffer) - 4; // strip leading 'K = ' sub-string
         memcpy(K_str, buffer + 4, K_str_len * sizeof(char));
         while ((K_str_len > 0) &&
                ((K_str[K_str_len - 1] == '\n') ||
@@ -108,7 +105,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           K_str[--K_str_len] = '\0';  // strip any trailing '\n' or '\r'
         }
       }
-  
+
       else if (strncmp(buffer, "P = ", 4) == 0)
       {
         // found 'P' vector component before 'K' - reset
@@ -118,12 +115,12 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           P_str_len = 0;
           C_str_len = 0;
         }
-  
+
         // correctly found 'P' component in step 2 or step 3
         else
         {
           step++;
-          P_str_len = strlen(buffer) - 4;  // strip leading 'P = ' sub-string
+          P_str_len = strlen(buffer) - 4; // strip leading 'P = ' sub-string
           memcpy(P_str, buffer + 4, P_str_len * sizeof(char));
           while ((P_str_len > 0) &&
                  ((P_str[P_str_len - 1] == '\n') ||
@@ -133,7 +130,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           }
         }
       }
-  
+
       else if (strncmp(buffer, "C = ", 4) == 0)
       {
         // found 'C' vector component before 'K' - reset
@@ -143,12 +140,12 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           P_str_len = 0;
           C_str_len = 0;
         }
-  
+
         // correctly found 'C' component in step 2 or step 3
         else
         {
           step++;
-          C_str_len = strlen(buffer) - 4;  // strip leading 'C = ' sub-string
+          C_str_len = strlen(buffer) - 4; // strip leading 'C = ' sub-string
           memcpy(C_str, buffer + 4, C_str_len * sizeof(char));
           while ((C_str_len > 0) &&
                  ((C_str[C_str_len - 1] == '\n') ||
@@ -158,7 +155,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           }
         }
       }
-  
+
       else if (strncmp(buffer, "FAIL", 4) == 0)
       {
         // found expected 'FAIL' result, but incomplete vector - reset
@@ -176,7 +173,7 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
           pass_result = false;
         }
       }
-  
+
       // found line in vector file that is not in one of the formats parsed by
       // this function - reset (start over, looking for next vector)
       else
@@ -192,18 +189,12 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
   if (step == 4)
   {
     // use parsed results to populate output parameters
-    convert_HexString_to_ByteArray((char **) K_vec,
-                                             K_str,
-                                             K_str_len);
-    *K_vec_len = K_str_len / 2;  // 2 hex chars map to a byte of key
-    convert_HexString_to_ByteArray((char **) P_vec,
-                                             P_str,
-                                             P_str_len);
-    *P_vec_len = P_str_len / 2;  // 2 hex chars map to a byte of key
-    convert_HexString_to_ByteArray((char **) C_vec,
-                                             C_str,
-                                             C_str_len);
-    *C_vec_len = C_str_len / 2;  // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) K_vec, K_str, K_str_len);
+    *K_vec_len = K_str_len / 2; // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) P_vec, P_str, P_str_len);
+    *P_vec_len = P_str_len / 2; // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) C_vec, C_str, C_str_len);
+    *C_vec_len = C_str_len / 2; // 2 hex chars map to a byte of key
     *expect_pass = pass_result;
   }
 
@@ -229,48 +220,57 @@ int get_aes_keywrap_vector_from_file(FILE * fid,
 //----------------------------------------------------------------------------
 void test_aes_keywrap_parameters(void)
 {
-  unsigned char* key = NULL;
+  unsigned char *key = NULL;
   int key_len = 0;
-  
-  unsigned char* inData = NULL;
+
+  unsigned char *inData = NULL;
   size_t inData_len = 0;
 
-  unsigned char* outData = NULL;
+  unsigned char *outData = NULL;
   size_t outData_len = 0;
 
   // Test failure on null key
   inData = malloc(16);
   inData_len = 16;
   key_len = 16;
-  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
-  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
 
   // Test failure on key of length 0
   key = malloc(16);
   key_len = 0;
-  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
-  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
 
   // Test failure on input data of length 0
   key_len = 16;
   inData_len = 0;
-  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
-  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
 
   // Test failure with input data too short
   inData_len = 8;
-  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
-  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
 
   // Test failure with input data that's not a multiple of 8 bytes long
   inData_len = 17;
-  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
-  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt
+            (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
 
   free(key);
   free(inData);
 }
-
 
 //----------------------------------------------------------------------------
 // test_aes_keywrap_vectors()
@@ -281,49 +281,57 @@ void test_aes_keywrap_vectors(void)
   // decrypt cipher testing.
   const cipher_vector_compilation aes_keywrap_vectors = {
     .count = 12,
-    .sets = 
-    {
-      { .desc = "AES-128, RFC-3394 Key Wrap no padding (KW-AE), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AE_128.txt" },
-      { .desc = "AES-128, RFC-3394 Key Unwrap no padding (KW-AD), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AD_128.txt" },
-      { .desc = "AES-192, RFC-3394 Key Wrap no padding (KW-AE), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AE_192.txt" },
-      { .desc = "AES-192, RFC-3394 Key Unwrap no padding (KW-AD), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AD_192.txt" },
-      { .desc = "AES-256, RFC-3394 Key Wrap no padding (KW-AE), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AE_256.txt" },
-      { .desc = "AES-256, RFC-3394 Key Unwrap no padding (KW-AD), forward",
-        .func_to_test = "aes_keywrap_3394nopad_encrypt",
-        .path = "./test/data/kwtestvectors/KW_AD_256.txt" },
-      { .desc = "AES-128, RFC-5649 Key Wrap with padding (KWP-AE), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AE_128.txt" },
-      { .desc = "AES-128, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AD_128.txt" },
-      { .desc = "AES-192, RFC-5649 Key Wrap with padding (KWP-AE), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AE_192.txt" },
-      { .desc = "AES-192, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AD_192.txt" },
-      { .desc = "AES-256, RFC-5649 Key Wrap with padding (KWP-AE), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AE_256.txt" },
-      { .desc = "AES-256, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
-        .func_to_test = "aes_keywrap_5649pad_encrypt",
-        .path = "./test/data/kwtestvectors/KWP_AD_256.txt" }
-    }
+    .sets = {
+             {.desc = "AES-128, RFC-3394 Key Wrap no padding (KW-AE), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AE_128.txt"},
+             {.desc =
+              "AES-128, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AD_128.txt"},
+             {.desc = "AES-192, RFC-3394 Key Wrap no padding (KW-AE), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AE_192.txt"},
+             {.desc =
+              "AES-192, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AD_192.txt"},
+             {.desc = "AES-256, RFC-3394 Key Wrap no padding (KW-AE), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AE_256.txt"},
+             {.desc =
+              "AES-256, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+              .func_to_test = "aes_keywrap_3394nopad_encrypt",
+              .path = "./test/data/kwtestvectors/KW_AD_256.txt"},
+             {.desc =
+              "AES-128, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AE_128.txt"},
+             {.desc =
+              "AES-128, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AD_128.txt"},
+             {.desc =
+              "AES-192, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AE_192.txt"},
+             {.desc =
+              "AES-192, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AD_192.txt"},
+             {.desc =
+              "AES-256, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AE_256.txt"},
+             {.desc =
+              "AES-256, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+              .func_to_test = "aes_keywrap_5649pad_encrypt",
+              .path = "./test/data/kwtestvectors/KWP_AD_256.txt"}
+             }
   };
 
   // array of file pointers for test vector files
-  FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
+  FILE *test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = { NULL };
 
   // counter to track number of test vectors applied from a file
   int test_vector_count = 0;
@@ -336,19 +344,18 @@ void test_aes_keywrap_vectors(void)
   {
     fprintf(stderr,
             "ERROR: too many (%ld) vector set mappings (%d max)",
-            aes_keywrap_vectors.count,
-            MAX_VECTOR_SETS_IN_COMPILATION);
+            aes_keywrap_vectors.count, MAX_VECTOR_SETS_IN_COMPILATION);
     CU_FAIL("AES Key Wrap Test Vector File Count Exceeds Limit");
     return;
   }
 
   // allocate memory to hold a single test vector - re-use these buffers
   // for all test vectors used during these tests
-  unsigned char * key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  unsigned char *key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t key_data_len = 0;
-  unsigned char * pt_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  unsigned char *pt_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t pt_data_len = 0;
-  unsigned char * ct_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  unsigned char *ct_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
   size_t ct_data_len = 0;
   bool result_bool = false;
 
@@ -368,11 +375,10 @@ void test_aes_keywrap_vectors(void)
                                              &pt_data,
                                              &pt_data_len,
                                              &ct_data,
-                                             &ct_data_len,
-                                             &result_bool) == 0)
+                                             &ct_data_len, &result_bool) == 0)
         {
           // Create a new buffer to hold the result for each vector applied
-          unsigned char * out = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+          unsigned char *out = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
           size_t out_len = 0;
 
           // increment count of test vectors applied
@@ -387,58 +393,46 @@ void test_aes_keywrap_vectors(void)
 
           // create pointers to applicable result (i.e., ct_data and
           // ct_data_len for encrypt, pt_data and pt_data_len for decrypt)
-          unsigned char * exp_result = NULL;
+          unsigned char *exp_result = NULL;
           size_t exp_result_len = 0;
 
           if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
-                      "aes_keywrap_3394nopad_encrypt",
-                      29) == 0)
+                      "aes_keywrap_3394nopad_encrypt", 29) == 0)
           {
             rc = aes_keywrap_3394nopad_encrypt(key_data,
                                                key_data_len,
                                                pt_data,
-                                               pt_data_len,
-                                               &out,
-                                               &out_len);
+                                               pt_data_len, &out, &out_len);
             exp_result = ct_data;
             exp_result_len = ct_data_len;
           }
           else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
-                           "aes_keywrap_3394nopad_decrypt",
-                           29) == 0)
+                           "aes_keywrap_3394nopad_decrypt", 29) == 0)
           {
             rc = aes_keywrap_3394nopad_decrypt(key_data,
                                                key_data_len,
                                                ct_data,
-                                               ct_data_len,
-                                               &out,
-                                               &out_len);
+                                               ct_data_len, &out, &out_len);
             exp_result = pt_data;
             exp_result_len = pt_data_len;
           }
           else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
-                           "aes_keywrap_5649pad_encrypt",
-                           29) == 0)
+                           "aes_keywrap_5649pad_encrypt", 29) == 0)
           {
             rc = aes_keywrap_5649pad_encrypt(key_data,
-                                               key_data_len,
-                                               pt_data,
-                                               pt_data_len,
-                                               &out,
-                                               &out_len);
+                                             key_data_len,
+                                             pt_data,
+                                             pt_data_len, &out, &out_len);
             exp_result = ct_data;
             exp_result_len = ct_data_len;
           }
           else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
-                           "aes_keywrap_5649pad_decrypt",
-                           29) == 0)
+                           "aes_keywrap_5649pad_decrypt", 29) == 0)
           {
             rc = aes_keywrap_5649pad_decrypt(key_data,
-                                               key_data_len,
-                                               ct_data,
-                                               ct_data_len,
-                                               &out,
-                                               &out_len);
+                                             key_data_len,
+                                             ct_data,
+                                             ct_data_len, &out, &out_len);
             exp_result = pt_data;
             exp_result_len = pt_data_len;
           }
@@ -462,7 +456,7 @@ void test_aes_keywrap_vectors(void)
             {
               // check if a test vector expected to fail, passed
               if (rc == 0)
-              { 
+              {
                 vector_passed = false;
                 printf("expected fail, passed: %d\n", test_vector_count);
               }
@@ -489,7 +483,8 @@ void test_aes_keywrap_vectors(void)
                 if (out[j] != exp_result[j])
                 {
                   vector_passed = false;
-                  printf("expected result mismatch at byte %d: %d\n", j, test_vector_count);
+                  printf("expected result mismatch at byte %d: %d\n", j,
+                         test_vector_count);
                 }
               }
             }
@@ -516,7 +511,7 @@ void test_aes_keywrap_vectors(void)
 
       // Provide INFO: message indicating how many test vectors were applied
       printf("INFO: %s - %d test vectors applied\n",
-              aes_keywrap_vectors.sets[i].path, test_vector_count);
+             aes_keywrap_vectors.sets[i].path, test_vector_count);
 
       // reset flag/counters for processing of next (if any) test vector file
       done_with_test_vector_file = false;
@@ -526,7 +521,7 @@ void test_aes_keywrap_vectors(void)
     else
     {
       printf("INFO: test vector file (%s) not installed ... ",
-              aes_keywrap_vectors.sets[i].path);
+             aes_keywrap_vectors.sets[i].path);
       printf("skipping these tests\n");
     }
   }
@@ -536,4 +531,3 @@ void test_aes_keywrap_vectors(void)
   free(pt_data);
   free(ct_data);
 }
-

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -1,0 +1,539 @@
+//############################################################################
+// aes_keywrap_test.c
+//
+// Tests for kmyth AES keywrap functionality in:
+//   - tpm2/src/cipher/aes_keywrap_3394nopad.c
+//   - tpm2/src/cipher/aes_keywrap_5649pad.c
+//############################################################################
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <CUnit/CUnit.h>
+
+#include "aes_keywrap_test.h"
+#include "kmyth_cipher_test.h"
+#include "aes_keywrap_3394nopad.h"
+#include "aes_keywrap_5649pad.h"
+
+#define AES_KW_VECTOR_PATH "test/vectors/kwtestvectors"
+
+
+//---------------------- AES Key Wrap Cipher Test Configuration --------------
+
+//----------------------------------------------------------------------------
+// aes_keywrap_add_tests()
+//----------------------------------------------------------------------------
+int aes_keywrap_add_tests(CU_pSuite suite)
+{
+  if (NULL == CU_add_test(suite,
+                          "Test Kmyth AES key wrap/unwrap parameter handling",
+                          test_aes_keywrap_parameters))
+  {
+    return 1;
+  }
+
+  if (NULL == CU_add_test(suite,
+                          "Run AES key wrap test vectors",
+                          test_aes_keywrap_vectors))
+  {
+    return 1;
+  }
+
+
+  return 0;
+}
+
+//---------------------- AES Key Wrap Cipher Test Utilities --------------
+
+//----------------------------------------------------------------------------
+// get_aes_keywrap_vector_from_file()
+//----------------------------------------------------------------------------
+int get_aes_keywrap_vector_from_file(FILE * fid,
+                                     uint8_t ** K_vec,
+                                     size_t * K_vec_len,
+                                     uint8_t ** P_vec,
+                                     size_t * P_vec_len,
+                                     uint8_t ** C_vec,
+                                     size_t * C_vec_len,
+                                     bool * expect_pass)
+{
+  // create buffer to hold vector data read in from file a line at a time
+  // specify buffer size to handle largest vector component (must include
+  // some extra space for leading and/or trailing characters that get
+  // stripped off)
+  char buffer[MAX_TEST_VECTOR_COMPONENT_LENGTH];
+
+  // create variables to buffer the components in a single test vector
+  char  * K_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int K_str_len = 0;
+  char * P_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int P_str_len = 0;
+  char * C_str = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  int C_str_len = 0;
+  bool pass_result = true;  // unless vector has a 'FAIL' line, should pass
+
+  // create/initialize a counter to track progress (ensure that test vector
+  // components are read and parsed in expected sequence)
+  //     step = 1: searching for a 'K' vector component (start of test vector)
+  //     step = 2: found a 'K' vector component
+  //               expecting 'P', 'C' vector component
+  //               finding another 'K' component in step 2 stays in step 2
+  //     step = 3: have 'K' and either 'P' or 'C' vector components
+  //               expecting 'P' or 'C' (whichever not yet found) or 'FAIL'
+  //               finding another 'K' component in step 3 returns to step 2
+  //     step = 4: found complete vector
+  // any other parsing sequence values are invalid - failure or unexepected
+  // file data at any step restarts the process (reset to first step)
+  int step = 1;
+
+  while ((!feof(fid)) && (step < 4))
+  {
+    // test vector file is read a line at a time until either EOF is reached
+    // or a test vector grouping is successfully parsed.
+    if (fgets(buffer, MAX_TEST_VECTOR_COMPONENT_LENGTH, fid) != NULL)
+    {
+      if (strncmp(buffer, "K = ", 4) == 0)
+      {
+        // If 'K = ' is found, we are at the start of a test vector
+        // Note: regardless of incoming step level (< 4), finding 'K = ' puts
+        //       the parsing process into step 2 (having 'K' but nothing else)
+        step = 2;
+        K_str_len = strlen(buffer) - 4;  // strip leading 'K = ' sub-string
+        memcpy(K_str, buffer + 4, K_str_len * sizeof(char));
+        while ((K_str_len > 0) &&
+               ((K_str[K_str_len - 1] == '\n') ||
+                (K_str[K_str_len - 1] == '\r')))
+        {
+          K_str[--K_str_len] = '\0';  // strip any trailing '\n' or '\r'
+        }
+      }
+  
+      else if (strncmp(buffer, "P = ", 4) == 0)
+      {
+        // found 'P' vector component before 'K' - reset
+        if ((step != 2) && (step != 3))
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+  
+        // correctly found 'P' component in step 2 or step 3
+        else
+        {
+          step++;
+          P_str_len = strlen(buffer) - 4;  // strip leading 'P = ' sub-string
+          memcpy(P_str, buffer + 4, P_str_len * sizeof(char));
+          while ((P_str_len > 0) &&
+                 ((P_str[P_str_len - 1] == '\n') ||
+                  (P_str[P_str_len - 1] == '\r')))
+          {
+            P_str[--P_str_len] = '\0';  // strip any trailing '\n' or '\r'
+          }
+        }
+      }
+  
+      else if (strncmp(buffer, "C = ", 4) == 0)
+      {
+        // found 'C' vector component before 'K' - reset
+        if ((step != 2) && (step != 3))
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+  
+        // correctly found 'C' component in step 2 or step 3
+        else
+        {
+          step++;
+          C_str_len = strlen(buffer) - 4;  // strip leading 'C = ' sub-string
+          memcpy(C_str, buffer + 4, C_str_len * sizeof(char));
+          while ((C_str_len > 0) &&
+                 ((C_str[C_str_len - 1] == '\n') ||
+                  (C_str[C_str_len - 1] == '\r')))
+          {
+            C_str[--C_str_len] = '\0';  // strip any trailing '\n' or '\r'
+          }
+        }
+      }
+  
+      else if (strncmp(buffer, "FAIL", 4) == 0)
+      {
+        // found expected 'FAIL' result, but incomplete vector - reset
+        if (step != 3)
+        {
+          step = 1;
+          P_str_len = 0;
+          C_str_len = 0;
+        }
+
+        // found expected 'FAIL' result (should be in place of 'P' component)
+        else
+        {
+          step++;
+          pass_result = false;
+        }
+      }
+  
+      // found line in vector file that is not in one of the formats parsed by
+      // this function - reset (start over, looking for next vector)
+      else
+      {
+        P_str_len = 0;
+        C_str_len = 0;
+        step = 1;
+      }
+    }
+  }
+
+  // reaching step 4 means a vector has been successfully parsed
+  if (step == 4)
+  {
+    // use parsed results to populate output parameters
+    convert_HexString_to_ByteArray((char **) K_vec,
+                                             K_str,
+                                             K_str_len);
+    *K_vec_len = K_str_len / 2;  // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) P_vec,
+                                             P_str,
+                                             P_str_len);
+    *P_vec_len = P_str_len / 2;  // 2 hex chars map to a byte of key
+    convert_HexString_to_ByteArray((char **) C_vec,
+                                             C_str,
+                                             C_str_len);
+    *C_vec_len = C_str_len / 2;  // 2 hex chars map to a byte of key
+    *expect_pass = pass_result;
+  }
+
+  // clean-up allocated memory
+  free(K_str);
+  free(P_str);
+  free(C_str);
+
+  // if while loop exit due to EOF, return unsuccessful result
+  if (step != 4)
+  {
+    return 1;
+  }
+
+  // normal termination
+  return 0;
+}
+
+//---------------------- AES Key Wrap Cipher Tests ---------------------------
+
+//----------------------------------------------------------------------------
+// test_aes_keywrap_parameters()
+//----------------------------------------------------------------------------
+void test_aes_keywrap_parameters(void)
+{
+  unsigned char* key = NULL;
+  int key_len = 0;
+  
+  unsigned char* inData = NULL;
+  size_t inData_len = 0;
+
+  unsigned char* outData = NULL;
+  size_t outData_len = 0;
+
+  // Test failure on null key
+  inData = malloc(16);
+  inData_len = 16;
+  key_len = 16;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure on key of length 0
+  key = malloc(16);
+  key_len = 0;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure on input data of length 0
+  key_len = 16;
+  inData_len = 0;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure with input data too short
+  inData_len = 8;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  // Test failure with input data that's not a multiple of 8 bytes long
+  inData_len = 17;
+  CU_ASSERT(aes_keywrap_3394nopad_encrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT(aes_keywrap_3394nopad_decrypt(key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+
+  free(key);
+  free(inData);
+}
+
+
+//----------------------------------------------------------------------------
+// test_aes_keywrap_vectors()
+//----------------------------------------------------------------------------
+void test_aes_keywrap_vectors(void)
+{
+  // specify the compilation of test vector mappings for kmyth AES GCM
+  // decrypt cipher testing.
+  const cipher_vector_compilation aes_keywrap_vectors = {
+    .count = 12,
+    .sets = 
+    {
+      { .desc = "AES-128, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_128.txt" },
+      { .desc = "AES-128, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_128.txt" },
+      { .desc = "AES-192, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_192.txt" },
+      { .desc = "AES-192, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_192.txt" },
+      { .desc = "AES-256, RFC-3394 Key Wrap no padding (KW-AE), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AE_256.txt" },
+      { .desc = "AES-256, RFC-3394 Key Unwrap no padding (KW-AD), forward",
+        .func_to_test = "aes_keywrap_3394nopad_encrypt",
+        .path = "./test/data/kwtestvectors/KW_AD_256.txt" },
+      { .desc = "AES-128, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_128.txt" },
+      { .desc = "AES-128, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_128.txt" },
+      { .desc = "AES-192, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_192.txt" },
+      { .desc = "AES-192, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_192.txt" },
+      { .desc = "AES-256, RFC-5649 Key Wrap with padding (KWP-AE), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AE_256.txt" },
+      { .desc = "AES-256, RFC-5649 Key Unwrap with padding (KWP-AD), forward",
+        .func_to_test = "aes_keywrap_5649pad_encrypt",
+        .path = "./test/data/kwtestvectors/KWP_AD_256.txt" }
+    }
+  };
+
+  // array of file pointers for test vector files
+  FILE * test_vector_fd[MAX_VECTOR_SETS_IN_COMPILATION] = {NULL};
+
+  // counter to track number of test vectors applied from a file
+  int test_vector_count = 0;
+
+  // flag used to signal end of processing for a given test vector file
+  bool done_with_test_vector_file = false;
+
+  // check that number of test vector files complies with specified maximum
+  if (aes_keywrap_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
+  {
+    fprintf(stderr,
+            "ERROR: too many (%ld) vector set mappings (%d max)",
+            aes_keywrap_vectors.count,
+            MAX_VECTOR_SETS_IN_COMPILATION);
+    CU_FAIL("AES Key Wrap Test Vector File Count Exceeds Limit");
+    return;
+  }
+
+  // allocate memory to hold a single test vector - re-use these buffers
+  // for all test vectors used during these tests
+  unsigned char * key_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t key_data_len = 0;
+  unsigned char * pt_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t pt_data_len = 0;
+  unsigned char * ct_data = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+  size_t ct_data_len = 0;
+  bool result_bool = false;
+
+  for (int i = 0; i < aes_keywrap_vectors.count; i++)
+  {
+    // open test vector file
+    test_vector_fd[i] = fopen(aes_keywrap_vectors.sets[i].path, "r");
+    if (test_vector_fd[i] != NULL)
+    {
+      while ((!done_with_test_vector_file) &&
+             (test_vector_count <= MAX_KEYWRAP_TEST_VECTOR_COUNT))
+      {
+        // Parse next vector from file
+        if (get_aes_keywrap_vector_from_file(test_vector_fd[i],
+                                             &key_data,
+                                             &key_data_len,
+                                             &pt_data,
+                                             &pt_data_len,
+                                             &ct_data,
+                                             &ct_data_len,
+                                             &result_bool) == 0)
+        {
+          // Create a new buffer to hold the result for each vector applied
+          unsigned char * out = calloc(MAX_TEST_VECTOR_COMPONENT_LENGTH, 1);
+          size_t out_len = 0;
+
+          // increment count of test vectors applied
+          test_vector_count++;
+
+          // create flag to aggregate pass/fail result
+          // (initialize true but latch in false for any unexpected result)
+          bool vector_passed = true;
+
+          // create variable to hold response code from function being tested
+          int rc = -1;
+
+          // create pointers to applicable result (i.e., ct_data and
+          // ct_data_len for encrypt, pt_data and pt_data_len for decrypt)
+          unsigned char * exp_result = NULL;
+          size_t exp_result_len = 0;
+
+          if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                      "aes_keywrap_3394nopad_encrypt",
+                      29) == 0)
+          {
+            rc = aes_keywrap_3394nopad_encrypt(key_data,
+                                               key_data_len,
+                                               pt_data,
+                                               pt_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = ct_data;
+            exp_result_len = ct_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_3394nopad_decrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_3394nopad_decrypt(key_data,
+                                               key_data_len,
+                                               ct_data,
+                                               ct_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = pt_data;
+            exp_result_len = pt_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_5649pad_encrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_5649pad_encrypt(key_data,
+                                               key_data_len,
+                                               pt_data,
+                                               pt_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = ct_data;
+            exp_result_len = ct_data_len;
+          }
+          else if (strncmp(aes_keywrap_vectors.sets[i].func_to_test,
+                           "aes_keywrap_5649pad_decrypt",
+                           29) == 0)
+          {
+            rc = aes_keywrap_5649pad_decrypt(key_data,
+                                               key_data_len,
+                                               ct_data,
+                                               ct_data_len,
+                                               &out,
+                                               &out_len);
+            exp_result = pt_data;
+            exp_result_len = pt_data_len;
+          }
+
+          else
+          {
+            printf("ERROR: test vector set for file (%s) associated with ",
+                   aes_keywrap_vectors.sets[i].path);
+            printf("function to test(%s)\n",
+                   aes_keywrap_vectors.sets[i].func_to_test);
+            CU_FAIL("Test vector file linked to invalid function to test");
+            // don't get any more vectors from this file - can't apply them
+            done_with_test_vector_file = true;
+          }
+
+          // if vector successfully applied
+          if (rc != -1)
+          {
+            // consolidate results of applying test vector into a single assertion
+            if (result_bool == false)
+            {
+              // check if a test vector expected to fail, passed
+              if (rc == 0)
+              { 
+                vector_passed = false;
+                printf("expected fail, passed: %d\n", test_vector_count);
+              }
+            }
+            else
+            {
+              // check if a test vector expected to pass, failed
+              if (rc != 0)
+              {
+                vector_passed = false;
+                printf("expected pass, failed: %d\n", test_vector_count);
+              }
+
+              // check for unexpected size of decrypted result
+              if (out_len != exp_result_len)
+              {
+                vector_passed = false;
+                printf("unexpected size for result: %d\n", test_vector_count);
+              }
+
+              // check that expected result matches (byte for byte)
+              for (int j = 0; j < out_len; j++)
+              {
+                if (out[j] != exp_result[j])
+                {
+                  vector_passed = false;
+                  printf("expected result mismatch at byte %d: %d\n", j, test_vector_count);
+                }
+              }
+            }
+
+            CU_ASSERT(vector_passed);
+
+            // clean-up output_data byte array
+            if (rc == 0)
+            {
+              free(out);
+            }
+          }
+        }
+
+        else
+        {
+          // get_aes_gcm_test_vector_from_file() returned error - must be done
+          done_with_test_vector_file = true;
+        }
+      }
+
+      // Done with the test vector file (processed all vectors or reached max)
+      fclose(test_vector_fd[i]);
+
+      // Provide INFO: message indicating how many test vectors were applied
+      printf("INFO: %s - %d test vectors applied\n",
+              aes_keywrap_vectors.sets[i].path, test_vector_count);
+
+      // reset flag/counters for processing of next (if any) test vector file
+      done_with_test_vector_file = false;
+      test_vector_count = 0;
+    }
+
+    else
+    {
+      printf("INFO: test vector file (%s) not installed ... ",
+              aes_keywrap_vectors.sets[i].path);
+      printf("skipping these tests\n");
+    }
+  }
+
+  // clean-up allocated test vector memory
+  free(key_data);
+  free(pt_data);
+  free(ct_data);
+}
+

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -346,12 +346,15 @@ void test_aes_keywrap_vectors(void)
   // check that number of test vector files complies with specified maximum
   if (aes_keywrap_vectors.count > MAX_VECTOR_SETS_IN_COMPILATION)
   {
-    fprintf(stderr,
-            "ERROR: too many (%ld) vector set mappings (%d max)",
-            aes_keywrap_vectors.count, MAX_VECTOR_SETS_IN_COMPILATION);
     CU_FAIL("AES Key Wrap Test Vector File Count Exceeds Limit");
     return;
   }
+
+  // create counters to track the number of:
+  //   - configured test vector files parsed (partially or fully)
+  //   - test vectors applied (cumulative count)
+  size_t parsed_test_vector_files = 0;
+  size_t cumulative_test_vector_count = 0;
 
   // allocate memory to hold a single test vector - re-use these buffers
   // for all test vectors used during these tests
@@ -520,17 +523,18 @@ void test_aes_keywrap_vectors(void)
       // Done with the test vector file (processed all vectors or reached max)
       fclose(test_vector_fd[i]);
 
-      // Provide INFO: message indicating how many test vectors were applied
-      printf("INFO: %s - %d test vectors applied\n",
-             aes_keywrap_vectors.sets[i].path, test_vector_count);
+      // update test vector tracking counters
+      parsed_test_vector_files++;
+      cumulative_test_vector_count += test_vector_count;
     }
+  }
 
-    else
-    {
-      printf("INFO: test vector file (%s) not installed ... ",
-             aes_keywrap_vectors.sets[i].path);
-      printf("skipping these tests\n");
-    }
+  // print message to inform about optional tests run
+  printf("\nINFO: %ld of %ld optional AES keywrap test vector files parsed\n",
+         parsed_test_vector_files, aes_keywrap_vectors.count);
+  if (cumulative_test_vector_count > 0)
+  {
+    printf("      %ld test vectors applied\n", cumulative_test_vector_count);
   }
 
   // clean-up allocated test vector memory

--- a/tpm2/test/src/cipher/aes_keywrap_test.c
+++ b/tpm2/test/src/cipher/aes_keywrap_test.c
@@ -235,38 +235,48 @@ void test_aes_keywrap_parameters(void)
   key_len = 16;
   CU_ASSERT(aes_keywrap_3394nopad_encrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
   CU_ASSERT(aes_keywrap_3394nopad_decrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
 
   // Test failure on key of length 0
   key = malloc(16);
   key_len = 0;
   CU_ASSERT(aes_keywrap_3394nopad_encrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
   CU_ASSERT(aes_keywrap_3394nopad_decrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
 
   // Test failure on input data of length 0
   key_len = 16;
   inData_len = 0;
   CU_ASSERT(aes_keywrap_3394nopad_encrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
   CU_ASSERT(aes_keywrap_3394nopad_decrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
 
   // Test failure with input data too short
   inData_len = 8;
   CU_ASSERT(aes_keywrap_3394nopad_encrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
   CU_ASSERT(aes_keywrap_3394nopad_decrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
 
   // Test failure with input data that's not a multiple of 8 bytes long
   inData_len = 17;
   CU_ASSERT(aes_keywrap_3394nopad_encrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
   CU_ASSERT(aes_keywrap_3394nopad_decrypt
             (key, key_len, inData, inData_len, &outData, &outData_len) == 1);
+  CU_ASSERT((outData == NULL) && (outData_len == 0));
 
   free(key);
   free(inData);

--- a/tpm2/test/src/cipher/kmyth_cipher_test.c
+++ b/tpm2/test/src/cipher/kmyth_cipher_test.c
@@ -11,23 +11,23 @@
 
 #include "kmyth_cipher_test.h"
 
-
 //----------------------------------------------------------------------------
 // convert_HexString_to_ByteArray()
 //----------------------------------------------------------------------------
 int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size)
 {
-  if((str_size % 2) != 0)
+  if ((str_size % 2) != 0)
   {
     fprintf(stderr, "ERROR: Invalid hex string size, must be even.\n");
-    return 1; 
+    return 1;
   }
 
   size_t bufSize = ((str_size) / 2);
-  char * buf = (char *) calloc(bufSize + 1, sizeof(char)); 
+  char *buf = (char *) calloc(bufSize + 1, sizeof(char));
+
   for (int i = 0; i < bufSize; i++)
   {
-    sscanf(hex_str+(i*2), "%02hhx", &buf[i]);
+    sscanf(hex_str + (i * 2), "%02hhx", &buf[i]);
   }
   buf[bufSize] = '\0';
 
@@ -35,4 +35,3 @@ int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size)
 
   return 0;
 }
-

--- a/tpm2/test/src/cipher/kmyth_cipher_test.c
+++ b/tpm2/test/src/cipher/kmyth_cipher_test.c
@@ -1,0 +1,38 @@
+//############################################################################
+// kmyth_test_cipher.c
+//
+// General utilities for kmyth cipher testing:
+//   - convert hexadecimal valued strings in vector files to byte arrays
+//############################################################################
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "kmyth_cipher_test.h"
+
+
+//----------------------------------------------------------------------------
+// convert_HexString_to_ByteArray()
+//----------------------------------------------------------------------------
+int convert_HexString_to_ByteArray(char **result, char *hex_str, int str_size)
+{
+  if((str_size % 2) != 0)
+  {
+    fprintf(stderr, "ERROR: Invalid hex string size, must be even.\n");
+    return 1; 
+  }
+
+  size_t bufSize = ((str_size) / 2);
+  char * buf = (char *) calloc(bufSize + 1, sizeof(char)); 
+  for (int i = 0; i < bufSize; i++)
+  {
+    sscanf(hex_str+(i*2), "%02hhx", &buf[i]);
+  }
+  buf[bufSize] = '\0';
+
+  *result = buf;
+
+  return 0;
+}
+

--- a/tpm2/test/src/kmyth-test.c
+++ b/tpm2/test/src/kmyth-test.c
@@ -103,10 +103,10 @@ int main(int argc, char **argv)
   object_tools_test_suite = CU_add_suite("TPM Object Tools Test Suite",
                                          init_suite, clean_suite);
   if (NULL == object_tools_test_suite)
-    {
-      CU_cleanup_registry();
-      return CU_get_error();
-    }
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
   if (object_tools_add_tests(object_tools_test_suite))
 
   {
@@ -164,22 +164,24 @@ int main(int argc, char **argv)
 
   // Create and configure the AES Key Wrap cipher test suite
   CU_pSuite aes_keywrap_test_suite = NULL;
+
   aes_keywrap_test_suite = CU_add_suite("AES Key Wrap Cipher Test Suite",
-				                                init_suite, clean_suite);
+                                        init_suite, clean_suite);
   if (NULL == aes_keywrap_test_suite)
   {
     CU_cleanup_registry();
     return CU_get_error();
   }
-  if(aes_keywrap_add_tests(aes_keywrap_test_suite))
+  if (aes_keywrap_add_tests(aes_keywrap_test_suite))
   {
     CU_cleanup_registry();
     return CU_get_error();
   }
 
-	// Create and configure the tpm2 interface test suite
-	CU_pSuite tpm2_interface_test_suite = NULL;
-	tpm2_interface_test_suite = CU_add_suite("TPM2 Interface Test Suite",
+  // Create and configure the tpm2 interface test suite
+  CU_pSuite tpm2_interface_test_suite = NULL;
+
+  tpm2_interface_test_suite = CU_add_suite("TPM2 Interface Test Suite",
                                            init_suite, clean_suite);
   if (NULL == tpm2_interface_test_suite)
   {

--- a/tpm2/test/src/kmyth-test.c
+++ b/tpm2/test/src/kmyth-test.c
@@ -19,6 +19,7 @@
 #include "formatting_tools_test.h"
 #include "tls_util_test.h"
 #include "aes_gcm_test.h"
+#include "aes_keywrap_test.h"
 #include "tpm2_interface_test.h"
 #include "storage_key_tools_test.h"
 #include "pcrs_test.h"
@@ -141,6 +142,21 @@ int main(int argc, char** argv)
     return CU_get_error();
   }
   if(aes_gcm_add_tests(aes_gcm_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+
+  // Create and configure the AES Key Wrap cipher test suite
+  CU_pSuite aes_keywrap_test_suite = NULL;
+  aes_keywrap_test_suite = CU_add_suite("AES Key Wrap Cipher Test Suite",
+				                                init_suite, clean_suite);
+  if (NULL == aes_keywrap_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if(aes_keywrap_add_tests(aes_keywrap_test_suite))
   {
     CU_cleanup_registry();
     return CU_get_error();


### PR DESCRIPTION
Added tests to apply NIST AES Key Wrap (RFC-3394 and RFC-5649) vectors to the kmyth AES Key Wrap cipher implementation.