### PR TITLE
Apply indent to all source and header files

### DIFF
--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -25,6 +25,7 @@ MAIN_OBJECTS = $(subst $(MAIN_SRC_DIR), \
 UTIL_SRC_DIR = $(SRC_DIR)/util
 UTIL_SOURCES = $(wildcard $(UTIL_SRC_DIR)/*.c)
 UTIL_INC_DIR = $(INC_DIR)/util
+UTIL_HEADERS = $(wildcard $(UTIL_INC)DIR/*.h)
 UTIL_OBJ_DIR = $(OBJ_DIR)/util
 UTIL_OBJECTS = $(subst $(UTIL_SRC_DIR), \
                        $(UTIL_OBJ_DIR), \
@@ -34,6 +35,7 @@ UTIL_OBJECTS = $(subst $(UTIL_SRC_DIR), \
 CIPHER_SRC_DIR = $(SRC_DIR)/cipher
 CIPHER_SOURCES = $(wildcard $(CIPHER_SRC_DIR)/*.c)
 CIPHER_INC_DIR = $(INC_DIR)/cipher
+CIPHER_HEADERS = $(wildcard $(CIPHER_INC_DIR)/*.h)
 CIPHER_OBJ_DIR = $(OBJ_DIR)/cipher
 CIPHER_OBJECTS = $(subst $(CIPHER_SRC_DIR), \
                          $(CIPHER_OBJ_DIR), \
@@ -43,15 +45,24 @@ CIPHER_OBJECTS = $(subst $(CIPHER_SRC_DIR), \
 TPM_SRC_DIR = $(SRC_DIR)/tpm
 TPM_SOURCES = $(wildcard $(TPM_SRC_DIR)/*.c)
 TPM_INC_DIR = $(INC_DIR)/tpm
+TPM_HEADERS = $(wildcard $(TPM_INC_DIR)/*.h)
 TPM_OBJ_DIR = $(OBJ_DIR)/tpm
 TPM_OBJECTS = $(subst $(TPM_SRC_DIR), \
                       $(TPM_OBJ_DIR), \
                       $(TPM_SOURCES:%.c=%.o))
 
+# Specify Kmyth source files
+SOURCE_FILES = $(wildcard $(SRC_DIR)/*.c)
+SOURCE_FILES += $(MAIN_SOURCES)
+SOURCE_FILES += $(UTIL_SOURCES)
+SOURCE_FILES += $(CIPHER_SOURCES)
+SOURCE_FILES += $(TPM_SOURCES)
+
 # Specify Kmyth header files
 HEADER_FILES = $(wildcard $(INC_DIR)/*.h)
-HEADER_FILES += $(wildcard $(CIPHER_INC_DIR)/*.h)
-HEADER_FILES += $(wildcard $(TPM_INC_DIR)/*.h)
+HEADER_FILES += $(UTIL_HEADERS)
+HEADER_FILES += $(CIPHER_HEADERS)
+HEADER_FILES += $(TPM_HEADERS)
 
 # Consolidate created directories to simplify mkdir call for 'pre' target
 OBJECT_DIRS = $(MAIN_OBJ_DIR)
@@ -86,12 +97,17 @@ TEST_INC_DIR ?= $(TEST_DIR)/include
 TEST_OBJ_DIR ?= $(TEST_DIR)/obj
 
 # Specify 'testrunner' (kmyth-test) files
-TESTRUNNER_SOURCES = $(TEST_DIR)/kmyth-test.c
-TESTRUNNER_OBJECTS = $(TEST_OBJ_DIR)/kmyth-test.o
+TESTRUNNER_SOURCES = $(wildcard $(TEST_SRC_DIR)/*.c)
+TESTRUNNER_HEADERS = $(wildcard $(TEST_INC_DIR)/*.h)
+TESTRUNNER_OBJECTS = $(subst $(TEST_SRC_DIR), \
+                             $(TEST_OBJ_DIR), \
+														 $(TESTRUNNER_SOURCES:%.c=%.o))
 
 # Specify directories/files supporting kmyth application (main) testing
 TEST_MAIN_SRC_DIR = $(TEST_SRC_DIR)/main
 TEST_MAIN_SOURCES = $(wildcard $(TEST_MAIN_SRC_DIR)/*.c)
+TEST_MAIN_INC_DIR = $(TEST_INC_DIR)/main
+TEST_MAIN_HEADERS = $(wildcard $(TEST_MAIN_INC_DIR)/*.h)
 TEST_MAIN_OBJ_DIR = $(TEST_OBJ_DIR)/main
 TEST_MAIN_OBJECTS = $(subst $(TEST_MAIN_SRC_DIR), \
                             $(TEST_MAIN_OBJ_DIR), \
@@ -101,6 +117,7 @@ TEST_MAIN_OBJECTS = $(subst $(TEST_MAIN_SRC_DIR), \
 TEST_UTIL_SRC_DIR = $(TEST_SRC_DIR)/util
 TEST_UTIL_SOURCES = $(wildcard $(TEST_UTIL_SRC_DIR)/*.c)
 TEST_UTIL_INC_DIR = $(TEST_INC_DIR)/util
+TEST_UTIL_HEADERS = $(wildcard $(TEST_UTIL_INC_DIR)/*.h)
 TEST_UTIL_OBJ_DIR = $(TEST_OBJ_DIR)/util
 TEST_UTIL_OBJECTS = $(subst $(TEST_UTIL_SRC_DIR), \
                             $(TEST_UTIL_OBJ_DIR), \
@@ -110,19 +127,21 @@ TEST_UTIL_OBJECTS = $(subst $(TEST_UTIL_SRC_DIR), \
 TEST_TPM_SRC_DIR = $(TEST_SRC_DIR)/tpm
 TEST_TPM_SOURCES = $(wildcard $(TEST_TPM_SRC_DIR)/*.c)
 TEST_TPM_INC_DIR = $(TEST_INC_DIR)/tpm
+TEST_TPM_HEADERS = $(wildcard $(TEST_TPM_INC_DIR)/*.h)
 TEST_TPM_OBJ_DIR = $(TEST_OBJ_DIR)/tpm
 TEST_TPM_OBJECTS = $(subst $(TEST_TPM_SRC_DIR), \
                            $(TEST_TPM_OBJ_DIR), \
                            $(TEST_TPM_SOURCES:%.c=%.o))
 
 # Specify directories/files supporting kmyth cipher utility testing
-TEST_CIPHER_SRC_DIR  = $(TEST_SRC_DIR)/cipher
-TEST_CIPHER_SOURCES  = $(wildcard $(TEST_CIPHER_SRC_DIR)/*.c)
+TEST_CIPHER_SRC_DIR = $(TEST_SRC_DIR)/cipher
+TEST_CIPHER_SOURCES = $(wildcard $(TEST_CIPHER_SRC_DIR)/*.c)
 TEST_CIPHER_INC_DIR = $(TEST_INC_DIR)/cipher
-TEST_CIPHER_OBJ_DIR  = $(TEST_OBJ_DIR)/cipher
-TEST_CIPHER_OBJECTS  = $(subst $(TEST_CIPHER_SRC_DIR), \
-                               $(TEST_CIPHER_OBJ_DIR), \
-                               $(TEST_CIPHER_SOURCES:%.c=%.o))
+TEST_CIPHER_HEADERS = $(wildcard $(TEST_CIPHER_INC_DIR)/*.h)
+TEST_CIPHER_OBJ_DIR = $(TEST_OBJ_DIR)/cipher
+TEST_CIPHER_OBJECTS = $(subst $(TEST_CIPHER_SRC_DIR), \
+                              $(TEST_CIPHER_OBJ_DIR), \
+                              $(TEST_CIPHER_SOURCES:%.c=%.o))
 
 # Create consolidated list of test source files
 TEST_SOURCES = $(TESTRUNNER_SOURCES)
@@ -130,6 +149,13 @@ TEST_SOURCES += $(TEST_MAIN_SOURCES)
 TEST_SOURCES += $(TEST_UTIL_SOURCES)
 TEST_SOURCES += $(TEST_TPM_SOURCES)
 TEST_SOURCES += $(TEST_CIPHER_SOURCES)
+
+# Create consolidated list of test header files
+TEST_HEADERS = $(TESTRUNNER_HEADERS)
+TEST_HEADERS += $(TEST_MAIN_HEADERS)
+TEST_HEADERS += $(TEST_UTIL_HEADERS)
+TEST_HEADERS += $(TEST_TPM_HEADERS)
+TEST_HEADERS += $(TEST_CIPHER_HEADERS)
 
 # Create consolidated list of test object files
 TEST_OBJECTS = $(TESTRUNNER_OBJECTS)
@@ -297,10 +323,12 @@ $(CIPHER_OBJ_DIR)/%.o: $(CIPHER_SRC_DIR)/%.c \
 
 .PHONY: pre
 pre:
-	indent $(INDENT_OPTS) src/*/*.c
-	indent $(INDENT_OPTS) include/*.h
+	indent $(INDENT_OPTS) $(SOURCE_FILES)
+	indent $(INDENT_OPTS) $(HEADER_FILES)
+	rm -f src/*.c~
 	rm -f src/*/*.c~
 	rm -f include/*.h~
+	rm -f include/*/*.h~
 	mkdir -p $(BIN_DIR)
 	mkdir -p $(OBJECT_DIRS)
 	mkdir -p $(LIB_DIR)
@@ -322,6 +350,12 @@ test: pretest kmyth-test
 
 .PHONY: pretest
 pretest:
+	indent $(INDENT_OPTS) $(TEST_SOURCES)
+	indent $(INDENT_OPTS) $(TEST_HEADERS)
+	rm -f test/src/*.c~
+	rm -f test/src/*/*.c~
+	rm -f test/include/*.h~
+	rm -f test/include/*/*.h~
 	mkdir -p $(TEST_OBJECT_DIRS)
 
 kmyth-test: $(TEST_OBJECTS)

--- a/tpm2/include/cipher/aes_gcm.h
+++ b/tpm2/include/cipher/aes_gcm.h
@@ -52,7 +52,7 @@ int aes_gcm_encrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData,
                     size_t inData_len, unsigned char **outData,
-                    size_t *outData_len);
+                    size_t * outData_len);
 
 /**
  * @brief This function uses the AES-GCM implementation from OpenSSL to
@@ -82,6 +82,6 @@ int aes_gcm_decrypt(unsigned char *key,
                     size_t key_len,
                     unsigned char *inData,
                     size_t inData_len, unsigned char **outData,
-                    size_t *outData_len);
+                    size_t * outData_len);
 
 #endif

--- a/tpm2/include/cipher/aes_keywrap_3394nopad.h
+++ b/tpm2/include/cipher/aes_keywrap_3394nopad.h
@@ -35,7 +35,7 @@ int aes_keywrap_3394nopad_encrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len);
+                                  size_t * outData_len);
 
 /**
  * @brief This function uses OpenSSL to perform AES key unwrap without padding
@@ -64,6 +64,6 @@ int aes_keywrap_3394nopad_decrypt(unsigned char *key,
                                   size_t key_len,
                                   unsigned char *inData,
                                   size_t inData_len, unsigned char **outData,
-                                  size_t *outData_len);
+                                  size_t * outData_len);
 
 #endif

--- a/tpm2/include/cipher/aes_keywrap_5649pad.h
+++ b/tpm2/include/cipher/aes_keywrap_5649pad.h
@@ -39,7 +39,7 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len);
+                                size_t * outData_len);
 
 /**
  * @brief This function uses OpenSSL to perform AES key unwrap with padding
@@ -68,6 +68,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
                                 size_t key_len,
                                 unsigned char *inData,
                                 size_t inData_len, unsigned char **outData,
-                                size_t *outData_len);
+                                size_t * outData_len);
 
 #endif

--- a/tpm2/include/cipher/cipher.h
+++ b/tpm2/include/cipher/cipher.h
@@ -39,11 +39,11 @@
  *
  * @return 0 on success, 1 on error.
  */
-typedef int (*cipher)(unsigned char *key,
-                      size_t key_len,
-                      unsigned char *inData,
-                      size_t inData_len,
-                      unsigned char **outData, size_t *outData_len);
+typedef int (*cipher) (unsigned char *key,
+                       size_t key_len,
+                       unsigned char *inData,
+                       size_t inData_len,
+                       unsigned char **outData, size_t * outData_len);
 
 /**
  * cipher_t:
@@ -118,8 +118,8 @@ int kmyth_encrypt_data(unsigned char *data,
                        size_t data_size,
                        cipher_t enc_cipher,
                        unsigned char **enc_data,
-                       size_t *enc_data_size, unsigned char **enc_key,
-                       size_t *enc_key_size);
+                       size_t * enc_data_size, unsigned char **enc_key,
+                       size_t * enc_key_size);
 
 /**
  * @brief Performs the symmetric decryption specified by the caller.
@@ -143,9 +143,8 @@ int kmyth_encrypt_data(unsigned char *data,
 int kmyth_decrypt_data(unsigned char *enc_data,
                        size_t enc_data_size,
                        cipher_t cipher_spec,
-                       unsigned char* key,
+                       unsigned char *key,
                        size_t key_size,
-                       unsigned char** result,
-                       size_t *result_size);
+                       unsigned char **result, size_t * result_size);
 
 #endif /* CIPHER_H */

--- a/tpm2/include/tpm/formatting_tools.h
+++ b/tpm2/include/tpm/formatting_tools.h
@@ -149,23 +149,23 @@ typedef struct Ski_s
  */
 int marshal_skiObjects(TPML_PCR_SELECTION * pcr_selection_struct,
                        uint8_t ** pcr_selection_struct_data,
-                       size_t *pcr_selection_struct_data_size,
+                       size_t * pcr_selection_struct_data_size,
                        size_t pcr_selection_struct_data_offset,
                        TPM2B_PUBLIC * storage_key_public_blob,
                        uint8_t ** storage_key_public_data,
-                       size_t *storage_key_public_data_size,
+                       size_t * storage_key_public_data_size,
                        size_t storage_key_public_data_offset,
                        TPM2B_PRIVATE * storage_key_private_blob,
                        uint8_t ** storage_key_private_data,
-                       size_t *storage_key_private_data_size,
+                       size_t * storage_key_private_data_size,
                        size_t storage_key_private_data_offset,
                        TPM2B_PUBLIC * sealed_key_public_blob,
                        uint8_t ** sealed_key_public_data,
-                       size_t *sealed_key_public_data_size,
+                       size_t * sealed_key_public_data_size,
                        size_t sealed_key_public_data_offset,
                        TPM2B_PRIVATE * sealed_key_private_blob,
                        uint8_t ** sealed_key_private_data,
-                       size_t *sealed_key_private_data_size,
+                       size_t * sealed_key_private_data_size,
                        size_t sealed_key_private_data_offset);
 
 /**
@@ -365,8 +365,7 @@ int unpack_pcr(TPML_PCR_SELECTION * pcr_select_out,
  */
 int pack_public(TPM2B_PUBLIC * public_blob_in,
                 uint8_t * packed_data_out,
-                size_t packed_data_out_size,
-                size_t packed_data_out_offset);
+                size_t packed_data_out_size, size_t packed_data_out_offset);
 
 /**
  * @brief As the contents of memory containing the public area of a TPM 2.0
@@ -431,8 +430,7 @@ int unpack_public(TPM2B_PUBLIC * public_blob_out,
  */
 int pack_private(TPM2B_PRIVATE * private_blob_in,
                  uint8_t * packed_data_out,
-                 size_t packed_data_out_size,
-                 size_t packed_data_out_offset);
+                 size_t packed_data_out_size, size_t packed_data_out_offset);
 
 /**
  * @brief As the contents of memory containing the public area of a TPM 2.0
@@ -466,8 +464,7 @@ int pack_private(TPM2B_PRIVATE * private_blob_in,
  */
 int unpack_private(TPM2B_PRIVATE * private_blob_out,
                    uint8_t * packed_data_in,
-                   size_t packed_data_in_size,
-                   size_t packed_data_in_offset);
+                   size_t packed_data_in_size, size_t packed_data_in_offset);
 
 /**
  * There are a number of fixed TPM properties (tagged properties)
@@ -511,7 +508,7 @@ int parse_ski_bytes(uint8_t * input, size_t input_length, Ski * output);
  *
  * @return 0 on success, 1 on error
  */
-int create_ski_bytes(Ski input, uint8_t ** output, size_t *output_length);
+int create_ski_bytes(Ski input, uint8_t ** output, size_t * output_length);
 
 /**
  * @brief Frees the contents of a ski struct
@@ -564,8 +561,8 @@ Ski get_default_ski(void);
  * @return 0 on success, 1 on failure
  */
 int get_ski_block_bytes(char **contents,
-                        size_t *remaining, unsigned char **block,
-                        size_t *blocksize,
+                        size_t * remaining, unsigned char **block,
+                        size_t * blocksize,
                         char *delim, size_t delim_len,
                         char *next_delim, size_t next_delim_len);
 
@@ -591,7 +588,7 @@ int get_ski_block_bytes(char **contents,
  */
 int encodeBase64Data(uint8_t * raw_data,
                      size_t raw_data_size, uint8_t ** base64_data,
-                     size_t *base64_data_size);
+                     size_t * base64_data_size);
 
 /**
  * @brief Decodes a base-64 encoded data buffer into "raw" hex bytes.
@@ -614,7 +611,7 @@ int encodeBase64Data(uint8_t * raw_data,
  */
 int decodeBase64Data(unsigned char *base64_data,
                      size_t base64_data_size, unsigned char **raw_data,
-                     size_t *raw_data_size);
+                     size_t * raw_data_size);
 
 /**
  * @brief Concatinates two arrays of type uint8_t
@@ -631,7 +628,7 @@ int decodeBase64Data(unsigned char *base64_data,
  *
  * @return 0 if success, 1 if error
  */
-int concat(uint8_t ** dest, size_t *dest_length, uint8_t * input,
+int concat(uint8_t ** dest, size_t * dest_length, uint8_t * input,
            size_t input_length);
 
 #endif /* FORMATTING_TOOLS_H */

--- a/tpm2/include/tpm/kmyth_seal_unseal_impl.h
+++ b/tpm2/include/tpm/kmyth_seal_unseal_impl.h
@@ -120,7 +120,6 @@ int tpm2_kmyth_unseal_data(TSS2_SYS_CONTEXT * sapi_ctx,
                            TPM2B_AUTH authVal,
                            TPML_PCR_SELECTION pcrList,
                            TPM2B_DIGEST authPolicy,
-                           uint8_t ** result,
-                           size_t *result_size);
+                           uint8_t ** result, size_t * result_size);
 
 #endif /* KMYTH_SEAL_UNSEAL_IMPL_H */

--- a/tpm2/include/tpm/object_tools.h
+++ b/tpm2/include/tpm/object_tools.h
@@ -46,9 +46,9 @@
  * @return 0 if success, 1 if error.
  */
 int init_kmyth_object_sensitive(TPM2B_AUTH object_auth,
-                                 uint8_t * object_data,
-                                 size_t object_dataSize,
-                                 TPM2B_SENSITIVE_CREATE * sensitiveArea);
+                                uint8_t * object_data,
+                                size_t object_dataSize,
+                                TPM2B_SENSITIVE_CREATE * sensitiveArea);
 
 /**
  * @brief Fill in public template used to create Kmyth object.
@@ -397,8 +397,7 @@ int load_kmyth_object(TSS2_SYS_CONTEXT * sapi_ctx,
                       TPM2B_AUTH parent_auth,
                       TPML_PCR_SELECTION parent_pcrList,
                       TPM2B_PRIVATE * in_private,
-                      TPM2B_PUBLIC * in_public,
-                      TPM2_HANDLE * object_handle);
+                      TPM2B_PUBLIC * in_public, TPM2_HANDLE * object_handle);
 
 /**
  * @brief Unseals a Kmyth TPM data object 

--- a/tpm2/include/tpm/pcrs.h
+++ b/tpm2/include/tpm/pcrs.h
@@ -34,9 +34,8 @@
  * @return 0 if success, 1 if error
  */
 int init_pcr_selection(TSS2_SYS_CONTEXT * sapi_ctx,
-                       int* pcrs,
-		       size_t pcrs_len,
-                       TPML_PCR_SELECTION * pcrs_struct);
+                       int *pcrs,
+                       size_t pcrs_len, TPML_PCR_SELECTION * pcrs_struct);
 
 /**
  * @brief Obtains the total count of available PCRs by reading the

--- a/tpm2/include/tpm/storage_key_tools.h
+++ b/tpm2/include/tpm/storage_key_tools.h
@@ -80,9 +80,7 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
  *
  * @return 0 if success, 1 if error. 
  */
-int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx,
-                 TPM2_HANDLE handle,
-                 bool *isSRK);
+int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx, TPM2_HANDLE handle, bool * isSRK);
 
 /**
  * @brief Re-derives SRK with configured public key and hash algorithms
@@ -100,8 +98,7 @@ int check_if_srk(TSS2_SYS_CONTEXT * sapi_ctx,
  * @return 0 if success, 1 if error. 
  */
 int put_srk_into_persistent_storage(TSS2_SYS_CONTEXT * sapi_ctx,
-                                    TPM2_HANDLE srkHandle,
-                                    TPM2B_AUTH sps_auth);
+                                    TPM2_HANDLE srkHandle, TPM2B_AUTH sps_auth);
 
 /**
  * @brief Creates and loads, into the TPM, a new storage key (SK) under the
@@ -149,7 +146,6 @@ int create_and_load_sk(TSS2_SYS_CONTEXT * sapi_ctx,
                        TPML_PCR_SELECTION sk_pcrList,
                        TPM2B_DIGEST sk_authPolicy,
                        TPM2_HANDLE * sk_handle,
-                       TPM2B_PRIVATE * sk_private,
-                       TPM2B_PUBLIC * sk_public);
+                       TPM2B_PRIVATE * sk_private, TPM2B_PUBLIC * sk_public);
 
 #endif /* STORAGE_KEY_TOOLS_H */

--- a/tpm2/include/tpm/tpm2_interface.h
+++ b/tpm2/include/tpm/tpm2_interface.h
@@ -170,7 +170,7 @@ int get_tpm2_properties(TSS2_SYS_CONTEXT * sapi_ctx,
  *
  * @return 0 if success, 1 if error
  */
-int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool *isEmulator);
+int get_tpm2_impl_type(TSS2_SYS_CONTEXT * sapi_ctx, bool * isEmulator);
 
 /**
  * @brief Translates error string from hex into human readable.
@@ -349,8 +349,7 @@ int check_response_auth(SESSION * authSession,
  * @return 0 if success, 1 if error
  */
 int create_authVal(uint8_t * auth_bytes,
-                   size_t auth_bytes_len,
-                   TPM2B_AUTH * authValOut);
+                   size_t auth_bytes_len, TPM2B_AUTH * authValOut);
 
 /**
  * @brief Computes command parameter hash that is one of the inputs used for
@@ -388,8 +387,7 @@ int create_authVal(uint8_t * auth_bytes,
 int compute_cpHash(TPM2_CC cmdCode,
                    TPM2B_NAME authEntityName,
                    uint8_t * cmdParams,
-                   size_t cmdParams_size,
-                   TPM2B_DIGEST * cpHash_out);
+                   size_t cmdParams_size, TPM2B_DIGEST * cpHash_out);
 
 /**
  * @brief Computes response parameter hash that is one of the inputs to the
@@ -425,8 +423,7 @@ int compute_cpHash(TPM2_CC cmdCode,
 int compute_rpHash(TPM2_RC rspCode,
                    TPM2_CC cmdCode,
                    uint8_t * cmdParams,
-                   size_t cmdParams_size,
-                   TPM2B_DIGEST * rpHash_out);
+                   size_t cmdParams_size, TPM2B_DIGEST * rpHash_out);
 
 /**
  * @brief Computes the authorization HMAC value required for command and
@@ -513,8 +510,7 @@ int create_policy_auth_session(TSS2_SYS_CONTEXT * sapi_ctx,
  * @return 0 if success, 1 if error. 
  */
 int start_policy_auth_session(TSS2_SYS_CONTEXT * sapi_ctx,
-                              SESSION * session,
-                              TPM2_SE session_type);
+                              SESSION * session, TPM2_SE session_type);
 
 /**
  * @brief Executes the Kmyth-specific authorization policy steps and updates

--- a/tpm2/include/util/file_io.h
+++ b/tpm2/include/util/file_io.h
@@ -51,7 +51,7 @@ int verifyOutputFilePath(char *path);
  * @return 0 if success, 1 if error
  */
 int read_bytes_from_file(char *input_path, uint8_t ** data,
-                         size_t *data_length);
+                         size_t * data_length);
 
 /**
  * @brief Verifies output_path is valid, then writes bytes to file

--- a/tpm2/include/util/tls_util.h
+++ b/tpm2/include/util/tls_util.h
@@ -109,7 +109,7 @@ int tls_cleanup(void);
  */
 int get_key_from_tls_server(BIO * bio,
                             char *message, size_t message_length,
-                            unsigned char **key, size_t *key_size);
+                            unsigned char **key, size_t * key_size);
 
 /**
  * <pre>
@@ -132,5 +132,5 @@ int get_key_from_tls_server(BIO * bio,
  */
 int get_key_from_kmip_server(BIO * bio,
                              char *message, size_t message_length,
-                             unsigned char **key, size_t *key_size);
+                             unsigned char **key, size_t * key_size);
 #endif

--- a/tpm2/test/include/cipher/aes_gcm_test.h
+++ b/tpm2/test/include/cipher/aes_gcm_test.h
@@ -62,4 +62,3 @@ void test_gcm_cipher_modification(void);
 void test_gcm_parameter_limits(void);
 
 #endif
-

--- a/tpm2/test/include/tpm/formatting_tools_test.h
+++ b/tpm2/test/include/tpm/formatting_tools_test.h
@@ -5,10 +5,8 @@
  * implemented in tpm2/src/tpm/formatting_tools.c
  */
 
-
 #ifndef FORMATTING_TOOLS_TEST_H
 #define FORMATTING_TOOLS_TEST_H
-
 
 /**
  * This function adds all of the tests contained in formatting_tools_test.c to a
@@ -20,7 +18,6 @@
  * @return     0 on success, 1 on failure
  */
 int formatting_tools_add_tests(CU_pSuite suite);
-
 
 //****************************************************************************
 // Tests

--- a/tpm2/test/include/tpm/object_tools_test.h
+++ b/tpm2/test/include/tpm/object_tools_test.h
@@ -5,10 +5,8 @@
  * implemented in tpm2/src/tpm/object_tools.c
  */
 
-
 #ifndef OBJECT_TOOLS_TEST_H
 #define OBJECT_TOOLS_TEST_H
-
 
 /**
  * This function adds all of the tests contained in object_tools_test.c to a
@@ -21,7 +19,6 @@
  * @return     0 on success, 1 on failure
  */
 int object_tools_add_tests(CU_pSuite suite);
-
 
 //****************************************************************************
 // Tests

--- a/tpm2/test/include/tpm/pcrs_test.h
+++ b/tpm2/test/include/tpm/pcrs_test.h
@@ -5,10 +5,8 @@
  * implemented in tpm2/src/tpm/pcrs.c
  */
 
-
 #ifndef PCRS_TEST_H
 #define PCRS_TEST_H
-
 
 /**
  * This function adds all of the tests contained in pcrs_test.c to a
@@ -21,10 +19,9 @@
  */
 int pcrs_add_tests(CU_pSuite suite);
 
-
 //****************************************************************************
-//	Tests for functions in pcrs.h, format for test names is:
-//  	test_funtion_name()
+//  Tests for functions in pcrs.h, format for test names is:
+//    test_funtion_name()
 //****************************************************************************
 void test_init_pcr_selection(void);
 void test_get_pcr_count(void);

--- a/tpm2/test/include/tpm/storage_key_tools_test.h
+++ b/tpm2/test/include/tpm/storage_key_tools_test.h
@@ -5,10 +5,8 @@
  * implemented in tpm2/src/tpm/storage_key_tools.c
  */
 
-
 #ifndef STORAGE_KEY_TOOLS_TEST_H
 #define STORAGE_KEY_TOOLS_TEST_H
-
 
 /**
  * This function adds all of the tests contained in storage_key_tools_test.c to a
@@ -21,10 +19,9 @@
  */
 int storage_key_tools_add_tests(CU_pSuite suite);
 
-
 //****************************************************************************
-//	Tests for functions in storage_key_tools.h, format for test names is:
-//  	test_funtion_name()
+//  Tests for functions in storage_key_tools.h, format for test names is:
+//    test_funtion_name()
 //****************************************************************************
 void test_get_srk_handle(void);
 void test_get_existing_srk_handle(void);

--- a/tpm2/test/include/tpm/tpm2_interface_test.h
+++ b/tpm2/test/include/tpm/tpm2_interface_test.h
@@ -5,10 +5,8 @@
  * implemented in tpm2/src/tpm/tpm2_interface.c
  */
 
-
 #ifndef TPM2_INTERFACE_TEST_H
 #define TPM2_INTERFACE_TEST_H
-
 
 /**
  * This function adds all of the tests contained in tpm2_interface_test.c to a
@@ -21,10 +19,9 @@
  */
 int tpm2_interface_add_tests(CU_pSuite suite);
 
-
 //****************************************************************************
-//	Tests for functions in tpm2_interface.h, format for test names is:
-//  	test_funtion_name()
+//  Tests for functions in tpm2_interface.h, format for test names is:
+//    test_funtion_name()
 //****************************************************************************
 void test_init_tpm2_connection(void);
 void test_init_tcti_abrmd(void);

--- a/tpm2/test/include/util/file_io_test.h
+++ b/tpm2/test/include/util/file_io_test.h
@@ -55,5 +55,4 @@ void test_write_bytes_to_file(void);
  */
 void test_print_to_stdout(void);
 
-
 #endif

--- a/tpm2/test/include/util/tls_util_test.h
+++ b/tpm2/test/include/util/tls_util_test.h
@@ -5,10 +5,8 @@
  * tpm2/src/util/tls_util.c
  */
 
-
 #ifndef TLS_UTIL_TEST__H
 #define TLS_UTIL_TEST__H
-
 
 /**
  * This function adds all of the tests contained in tls_util_test.c to a test
@@ -21,7 +19,6 @@
  * @return     0 on success, 1 on failure
  */
 int tls_util_add_tests(CU_pSuite suite);
-
 
 //****************************************************************************
 // Tests
@@ -48,4 +45,3 @@ void test_get_key_from_tls_server(void);
 void test_get_key_from_kmip_server(void);
 
 #endif
-

--- a/tpm2/test/src/cipher/aes_gcm_test.c
+++ b/tpm2/test/src/cipher/aes_gcm_test.c
@@ -17,38 +17,38 @@
 //----------------------------------------------------------------------------
 int aes_gcm_add_tests(CU_pSuite suite)
 {
-  if(NULL == CU_add_test(suite, "Test AES/GCM encryption/decryption",
-                         test_gcm_encrypt_decrypt))
+  if (NULL == CU_add_test(suite, "Test AES/GCM encryption/decryption",
+                          test_gcm_encrypt_decrypt))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM key modification",
-                         test_gcm_key_modification))
+  if (NULL == CU_add_test(suite, "Test AES/GCM key modification",
+                          test_gcm_key_modification))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM tag modification",
-                         test_gcm_tag_modification))
+  if (NULL == CU_add_test(suite, "Test AES/GCM tag modification",
+                          test_gcm_tag_modification))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM IV modification",
-                         test_gcm_iv_modification))
+  if (NULL == CU_add_test(suite, "Test AES/GCM IV modification",
+                          test_gcm_iv_modification))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "TEST AES/GCM cipher modification",
-                         test_gcm_cipher_modification))
+  if (NULL == CU_add_test(suite, "TEST AES/GCM cipher modification",
+                          test_gcm_cipher_modification))
   {
     return 1;
   }
 
-  if(NULL == CU_add_test(suite, "Test AES/GCM parameter limits",
-                         test_gcm_parameter_limits))
+  if (NULL == CU_add_test(suite, "Test AES/GCM parameter limits",
+                          test_gcm_parameter_limits))
   {
     return 1;
   }
@@ -61,24 +61,24 @@ int aes_gcm_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_gcm_encrypt_decrypt(void)
 {
-  unsigned char* key        = NULL;
-  unsigned char* plaintext  = NULL;
-  unsigned char* ciphertext = NULL;
-  unsigned char* decrypt    = NULL;
+  unsigned char *key = NULL;
+  unsigned char *plaintext = NULL;
+  unsigned char *ciphertext = NULL;
+  unsigned char *decrypt = NULL;
 
   int key_len = 16;
   size_t plaintext_len = 16;
   size_t ciphertext_len = 0;
   size_t decrypt_len = 0;
-  
+
   key = calloc(key_len, 1);
   plaintext = calloc(plaintext_len, 1);
-  
+
   CU_ASSERT(aes_gcm_encrypt(key, key_len, plaintext,
-            plaintext_len, &ciphertext, &ciphertext_len) == 0);
+                            plaintext_len, &ciphertext, &ciphertext_len) == 0);
   CU_ASSERT(ciphertext_len == plaintext_len + GCM_IV_LEN + GCM_TAG_LEN);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, ciphertext,
-            ciphertext_len, &decrypt, &decrypt_len) == 0);
+                            ciphertext_len, &decrypt, &decrypt_len) == 0);
   CU_ASSERT(decrypt_len == plaintext_len);
   CU_ASSERT(memcmp(plaintext, decrypt, plaintext_len) == 0);
 
@@ -92,10 +92,10 @@ void test_gcm_encrypt_decrypt(void)
 
 void test_gcm_key_modification(void)
 {
-  unsigned char* key        = NULL;
-  unsigned char* plaintext  = NULL;
-  unsigned char* ciphertext = NULL;
-  unsigned char* decrypt    = NULL;
+  unsigned char *key = NULL;
+  unsigned char *plaintext = NULL;
+  unsigned char *ciphertext = NULL;
+  unsigned char *decrypt = NULL;
 
   int key_len = 16;
   size_t plaintext_len = 16;
@@ -126,19 +126,19 @@ void test_gcm_key_modification(void)
   free(ciphertext);
   free(key);
 }
-	    
+
 void test_gcm_tag_modification(void)
 {
-  unsigned char* key        = NULL;
-  unsigned char* plaintext  = NULL;
-  unsigned char* ciphertext = NULL;
-  unsigned char* decrypt    = NULL;
+  unsigned char *key = NULL;
+  unsigned char *plaintext = NULL;
+  unsigned char *ciphertext = NULL;
+  unsigned char *decrypt = NULL;
 
   int key_len = 16;
   size_t plaintext_len = 16;
   size_t ciphertext_len = 0;
   size_t decrypt_len = 0;
-  
+
   key = calloc(key_len, 1);
   plaintext = calloc(plaintext_len, 1);
 
@@ -153,18 +153,18 @@ void test_gcm_tag_modification(void)
   decrypt_len = 0;
 
   // truncate tag by 2 bytes (pass wrong length) and verify decryption failure
-  CU_ASSERT(aes_gcm_decrypt(key, key_len, ciphertext, ciphertext_len-2,
+  CU_ASSERT(aes_gcm_decrypt(key, key_len, ciphertext, ciphertext_len - 2,
                             &decrypt, &decrypt_len) == 1);
   decrypt_len = 0;
   decrypt = NULL;
-  
+
   // alter last byte of tag (pass correct length) and verify decryption failure
-  ciphertext[ciphertext_len-1] ^= 0x1;
+  ciphertext[ciphertext_len - 1] ^= 0x1;
   CU_ASSERT(aes_gcm_decrypt(key, key_len, ciphertext, ciphertext_len,
                             &decrypt, &decrypt_len) == 1);
   decrypt_len = 0;
   decrypt = NULL;
- 
+
   free(key);
   free(plaintext);
   free(ciphertext);
@@ -172,16 +172,16 @@ void test_gcm_tag_modification(void)
 
 void test_gcm_iv_modification(void)
 {
-  unsigned char* key        = NULL;
-  unsigned char* plaintext  = NULL;
-  unsigned char* ciphertext = NULL;
-  unsigned char* decrypt    = NULL;
+  unsigned char *key = NULL;
+  unsigned char *plaintext = NULL;
+  unsigned char *ciphertext = NULL;
+  unsigned char *decrypt = NULL;
 
   int key_len = 16;
   size_t plaintext_len = 16;
   size_t ciphertext_len = 0;
   size_t decrypt_len = 0;
-  
+
   key = calloc(key_len, 1);
   plaintext = calloc(plaintext_len, 1);
 
@@ -196,10 +196,12 @@ void test_gcm_iv_modification(void)
   decrypt_len = 0;
 
   // truncate the IV and verify decryption failure
-  unsigned char* truncated_iv_cipher = ciphertext + 2;
-  CU_ASSERT(aes_gcm_decrypt(key, key_len, truncated_iv_cipher, ciphertext_len-2,
-                            &decrypt, &decrypt_len) == 1);
- 
+  unsigned char *truncated_iv_cipher = ciphertext + 2;
+
+  CU_ASSERT(aes_gcm_decrypt
+            (key, key_len, truncated_iv_cipher, ciphertext_len - 2, &decrypt,
+             &decrypt_len) == 1);
+
   decrypt = NULL;
   decrypt_len = 0;
 
@@ -215,16 +217,16 @@ void test_gcm_iv_modification(void)
 
 void test_gcm_cipher_modification(void)
 {
-  unsigned char* key        = NULL;
-  unsigned char* plaintext  = NULL;
-  unsigned char* ciphertext = NULL;
-  unsigned char* decrypt    = NULL;
+  unsigned char *key = NULL;
+  unsigned char *plaintext = NULL;
+  unsigned char *ciphertext = NULL;
+  unsigned char *decrypt = NULL;
 
   int key_len = 16;
   size_t plaintext_len = 16;
   size_t ciphertext_len = 0;
   size_t decrypt_len = 0;
-  
+
   key = calloc(key_len, 1);
   plaintext = calloc(plaintext_len, 1);
 
@@ -241,8 +243,8 @@ void test_gcm_cipher_modification(void)
   // modify first byte of ciphertext and verify decryption failure
   ciphertext[GCM_IV_LEN] ^= 0x1;
   CU_ASSERT(aes_gcm_decrypt(key, key_len, ciphertext, ciphertext_len,
-            &decrypt, &decrypt_len) == 1);
-  
+                            &decrypt, &decrypt_len) == 1);
+
   free(key);
   free(plaintext);
   free(ciphertext);
@@ -250,20 +252,21 @@ void test_gcm_cipher_modification(void)
 
 void test_gcm_parameter_limits(void)
 {
-  unsigned char* key     = NULL;
-  unsigned char* inData  = NULL;
-  unsigned char* outData = NULL;
-  
+  unsigned char *key = NULL;
+  unsigned char *inData = NULL;
+  unsigned char *outData = NULL;
+
   // check that null keys produce an error
-  int    key_len     = 16;
-  size_t inData_len  = 16;
+  int key_len = 16;
+  size_t inData_len = 16;
   size_t outData_len = 0;
+
   inData = malloc(inData_len);
   CU_ASSERT(inData != NULL);
   CU_ASSERT(aes_gcm_encrypt(key, key_len, inData, inData_len,
-            &outData, &outData_len) == 1);
+                            &outData, &outData_len) == 1);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
-            &outData, &outData_len) == 1);
+                            &outData, &outData_len) == 1);
 
   // check that zero length keys produce an error
   key = malloc(key_len);
@@ -282,7 +285,7 @@ void test_gcm_parameter_limits(void)
                             &outData, &outData_len) == 1);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
                             &outData, &outData_len) == 1);
-  
+
   // check that an input data length being too short produces an error
   inData_len = 32;
   inData = malloc(inData_len);
@@ -300,7 +303,7 @@ void test_gcm_parameter_limits(void)
   inData_len += 1;
   key_len = 12;
   CU_ASSERT(aes_gcm_encrypt(key, key_len, inData, inData_len,
-            &outData, &outData_len) == 1);
+                            &outData, &outData_len) == 1);
   CU_ASSERT(aes_gcm_decrypt(key, key_len, inData, inData_len,
                             &outData, &outData_len) == 1);
 }

--- a/tpm2/test/src/kmyth-test.c
+++ b/tpm2/test/src/kmyth-test.c
@@ -26,68 +26,78 @@
 /**
  * Use trivial (do nothing) init_suite and clean_suite functionality
  */
-int init_suite(void) { return 0; }
-int clean_suite(void) { return 0; }
+int init_suite(void)
+{
+  return 0;
+}
 
+int clean_suite(void)
+{
+  return 0;
+}
 
 //----------------------------------------------------------------------------
 // main() - kmyth unit test suites created, populated, and run here
 //----------------------------------------------------------------------------
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   // Initialize CUnit test registry
   if (CUE_SUCCESS != CU_initialize_registry())
   {
     return CU_get_error();
   }
-  
+
   // Create and configure File I/O utility test suite
   CU_pSuite file_io_utility_test_suite = NULL;
+
   file_io_utility_test_suite = CU_add_suite("File I/O Utility Test Suite",
-                                             init_suite, clean_suite);
+                                            init_suite, clean_suite);
   if (NULL == file_io_utility_test_suite)
   {
     CU_cleanup_registry();
-    return CU_get_error(); 
+    return CU_get_error();
   }
   if (file_io_add_tests(file_io_utility_test_suite))
   {
     CU_cleanup_registry();
-    return CU_get_error(); 
+    return CU_get_error();
   }
 
   // Create and configure kmyth memory utility test suite
   CU_pSuite memory_utility_test_suite = NULL;
+
   memory_utility_test_suite = CU_add_suite("Memory Utility Test Suite",
-                                             init_suite, clean_suite);
+                                           init_suite, clean_suite);
   if (NULL == memory_utility_test_suite)
   {
     CU_cleanup_registry();
-    return CU_get_error(); 
+    return CU_get_error();
   }
   if (memory_util_add_tests(memory_utility_test_suite))
   {
     CU_cleanup_registry();
-    return CU_get_error(); 
+    return CU_get_error();
   }
 
-	// Create and configure storage key tools test suite
-	CU_pSuite storage_key_tools_test_suite = NULL;
-	storage_key_tools_test_suite = CU_add_suite("Storage Key Tools Test Suite",
-                                               init_suite, clean_suite);
-	if (NULL == storage_key_tools_test_suite)
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
-	if (storage_key_tools_add_tests(storage_key_tools_test_suite))
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
+  // Create and configure storage key tools test suite
+  CU_pSuite storage_key_tools_test_suite = NULL;
+
+  storage_key_tools_test_suite = CU_add_suite("Storage Key Tools Test Suite",
+                                              init_suite, clean_suite);
+  if (NULL == storage_key_tools_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if (storage_key_tools_add_tests(storage_key_tools_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
 
   // Create and configure TPM object tools test suite
   CU_pSuite object_tools_test_suite = NULL;
+
   object_tools_test_suite = CU_add_suite("TPM Object Tools Test Suite",
                                          init_suite, clean_suite);
   if (NULL == object_tools_test_suite)
@@ -101,23 +111,25 @@ int main(int argc, char** argv)
     return CU_get_error();
   }
 
-	// Create and configure TPM formatting tools test suite
-	CU_pSuite formatting_tools_test_suite = NULL;
-	formatting_tools_test_suite = CU_add_suite("TPM Formatting Tools Test Suite",
+  // Create and configure TPM formatting tools test suite
+  CU_pSuite formatting_tools_test_suite = NULL;
+
+  formatting_tools_test_suite = CU_add_suite("TPM Formatting Tools Test Suite",
                                              init_suite, clean_suite);
-	if (NULL == formatting_tools_test_suite)
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
-	if (formatting_tools_add_tests(formatting_tools_test_suite))
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
+  if (NULL == formatting_tools_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if (formatting_tools_add_tests(formatting_tools_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
 
   // Create and configure TLS utility test suite
   CU_pSuite tls_utility_test_suite = NULL;
+
   tls_utility_test_suite = CU_add_suite("TLS Utility Test Suite",
                                         init_suite, clean_suite);
   if (NULL == tls_utility_test_suite)
@@ -133,47 +145,50 @@ int main(int argc, char** argv)
 
   // Create and configure the AES/GCM cipher test suite
   CU_pSuite aes_gcm_test_suite = NULL;
+
   aes_gcm_test_suite = CU_add_suite("AES/GCM Cipher Test Suite",
-				                            init_suite, clean_suite);
+                                    init_suite, clean_suite);
   if (NULL == aes_gcm_test_suite)
   {
     CU_cleanup_registry();
     return CU_get_error();
   }
-  if(aes_gcm_add_tests(aes_gcm_test_suite))
+  if (aes_gcm_add_tests(aes_gcm_test_suite))
   {
     CU_cleanup_registry();
     return CU_get_error();
   }
 
-	// Create and configure the tpm2 interface test suite
-	CU_pSuite tpm2_interface_test_suite = NULL;
-	tpm2_interface_test_suite = CU_add_suite("TPM2 Interface Test Suite",
-                                           init_suite, clean_suite);
-	if (NULL == tpm2_interface_test_suite)
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
-	if(tpm2_interface_add_tests(tpm2_interface_test_suite))
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
+  // Create and configure the tpm2 interface test suite
+  CU_pSuite tpm2_interface_test_suite = NULL;
 
-	// Create and configure pcrs test suite
-	CU_pSuite pcrs_test_suite = NULL;
-	pcrs_test_suite = CU_add_suite("PCRs Test Suite", init_suite, clean_suite);
-	if (NULL == pcrs_test_suite)
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
-	if (pcrs_add_tests(pcrs_test_suite))
-	{
-		CU_cleanup_registry();
-		return CU_get_error();
-	}
+  tpm2_interface_test_suite = CU_add_suite("TPM2 Interface Test Suite",
+                                           init_suite, clean_suite);
+  if (NULL == tpm2_interface_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if (tpm2_interface_add_tests(tpm2_interface_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+
+  // Create and configure pcrs test suite
+  CU_pSuite pcrs_test_suite = NULL;
+
+  pcrs_test_suite = CU_add_suite("PCRs Test Suite", init_suite, clean_suite);
+  if (NULL == pcrs_test_suite)
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
+  if (pcrs_add_tests(pcrs_test_suite))
+  {
+    CU_cleanup_registry();
+    return CU_get_error();
+  }
 
   // Run tests using basic interface
   CU_basic_run_tests();

--- a/tpm2/test/src/tpm/formatting_tools_test.c
+++ b/tpm2/test/src/tpm/formatting_tools_test.c
@@ -4,7 +4,6 @@
 // Tests for TPM 2.0 object utility functions in tpm2/src/tpm/formatting_tools.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -13,7 +12,7 @@
 #include "formatting_tools.h"
 #include "defines.h"
 
-const char* CONST_SKI_BYTES = "\
+const char *CONST_SKI_BYTES = "\
 -----PCR SELECTION LIST-----\n\
 AAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
@@ -47,66 +46,76 @@ lYUkqJ/V5ZBlLek/ufMxMg==\n\
 j53ixEuUSZcgOBkv9bSQkH1WXo7IWKsMP/XfevBjYhl/RBAmxpZeXLao2uCA8cc=\n\
 -----FILE END-----\n";
 
-const char* RAW_PCR64 = "AAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
+const char *RAW_PCR64 =
+  "AAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n";
 
 const size_t RAW_PCR_LEN = 132;
-uint8_t RAW_PCR[] = {0, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0};
+
+uint8_t RAW_PCR[] = { 0, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0
+};
 
 //----------------------------------------------------------------------------
 // formatting_tools_add_tests()
 //----------------------------------------------------------------------------
 int formatting_tools_add_tests(CU_pSuite suite)
 {
-	if (NULL == CU_add_test(suite, "parse_ski_bytes() Tests", test_parse_ski_bytes))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "parse_ski_bytes() Tests", test_parse_ski_bytes))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "create_ski_bytes() Tests", test_create_ski_bytes))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "create_ski_bytes() Tests", test_create_ski_bytes))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "free_ski() Tests", test_free_ski))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "free_ski() Tests", test_free_ski))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "get_default_ski() Tests", test_get_default_ski))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "get_default_ski() Tests", test_get_default_ski))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "get_ski_block_bytes() Tests", test_get_ski_block_bytes))
-	{
-		return 1;
-	}
-	if (NULL == CU_add_test(suite, "encodeBase64Data() Tests", test_encodeBase64Data))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "get_ski_block_bytes() Tests",
+                  test_get_ski_block_bytes))
+  {
+    return 1;
+  }
+  if (NULL ==
+      CU_add_test(suite, "encodeBase64Data() Tests", test_encodeBase64Data))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "decodeBase64Data() Tests", test_decodeBase64Data))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "decodeBase64Data() Tests", test_decodeBase64Data))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "concat() Tests", test_concat))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "concat() Tests", test_concat))
+  {
+    return 1;
+  }
 
-	return 0;
+  return 0;
 }
 
 //----------------------------------------------------------------------------
@@ -114,73 +123,74 @@ int formatting_tools_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_parse_ski_bytes(void)
 {
-	size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
+  size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
 
-	uint8_t* ski_bytes = malloc(ski_bytes_len*sizeof(char));
-	memcpy(ski_bytes, CONST_SKI_BYTES, ski_bytes_len);
+  uint8_t *ski_bytes = malloc(ski_bytes_len * sizeof(char));
 
-	Ski output = get_default_ski();
+  memcpy(ski_bytes, CONST_SKI_BYTES, ski_bytes_len);
 
-	//Valid ski test	
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  Ski output = get_default_ski();
 
-	//NULL or invalid input
-	CU_ASSERT(parse_ski_bytes(NULL, ski_bytes_len, &output) == 1);
-	CU_ASSERT(parse_ski_bytes(ski_bytes, 0, &output) == 1);
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len-1, &output) == 1);
+  //Valid ski test  
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	/////////
-	//Invalid delims:
-	////////
-	
-	//PCR_SELECTION_LIST, indices 0-28
-	ski_bytes[0] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[0] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //NULL or invalid input
+  CU_ASSERT(parse_ski_bytes(NULL, ski_bytes_len, &output) == 1);
+  CU_ASSERT(parse_ski_bytes(ski_bytes, 0, &output) == 1);
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len - 1, &output) == 1);
 
-	//STORAGE_KEY_PUBLIC, indices 208-236
-	ski_bytes[208] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[208] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  /////////
+  //Invalid delims:
+  ////////
 
-	//STORAGE_KEY_PRIVATE, indices 668-701
-	ski_bytes[668] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[668] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //PCR_SELECTION_LIST, indices 0-28
+  ski_bytes[0] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[0] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	//CIPHER_SUITE, indices 1052-1074
-	ski_bytes[1052] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[1052] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //STORAGE_KEY_PUBLIC, indices 208-236
+  ski_bytes[208] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[208] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	//SYM_KEY_PUBLIC, indices 1097-1121
-	ski_bytes[1097] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[1097] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //STORAGE_KEY_PRIVATE, indices 668-701
+  ski_bytes[668] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[668] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	//SYM_KEY_PRIVATE, indices 1232-1261
-	ski_bytes[1232] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[1232] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //CIPHER_SUITE, indices 1052-1074
+  ski_bytes[1052] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[1052] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	//ENC_DATA, indices 1482-1500
-	ski_bytes[1482] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[1482] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  //SYM_KEY_PUBLIC, indices 1097-1121
+  ski_bytes[1097] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[1097] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
 
-	//END_FILE, indices 1566-1584
-	ski_bytes[1566] = '!';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
-	ski_bytes[1566] = '-';
-	CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
-	free(ski_bytes);
+  //SYM_KEY_PRIVATE, indices 1232-1261
+  ski_bytes[1232] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[1232] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+
+  //ENC_DATA, indices 1482-1500
+  ski_bytes[1482] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[1482] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+
+  //END_FILE, indices 1566-1584
+  ski_bytes[1566] = '!';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 1);
+  ski_bytes[1566] = '-';
+  CU_ASSERT(parse_ski_bytes(ski_bytes, ski_bytes_len, &output) == 0);
+  free(ski_bytes);
 }
 
 //----------------------------------------------------------------------------
@@ -188,95 +198,98 @@ void test_parse_ski_bytes(void)
 //----------------------------------------------------------------------------
 void test_create_ski_bytes(void)
 {
-	size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
+  size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
 
-	Ski ski = get_default_ski();
+  Ski ski = get_default_ski();
 
-	parse_ski_bytes((uint8_t*)CONST_SKI_BYTES, ski_bytes_len, &ski); //get valid ski struct
+  parse_ski_bytes((uint8_t *) CONST_SKI_BYTES, ski_bytes_len, &ski);  //get valid ski struct
 
-	//Valid ski struct test
-	uint8_t* sb = NULL;
-	size_t sb_len = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	CU_ASSERT(sb_len == ski_bytes_len);
-	CU_ASSERT(memcmp(sb, CONST_SKI_BYTES, sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  //Valid ski struct test
+  uint8_t *sb = NULL;
+  size_t sb_len = 0;
 
-	//Modify internals of ski to find failures
-	int orig = ski.sk_pub.size;
-	ski.sk_pub.size = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.sk_pub.size = orig;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  CU_ASSERT(sb_len == ski_bytes_len);
+  CU_ASSERT(memcmp(sb, CONST_SKI_BYTES, sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
 
-	orig = ski.sk_priv.size;
-	ski.sk_priv.size = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.sk_priv.size = orig;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  //Modify internals of ski to find failures
+  int orig = ski.sk_pub.size;
 
-	orig = ski.wk_pub.size;
-	ski.wk_pub.size = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.wk_pub.size = orig;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  ski.sk_pub.size = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.sk_pub.size = orig;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
 
-	orig = ski.wk_priv.size;
-	ski.wk_priv.size = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.wk_priv.size = orig;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  orig = ski.sk_priv.size;
+  ski.sk_priv.size = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.sk_priv.size = orig;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
 
-	orig = ski.enc_data_size;
-	ski.enc_data_size = 0;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.enc_data_size = orig;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
+  orig = ski.wk_pub.size;
+  ski.wk_pub.size = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.wk_pub.size = orig;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
 
-	uint8_t* data = malloc(ski.enc_data_size);
-	memcpy(data, ski.enc_data, ski.enc_data_size);
-	ski.enc_data = NULL;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
-	ski.enc_data = data;
-	CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);	
-	free(sb);
-	sb = NULL;
-	sb_len = 0;
-	free_ski(&ski);
+  orig = ski.wk_priv.size;
+  ski.wk_priv.size = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.wk_priv.size = orig;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
 
-	//Valid ski that has empty/NULL cannot be used
-	CU_ASSERT(create_ski_bytes(get_default_ski(), &sb, &sb_len) == 1);
-	CU_ASSERT(sb == NULL);
-	CU_ASSERT(sb_len == 0);
+  orig = ski.enc_data_size;
+  ski.enc_data_size = 0;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.enc_data_size = orig;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
+
+  uint8_t *data = malloc(ski.enc_data_size);
+
+  memcpy(data, ski.enc_data, ski.enc_data_size);
+  ski.enc_data = NULL;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
+  ski.enc_data = data;
+  CU_ASSERT(create_ski_bytes(ski, &sb, &sb_len) == 0);
+  free(sb);
+  sb = NULL;
+  sb_len = 0;
+  free_ski(&ski);
+
+  //Valid ski that has empty/NULL cannot be used
+  CU_ASSERT(create_ski_bytes(get_default_ski(), &sb, &sb_len) == 1);
+  CU_ASSERT(sb == NULL);
+  CU_ASSERT(sb_len == 0);
 }
 
 //----------------------------------------------------------------------------
@@ -284,15 +297,16 @@ void test_create_ski_bytes(void)
 //----------------------------------------------------------------------------
 void test_free_ski(void)
 {
-	size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
-	Ski ski = get_default_ski();
-	parse_ski_bytes((uint8_t*)CONST_SKI_BYTES, ski_bytes_len, &ski); //get valid ski struct
+  size_t ski_bytes_len = strlen(CONST_SKI_BYTES);
+  Ski ski = get_default_ski();
 
-	CU_ASSERT(ski.enc_data != NULL);
-	CU_ASSERT(ski.enc_data_size > 0);
-	free_ski(&ski);
-	CU_ASSERT(ski.enc_data == NULL);
-	CU_ASSERT(ski.enc_data_size == 0);
+  parse_ski_bytes((uint8_t *) CONST_SKI_BYTES, ski_bytes_len, &ski);  //get valid ski struct
+
+  CU_ASSERT(ski.enc_data != NULL);
+  CU_ASSERT(ski.enc_data_size > 0);
+  free_ski(&ski);
+  CU_ASSERT(ski.enc_data == NULL);
+  CU_ASSERT(ski.enc_data_size == 0);
 }
 
 //----------------------------------------------------------------------------
@@ -300,14 +314,15 @@ void test_free_ski(void)
 //----------------------------------------------------------------------------
 void test_get_default_ski(void)
 {
-	Ski ski = get_default_ski();
-	CU_ASSERT(ski.pcr_list.count == 0);
-	CU_ASSERT(ski.sk_pub.size == 0);
-	CU_ASSERT(ski.sk_priv.size == 0);
-	CU_ASSERT(ski.wk_pub.size == 0);
-	CU_ASSERT(ski.wk_priv.size == 0);
-	CU_ASSERT(ski.enc_data == NULL);
-	CU_ASSERT(ski.enc_data_size == 0);
+  Ski ski = get_default_ski();
+
+  CU_ASSERT(ski.pcr_list.count == 0);
+  CU_ASSERT(ski.sk_pub.size == 0);
+  CU_ASSERT(ski.sk_priv.size == 0);
+  CU_ASSERT(ski.wk_pub.size == 0);
+  CU_ASSERT(ski.wk_priv.size == 0);
+  CU_ASSERT(ski.enc_data == NULL);
+  CU_ASSERT(ski.enc_data_size == 0);
 }
 
 //----------------------------------------------------------------------------
@@ -315,123 +330,120 @@ void test_get_default_ski(void)
 //----------------------------------------------------------------------------
 void test_get_ski_block_bytes(void)
 {
-	//NOTE: We do not test every required block here, because each specific 
-	//      block is tested in parse_ski_bytes.
+  //NOTE: We do not test every required block here, because each specific 
+  //      block is tested in parse_ski_bytes.
 
-	size_t sb_len = strlen(CONST_SKI_BYTES);
-	uint8_t* sb = malloc(sb_len*sizeof(char));
-	memcpy(sb, CONST_SKI_BYTES, sb_len);
+  size_t sb_len = strlen(CONST_SKI_BYTES);
+  uint8_t *sb = malloc(sb_len * sizeof(char));
 
-	uint8_t *position = sb;
-	size_t remaining = sb_len;
-	uint8_t *raw_pcr_select_list_data = NULL;
-	size_t raw_pcr_select_list_size = 0;
+  memcpy(sb, CONST_SKI_BYTES, sb_len);
 
-	//Valid parse test
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0);
-	CU_ASSERT(raw_pcr_select_list_size == strlen(RAW_PCR64));
-	CU_ASSERT(memcmp(raw_pcr_select_list_data, RAW_PCR64, raw_pcr_select_list_size) == 0);
-	free(raw_pcr_select_list_data);
-	raw_pcr_select_list_data = NULL;
+  uint8_t *position = sb;
+  size_t remaining = sb_len;
+  uint8_t *raw_pcr_select_list_data = NULL;
+  size_t raw_pcr_select_list_size = 0;
 
-	//Invalid first delim
-	position = sb;
-	remaining = sb_len;
-	raw_pcr_select_list_size = 0;
-	sb[0] = '!';
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
-	CU_ASSERT(raw_pcr_select_list_data == NULL);
-	CU_ASSERT(raw_pcr_select_list_size == 0);
+  //Valid parse test
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0);
+  CU_ASSERT(raw_pcr_select_list_size == strlen(RAW_PCR64));
+  CU_ASSERT(memcmp
+            (raw_pcr_select_list_data, RAW_PCR64,
+             raw_pcr_select_list_size) == 0);
+  free(raw_pcr_select_list_data);
+  raw_pcr_select_list_data = NULL;
 
-	position = sb;
-	remaining = sb_len;
-	sb[0] = '-';
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0)
-	free(raw_pcr_select_list_data);
-	raw_pcr_select_list_data = NULL;
+  //Invalid first delim
+  position = sb;
+  remaining = sb_len;
+  raw_pcr_select_list_size = 0;
+  sb[0] = '!';
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
+    CU_ASSERT(raw_pcr_select_list_data == NULL);
+  CU_ASSERT(raw_pcr_select_list_size == 0);
 
-	//Invalid second delim
-	position = sb;
-	remaining = sb_len;
-	raw_pcr_select_list_size = 0;
-	sb[208] = '!';
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
-	CU_ASSERT(raw_pcr_select_list_data == NULL);
-	CU_ASSERT(raw_pcr_select_list_size == 0);
+  position = sb;
+  remaining = sb_len;
+  sb[0] = '-';
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0)
+    free(raw_pcr_select_list_data);
+  raw_pcr_select_list_data = NULL;
 
-	position = sb;
-	remaining = sb_len;
-	sb[208] = '-';
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0)
-	free(raw_pcr_select_list_data);
-	raw_pcr_select_list_data = NULL;
+  //Invalid second delim
+  position = sb;
+  remaining = sb_len;
+  raw_pcr_select_list_size = 0;
+  sb[208] = '!';
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
+    CU_ASSERT(raw_pcr_select_list_data == NULL);
+  CU_ASSERT(raw_pcr_select_list_size == 0);
 
-	//Check to verify unexpected end of file
-	position = sb;
-	remaining = sb_len;
-	raw_pcr_select_list_size = 0;
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          remaining+1) == 1) //next_delim_len > remaining
-	CU_ASSERT(raw_pcr_select_list_data == NULL);
-	CU_ASSERT(raw_pcr_select_list_size == 0);
+  position = sb;
+  remaining = sb_len;
+  sb[208] = '-';
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 0)
+    free(raw_pcr_select_list_data);
+  raw_pcr_select_list_data = NULL;
 
-	//Test empty block
-	const char* empty_block = "-----PCR SELECTION LIST-----\n-----STORAGE KEY PUBLIC-----\n";
-	position = (uint8_t*)empty_block;
-	remaining = strlen(empty_block);;
-	raw_pcr_select_list_size = 0;
-	CU_ASSERT(get_ski_block_bytes((char **) &position,
-                          &remaining,
-                          &raw_pcr_select_list_data,
-                          &raw_pcr_select_list_size,
-                          KMYTH_DELIM_PCR_SELECTION_LIST,
-                          strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
-                          KMYTH_DELIM_STORAGE_KEY_PUBLIC,
-                          strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
-	CU_ASSERT(raw_pcr_select_list_data == NULL);
-	CU_ASSERT(raw_pcr_select_list_size == 0);
-	free(sb);
+  //Check to verify unexpected end of file
+  position = sb;
+  remaining = sb_len;
+  raw_pcr_select_list_size = 0;
+  CU_ASSERT(get_ski_block_bytes((char **) &position, &remaining, &raw_pcr_select_list_data, &raw_pcr_select_list_size, KMYTH_DELIM_PCR_SELECTION_LIST, strlen(KMYTH_DELIM_PCR_SELECTION_LIST), KMYTH_DELIM_STORAGE_KEY_PUBLIC, remaining + 1) == 1) //next_delim_len > remaining
+    CU_ASSERT(raw_pcr_select_list_data == NULL);
+  CU_ASSERT(raw_pcr_select_list_size == 0);
+
+  //Test empty block
+  const char *empty_block =
+    "-----PCR SELECTION LIST-----\n-----STORAGE KEY PUBLIC-----\n";
+  position = (uint8_t *) empty_block;
+  remaining = strlen(empty_block);;
+  raw_pcr_select_list_size = 0;
+  CU_ASSERT(get_ski_block_bytes((char **) &position,
+                                &remaining,
+                                &raw_pcr_select_list_data,
+                                &raw_pcr_select_list_size,
+                                KMYTH_DELIM_PCR_SELECTION_LIST,
+                                strlen(KMYTH_DELIM_PCR_SELECTION_LIST),
+                                KMYTH_DELIM_STORAGE_KEY_PUBLIC,
+                                strlen(KMYTH_DELIM_STORAGE_KEY_PUBLIC)) == 1)
+    CU_ASSERT(raw_pcr_select_list_data == NULL);
+  CU_ASSERT(raw_pcr_select_list_size == 0);
+  free(sb);
 }
 
 //----------------------------------------------------------------------------
@@ -439,53 +451,55 @@ void test_get_ski_block_bytes(void)
 //----------------------------------------------------------------------------
 void test_encodeBase64Data(void)
 {
-	uint8_t *pcr64 = NULL;
-	size_t pcr64_len = 0;
+  uint8_t *pcr64 = NULL;
+  size_t pcr64_len = 0;
 
-	//Test valid encode
-	CU_ASSERT(encodeBase64Data(RAW_PCR, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
-	CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
-	CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len)==0);
-	free(pcr64);
-	pcr64 = NULL;
-	pcr64_len = 0;
+  //Test valid encode
+  CU_ASSERT(encodeBase64Data(RAW_PCR, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
+  CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
+  CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len) == 0);
+  free(pcr64);
+  pcr64 = NULL;
+  pcr64_len = 0;
 
-	//Test empty input
-	CU_ASSERT(encodeBase64Data(NULL, RAW_PCR_LEN, &pcr64, &pcr64_len) == 1);
-	CU_ASSERT(encodeBase64Data(RAW_PCR, 0, &pcr64, &pcr64_len) == 1);
-	CU_ASSERT(pcr64 == NULL);
-	CU_ASSERT(pcr64_len == 0);
+  //Test empty input
+  CU_ASSERT(encodeBase64Data(NULL, RAW_PCR_LEN, &pcr64, &pcr64_len) == 1);
+  CU_ASSERT(encodeBase64Data(RAW_PCR, 0, &pcr64, &pcr64_len) == 1);
+  CU_ASSERT(pcr64 == NULL);
+  CU_ASSERT(pcr64_len == 0);
 
-	//Test different inputs don't produce the same base64 output
-	//First entry has a bit flipped
-	uint8_t wrong_pcr[] = {1, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0};
-	CU_ASSERT(encodeBase64Data(wrong_pcr, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
-	CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
-	CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len)!=0);
-	free(pcr64);
-	pcr64 = NULL;
-	pcr64_len = 0;
+  //Test different inputs don't produce the same base64 output
+  //First entry has a bit flipped
+  uint8_t wrong_pcr[] = { 1, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0
+  };
+  CU_ASSERT(encodeBase64Data(wrong_pcr, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
+  CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
+  CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len) != 0);
+  free(pcr64);
+  pcr64 = NULL;
+  pcr64_len = 0;
 
-	//Test that different length raw data results in different length base64
-	uint8_t short_pcr[] = {0, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                         0, 0, 0, 0};
-	CU_ASSERT(encodeBase64Data(short_pcr, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
-	CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
-	CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len)!=0);
+  //Test that different length raw data results in different length base64
+  uint8_t short_pcr[] = { 0, 0, 0, 1, 0, 11, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0
+  };
+  CU_ASSERT(encodeBase64Data(short_pcr, RAW_PCR_LEN, &pcr64, &pcr64_len) == 0);
+  CU_ASSERT(pcr64_len == strlen(RAW_PCR64));
+  CU_ASSERT(memcmp(pcr64, RAW_PCR64, pcr64_len) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -493,44 +507,49 @@ void test_encodeBase64Data(void)
 //----------------------------------------------------------------------------
 void test_decodeBase64Data(void)
 {
-	uint8_t *pcr = NULL;
-	size_t pcr_len = 0;
+  uint8_t *pcr = NULL;
+  size_t pcr_len = 0;
 
-	//Test valid decode
-	CU_ASSERT(decodeBase64Data((uint8_t*)RAW_PCR64, strlen(RAW_PCR64), &pcr, &pcr_len) == 0);
-	CU_ASSERT(pcr_len == RAW_PCR_LEN);
-	CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len)==0);
-	free(pcr);
-	pcr = NULL;
-	pcr_len = 0;
+  //Test valid decode
+  CU_ASSERT(decodeBase64Data
+            ((uint8_t *) RAW_PCR64, strlen(RAW_PCR64), &pcr, &pcr_len) == 0);
+  CU_ASSERT(pcr_len == RAW_PCR_LEN);
+  CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len) == 0);
+  free(pcr);
+  pcr = NULL;
+  pcr_len = 0;
 
-	//Test invalid input
-	CU_ASSERT(decodeBase64Data(NULL, strlen(RAW_PCR64), &pcr, &pcr_len) == 1);
-	CU_ASSERT(decodeBase64Data((uint8_t*)RAW_PCR64, 0, &pcr, &pcr_len) == 1)
+  //Test invalid input
+  CU_ASSERT(decodeBase64Data(NULL, strlen(RAW_PCR64), &pcr, &pcr_len) == 1);
+  CU_ASSERT(decodeBase64Data((uint8_t *) RAW_PCR64, 0, &pcr, &pcr_len) == 1)
+    //INT_MAX+1
+    CU_ASSERT(decodeBase64Data
+              ((uint8_t *) RAW_PCR64, -2147483648, &pcr, &pcr_len) == 1);
+  CU_ASSERT(pcr == NULL);
+  CU_ASSERT(pcr_len == 0);
 
-																								  //INT_MAX+1
-	CU_ASSERT(decodeBase64Data((uint8_t*)RAW_PCR64, -2147483648, &pcr, &pcr_len) == 1);
-	CU_ASSERT(pcr == NULL);
-	CU_ASSERT(pcr_len == 0);
-
-	//Test that different input decodes to different output
-	char* modified = "BAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
+  //Test that different input decodes to different output
+  char *modified =
+    "BAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n";
-	CU_ASSERT(decodeBase64Data((uint8_t*)modified, strlen(modified), &pcr, &pcr_len) == 0);
-	CU_ASSERT(pcr_len == RAW_PCR_LEN);
-	CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len)!=0);
-	free(pcr);
-	pcr = NULL;
-	pcr_len = 0;
+  CU_ASSERT(decodeBase64Data
+            ((uint8_t *) modified, strlen(modified), &pcr, &pcr_len) == 0);
+  CU_ASSERT(pcr_len == RAW_PCR_LEN);
+  CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len) != 0);
+  free(pcr);
+  pcr = NULL;
+  pcr_len = 0;
 
-	//Test that different length base64 result in different length raw data
-	char* shorter = "BAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
+  //Test that different length base64 result in different length raw data
+  char *shorter =
+    "BAAAAQALAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n";
-	CU_ASSERT(decodeBase64Data((uint8_t*)shorter, strlen(shorter), &pcr, &pcr_len) == 0);
-	CU_ASSERT(pcr_len != RAW_PCR_LEN);
-	CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len)!=0);
-	free(pcr);
+  CU_ASSERT(decodeBase64Data
+            ((uint8_t *) shorter, strlen(shorter), &pcr, &pcr_len) == 0);
+  CU_ASSERT(pcr_len != RAW_PCR_LEN);
+  CU_ASSERT(memcmp(pcr, RAW_PCR, pcr_len) != 0);
+  free(pcr);
 }
 
 //----------------------------------------------------------------------------
@@ -538,38 +557,39 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n";
 //----------------------------------------------------------------------------
 void test_concat(void)
 {
-	uint8_t* green = (uint8_t*)"green";
-	size_t green_len = 5;
-	uint8_t* chile = (uint8_t*)"chile";
-	size_t chile_len = 5;
-	uint8_t* result = (uint8_t*)"greenchile";
-	size_t result_len = 10;
+  uint8_t *green = (uint8_t *) "green";
+  size_t green_len = 5;
+  uint8_t *chile = (uint8_t *) "chile";
+  size_t chile_len = 5;
+  uint8_t *result = (uint8_t *) "greenchile";
+  size_t result_len = 10;
 
-	size_t dest_len = green_len;
-	uint8_t* dest = malloc(dest_len);
-	memcpy(dest, green, dest_len);
+  size_t dest_len = green_len;
+  uint8_t *dest = malloc(dest_len);
 
-	//Test valid concat
-	CU_ASSERT(concat(&dest, &dest_len, chile, chile_len) == 0);
-	CU_ASSERT(result_len == dest_len);
-	CU_ASSERT(memcmp(dest, result, dest_len) == 0);
+  memcpy(dest, green, dest_len);
 
-	//Test empty input
-	dest_len = green_len;
-	free(dest);
-	dest = malloc(dest_len);
-	memcpy(dest, green, dest_len);
+  //Test valid concat
+  CU_ASSERT(concat(&dest, &dest_len, chile, chile_len) == 0);
+  CU_ASSERT(result_len == dest_len);
+  CU_ASSERT(memcmp(dest, result, dest_len) == 0);
 
-	CU_ASSERT(concat(&dest, &dest_len, NULL, chile_len) == 0);
-	CU_ASSERT(green_len == dest_len);
-	CU_ASSERT(memcmp(dest, green, dest_len) == 0);
+  //Test empty input
+  dest_len = green_len;
+  free(dest);
+  dest = malloc(dest_len);
+  memcpy(dest, green, dest_len);
 
-	CU_ASSERT(concat(&dest, &dest_len, chile, 0) == 0);
-	CU_ASSERT(green_len == dest_len);
-	CU_ASSERT(memcmp(dest, green, dest_len) == 0);
+  CU_ASSERT(concat(&dest, &dest_len, NULL, chile_len) == 0);
+  CU_ASSERT(green_len == dest_len);
+  CU_ASSERT(memcmp(dest, green, dest_len) == 0);
 
-	//Test invalid input
-	//The -1 sould trigger overflows here:    if (new_dest_len < *dest_length)
-	CU_ASSERT(concat(&dest, &dest_len, chile, -1) == 1);
-	free(dest);
+  CU_ASSERT(concat(&dest, &dest_len, chile, 0) == 0);
+  CU_ASSERT(green_len == dest_len);
+  CU_ASSERT(memcmp(dest, green, dest_len) == 0);
+
+  //Test invalid input
+  //The -1 sould trigger overflows here:    if (new_dest_len < *dest_length)
+  CU_ASSERT(concat(&dest, &dest_len, chile, -1) == 1);
+  free(dest);
 }

--- a/tpm2/test/src/tpm/object_tools_test.c
+++ b/tpm2/test/src/tpm/object_tools_test.c
@@ -4,7 +4,6 @@
 // Tests for TPM 2.0 object utility functions in tpm2/src/tpm/object_tools.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -54,8 +53,8 @@ int object_tools_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_init_kmyth_object_sensitive(void)
 {
-  TPM2B_AUTH object_auth = {0};
-  TPM2B_SENSITIVE_CREATE sensitiveArea = {0};
+  TPM2B_AUTH object_auth = { 0 };
+  TPM2B_SENSITIVE_CREATE sensitiveArea = { 0 };
 
   // A null sensitive area should produce an error
   CU_ASSERT(init_kmyth_object_sensitive(object_auth, (uint8_t *) NULL, 0,
@@ -70,7 +69,7 @@ void test_init_kmyth_object_sensitive(void)
 
   // Non-empty object auth and data should yield a valid sensitive area
   object_auth.size = 4;
-  uint8_t object_data[] = {1, 2, 3, 4};
+  uint8_t object_data[] = { 1, 2, 3, 4 };
   size_t object_dataSize = 4;
 
   CU_ASSERT(init_kmyth_object_sensitive(object_auth, object_data,
@@ -89,17 +88,16 @@ void test_init_kmyth_object_sensitive(void)
 //----------------------------------------------------------------------------
 void test_init_kmyth_object_template(void)
 {
-  TPM2B_DIGEST emptyAuthPolicy = {0};
-  TPMT_PUBLIC pubArea = {0};
-  static const TPMT_PUBLIC emptyPubArea = {0};
+  TPM2B_DIGEST emptyAuthPolicy = { 0 };
+  TPMT_PUBLIC pubArea = { 0 };
+  static const TPMT_PUBLIC emptyPubArea = { 0 };
 
   // A null public area should produce an error
   CU_ASSERT(init_kmyth_object_template(false, emptyAuthPolicy,
                                        (TPMT_PUBLIC *) NULL) == 1);
 
   // An object template for a non-key should be initialized in a certain way
-  CU_ASSERT(init_kmyth_object_template(false, emptyAuthPolicy,
-                                       &pubArea) == 0);
+  CU_ASSERT(init_kmyth_object_template(false, emptyAuthPolicy, &pubArea) == 0);
   CU_ASSERT(pubArea.type == KMYTH_DATA_PUBKEY_ALG);
   CU_ASSERT(pubArea.nameAlg == KMYTH_HASH_ALG);
   CU_ASSERT(pubArea.authPolicy.size == 0);
@@ -107,7 +105,7 @@ void test_init_kmyth_object_template(void)
   // An object template for a key should be initialized in a certain way with
   // a non-empty auth policy
   pubArea = emptyPubArea;
-  TPM2B_DIGEST authPolicy = {.size = 4, .buffer = {1, 2, 3, 4}};
+  TPM2B_DIGEST authPolicy = {.size = 4,.buffer = {1, 2, 3, 4} };
   CU_ASSERT(init_kmyth_object_template(true, authPolicy, &pubArea) == 0);
   CU_ASSERT(pubArea.type == KMYTH_KEY_PUBKEY_ALG);
   CU_ASSERT(pubArea.nameAlg == KMYTH_HASH_ALG);
@@ -129,8 +127,7 @@ void test_init_kmyth_object_attributes(void)
   // The object attribute for a non-key should be initialized a certain way
   CU_ASSERT(init_kmyth_object_attributes(false, &objectAttrib) == 0);
   CU_ASSERT(objectAttrib == (TPMA_OBJECT_USERWITHAUTH |
-                             TPMA_OBJECT_FIXEDTPM |
-                             TPMA_OBJECT_FIXEDPARENT));
+                             TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT));
 
   // The object attribute for a key should be initialized a certain way
   CU_ASSERT(init_kmyth_object_attributes(true, &objectAttrib) == 0);
@@ -138,8 +135,7 @@ void test_init_kmyth_object_attributes(void)
                              TPMA_OBJECT_DECRYPT |
                              TPMA_OBJECT_SENSITIVEDATAORIGIN |
                              TPMA_OBJECT_USERWITHAUTH |
-                             TPMA_OBJECT_FIXEDTPM |
-                             TPMA_OBJECT_FIXEDPARENT));
+                             TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT));
 }
 
 //----------------------------------------------------------------------------
@@ -148,8 +144,8 @@ void test_init_kmyth_object_attributes(void)
 void test_init_kmyth_object_parameters(void)
 {
   TPMI_ALG_PUBLIC objectType = 0;
-  TPMU_PUBLIC_PARMS objectParams = {0};
-  static const TPMU_PUBLIC_PARMS emptyObjectParams = {0};
+  TPMU_PUBLIC_PARMS objectParams = { 0 };
+  static const TPMU_PUBLIC_PARMS emptyObjectParams = { 0 };
 
   // A null parameters object should produce an error
   CU_ASSERT(init_kmyth_object_parameters(objectType,
@@ -206,12 +202,11 @@ void test_init_kmyth_object_parameters(void)
 void test_init_kmyth_object_unique(void)
 {
   TPMI_ALG_PUBLIC objectType = 0;
-  TPMU_PUBLIC_ID objectUnique = {0};
-  static const TPMU_PUBLIC_ID emptyObjectUnique = {0};
+  TPMU_PUBLIC_ID objectUnique = { 0 };
+  static const TPMU_PUBLIC_ID emptyObjectUnique = { 0 };
 
   // A null unique object should produce an error
-  CU_ASSERT(init_kmyth_object_unique(objectType,
-                                     (TPMU_PUBLIC_ID *) NULL) == 1);
+  CU_ASSERT(init_kmyth_object_unique(objectType, (TPMU_PUBLIC_ID *) NULL) == 1);
 
   // An unrecognized object type should produce an error
   CU_ASSERT(init_kmyth_object_unique(objectType, &objectUnique) == 1);

--- a/tpm2/test/src/tpm/pcrs_test.c
+++ b/tpm2/test/src/tpm/pcrs_test.c
@@ -4,7 +4,6 @@
 // Tests for TPM 2.0 pcr utility functions in tpm2/src/tpm/pcrs.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -24,8 +23,7 @@ int pcrs_add_tests(CU_pSuite suite)
   {
     return 1;
   }
-  if (NULL == CU_add_test(suite, "get_pcr_count() Tests",
-                          test_get_pcr_count))
+  if (NULL == CU_add_test(suite, "get_pcr_count() Tests", test_get_pcr_count))
   {
     return 1;
   }
@@ -38,44 +36,46 @@ int pcrs_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_init_pcr_selection(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	bool emulator = true;
-	get_tpm2_impl_type(sapi_ctx, &emulator);
-	if(!emulator)
-	{
-		return;
-	}
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	int pcrs[2] = {};
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
+  init_tpm2_connection(&sapi_ctx);
+  bool emulator = true;
 
-	//No PCRs selected
-	CU_ASSERT(init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct) == 0);
+  get_tpm2_impl_type(sapi_ctx, &emulator);
+  if (!emulator)
+  {
+    return;
+  }
 
-	//One PCR selected
-	pcrs[0] = 5;
-	CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct) == 0);
+  int pcrs[2] = { };
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
 
-	//Multiple PCRS selected
-	pcrs[1] = 3;
-	CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct) == 0);
+  //No PCRs selected
+  CU_ASSERT(init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct) == 0);
 
-	//Invalid PCR selected
-	pcrs[0] = -3;
-	CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct) == 1);
+  //One PCR selected
+  pcrs[0] = 5;
+  CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct) == 0);
 
-	//Valid AND invalid PCRs
-	pcrs[0] = 2;
-	pcrs[1] = -4;
-	CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct) == 1);
+  //Multiple PCRS selected
+  pcrs[1] = 3;
+  CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct) == 0);
 
-	//Check for length 0 with non-NULL pcrs array
-	pcrs[1] = 3; //make all entries valid
-	CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 0, &pcrs_struct) == 1);
+  //Invalid PCR selected
+  pcrs[0] = -3;
+  CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct) == 1);
 
-	//NULL TPM context
-	CU_ASSERT(init_pcr_selection(NULL, pcrs, 2, &pcrs_struct) != 0);
+  //Valid AND invalid PCRs
+  pcrs[0] = 2;
+  pcrs[1] = -4;
+  CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct) == 1);
+
+  //Check for length 0 with non-NULL pcrs array
+  pcrs[1] = 3;                  //make all entries valid
+  CU_ASSERT(init_pcr_selection(sapi_ctx, pcrs, 0, &pcrs_struct) == 1);
+
+  //NULL TPM context
+  CU_ASSERT(init_pcr_selection(NULL, pcrs, 2, &pcrs_struct) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -83,20 +83,23 @@ void test_init_pcr_selection(void)
 //----------------------------------------------------------------------------
 void test_get_pcr_count(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	bool emulator = true;
-	get_tpm2_impl_type(sapi_ctx, &emulator);
-	if(!emulator)
-	{
-		return;
-	}
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	int count = 0;
-	//Valid get count
-	CU_ASSERT(get_pcr_count(sapi_ctx, &count) == 0);
-	CU_ASSERT(count > 0); //counts may vary per platform
+  init_tpm2_connection(&sapi_ctx);
+  bool emulator = true;
 
-	//Test NULL context
-	CU_ASSERT(get_pcr_count(NULL, &count) == 1);
+  get_tpm2_impl_type(sapi_ctx, &emulator);
+  if (!emulator)
+  {
+    return;
+  }
+
+  int count = 0;
+
+  //Valid get count
+  CU_ASSERT(get_pcr_count(sapi_ctx, &count) == 0);
+  CU_ASSERT(count > 0);         //counts may vary per platform
+
+  //Test NULL context
+  CU_ASSERT(get_pcr_count(NULL, &count) == 1);
 }

--- a/tpm2/test/src/tpm/storage_key_tools_test.c
+++ b/tpm2/test/src/tpm/storage_key_tools_test.c
@@ -4,7 +4,6 @@
 // Tests for TPM 2.0 storage key utility functions in tpm2/src/tpm/storage_key_tools.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -20,41 +19,41 @@
 //----------------------------------------------------------------------------
 int storage_key_tools_add_tests(CU_pSuite suite)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	bool emulator = true;
-	get_tpm2_impl_type(sapi_ctx, &emulator);
-	if(!emulator)
-	{
-		return 0;
-	}
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	if (NULL == CU_add_test(suite, "get_srk_handle() Tests",
-                          test_get_srk_handle))
-	{
-		return 1;
-	}
-	if (NULL == CU_add_test(suite, "get_existing_srk_handle() Tests",
+  init_tpm2_connection(&sapi_ctx);
+  bool emulator = true;
+
+  get_tpm2_impl_type(sapi_ctx, &emulator);
+  if (!emulator)
+  {
+    return 0;
+  }
+
+  if (NULL == CU_add_test(suite, "get_srk_handle() Tests", test_get_srk_handle))
+  {
+    return 1;
+  }
+  if (NULL == CU_add_test(suite, "get_existing_srk_handle() Tests",
                           test_get_existing_srk_handle))
-	{
-		return 1;
-	}
-	if (NULL == CU_add_test(suite, "check_if_srk() Tests",
-                          test_check_if_srk))
-	{
-		return 1;
-	}
-	if (NULL == CU_add_test(suite, "put_srk_into_persistent_storage() Tests",
+  {
+    return 1;
+  }
+  if (NULL == CU_add_test(suite, "check_if_srk() Tests", test_check_if_srk))
+  {
+    return 1;
+  }
+  if (NULL == CU_add_test(suite, "put_srk_into_persistent_storage() Tests",
                           test_put_srk_into_persistent_storage))
-	{
-		return 1;
-	}
-	if (NULL == CU_add_test(suite, "create_and_load_sk() Tests",
+  {
+    return 1;
+  }
+  if (NULL == CU_add_test(suite, "create_and_load_sk() Tests",
                           test_create_and_load_sk))
-	{
-		return 1;
-	}
-	return 0;
+  {
+    return 1;
+  }
+  return 0;
 }
 
 //----------------------------------------------------------------------------
@@ -62,18 +61,19 @@ int storage_key_tools_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_get_srk_handle(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	TPM2_HANDLE srk_handle = 0;
-	TPM2B_AUTH owner_auth = {.size=0,};
-	CU_ASSERT(get_srk_handle(sapi_ctx, &srk_handle, &owner_auth) == 0);
+  init_tpm2_connection(&sapi_ctx);
 
-	//NULL context
-	CU_ASSERT(get_srk_handle(NULL, &srk_handle, &owner_auth) != 0);
+  //Valid test
+  TPM2_HANDLE srk_handle = 0;
+  TPM2B_AUTH owner_auth = {.size = 0, };
+  CU_ASSERT(get_srk_handle(sapi_ctx, &srk_handle, &owner_auth) == 0);
 
-	free_tpm2_resources(&sapi_ctx);
+  //NULL context
+  CU_ASSERT(get_srk_handle(NULL, &srk_handle, &owner_auth) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -81,58 +81,63 @@ void test_get_srk_handle(void)
 //----------------------------------------------------------------------------
 void test_get_existing_srk_handle(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	TPM2_HANDLE srkHandle = 0;
-	TPM2_HANDLE next = 0;
-	CU_ASSERT(get_existing_srk_handle(sapi_ctx, &srkHandle, &next) == 0);
+  init_tpm2_connection(&sapi_ctx);
 
-	//NULL api
-	CU_ASSERT(get_existing_srk_handle(NULL, &srkHandle, &next) != 0);
+  //Valid test
+  TPM2_HANDLE srkHandle = 0;
+  TPM2_HANDLE next = 0;
 
-	free_tpm2_resources(&sapi_ctx);
+  CU_ASSERT(get_existing_srk_handle(sapi_ctx, &srkHandle, &next) == 0);
+
+  //NULL api
+  CU_ASSERT(get_existing_srk_handle(NULL, &srkHandle, &next) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
-
 
 //----------------------------------------------------------------------------
 // test_check_if_srk
 //----------------------------------------------------------------------------
 void test_check_if_srk(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test if srk
-	TPM2_HANDLE srk_handle = 0;
-	TPM2B_AUTH owner_auth = {.size=0,};
-	get_srk_handle(sapi_ctx, &srk_handle, &owner_auth);
-	bool is_srk = false;
-	CU_ASSERT(check_if_srk(sapi_ctx, srk_handle, &is_srk) == 0);
-	CU_ASSERT(is_srk);
+  init_tpm2_connection(&sapi_ctx);
 
-	//Valid test if not srk
-	TPM2B_AUTH obj_auth = {.size = 0, };
-	create_authVal(NULL, 0, &obj_auth);
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
-	TPM2B_DIGEST auth_policy = {.size=0,};
-	init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct);
-	create_policy_digest(sapi_ctx, pcrs_struct, &auth_policy);
-	TPM2B_PRIVATE sk_priv = {.size = 0,};
-	TPM2B_PUBLIC sk_pub = {.size = 0,};
-	TPM2_HANDLE sk_handle = 0;
-	create_and_load_sk(sapi_ctx, srk_handle, owner_auth, obj_auth, pcrs_struct, auth_policy, &sk_handle, &sk_priv, &sk_pub);
-	CU_ASSERT(check_if_srk(sapi_ctx, sk_handle, &is_srk) == 0);
-	CU_ASSERT(!is_srk);
+  //Valid test if srk
+  TPM2_HANDLE srk_handle = 0;
+  TPM2B_AUTH owner_auth = {.size = 0, };
+  get_srk_handle(sapi_ctx, &srk_handle, &owner_auth);
+  bool is_srk = false;
 
-	//Test invalid sk handle
-	CU_ASSERT(check_if_srk(sapi_ctx, TPM2_PERSISTENT_FIRST-1, &is_srk) != 0);
-	
-	//NULL sapi_context
-	CU_ASSERT(check_if_srk(NULL, srk_handle, &is_srk) != 0);
+  CU_ASSERT(check_if_srk(sapi_ctx, srk_handle, &is_srk) == 0);
+  CU_ASSERT(is_srk);
 
-	free_tpm2_resources(&sapi_ctx);
+  //Valid test if not srk
+  TPM2B_AUTH obj_auth = {.size = 0, };
+  create_authVal(NULL, 0, &obj_auth);
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
+  TPM2B_DIGEST auth_policy = {.size = 0, };
+  init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct);
+  create_policy_digest(sapi_ctx, pcrs_struct, &auth_policy);
+  TPM2B_PRIVATE sk_priv = {.size = 0, };
+  TPM2B_PUBLIC sk_pub = {.size = 0, };
+  TPM2_HANDLE sk_handle = 0;
+
+  create_and_load_sk(sapi_ctx, srk_handle, owner_auth, obj_auth, pcrs_struct,
+                     auth_policy, &sk_handle, &sk_priv, &sk_pub);
+  CU_ASSERT(check_if_srk(sapi_ctx, sk_handle, &is_srk) == 0);
+  CU_ASSERT(!is_srk);
+
+  //Test invalid sk handle
+  CU_ASSERT(check_if_srk(sapi_ctx, TPM2_PERSISTENT_FIRST - 1, &is_srk) != 0);
+
+  //NULL sapi_context
+  CU_ASSERT(check_if_srk(NULL, srk_handle, &is_srk) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -140,51 +145,53 @@ void test_check_if_srk(void)
 //----------------------------------------------------------------------------
 void test_put_srk_into_persistent_storage(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	TPM2B_AUTH auth = {.size=0,};
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//NULL context
-	CU_ASSERT(put_srk_into_persistent_storage(NULL, 0, auth) != 0);
+  init_tpm2_connection(&sapi_ctx);
+  TPM2B_AUTH auth = {.size = 0, };
 
-	//Valid test - load SRK into next available persistent handle, clear TPM
-	TPM2_HANDLE next = 0;
-	TPM2_HANDLE srk_handle = 0;
-	//Other tests will hvae already persisted the key
-	get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
-	TPM2_HANDLE old_srk = srk_handle;
-	srk_handle = next;
-	//Test for failure if we try to load at a location that is already in use
-	CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, old_srk, auth) != 0);
-	//Loading second copy of SRK at next available persistent handle should work
-	CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, srk_handle, auth) == 0);
-	TPM2B_AUTH emptyAuth = { .size = 0 };
-	TPM2B_NONCE emptyNonce = { .size = 0 };
-	TSS2L_SYS_AUTH_RESPONSE cmdRsp;
-	TSS2L_SYS_AUTH_COMMAND cmdAuth = {
-                                     .count = 1,
-                                     .auths = {{
-                                                 .sessionHandle = TPM2_RS_PW,
-                                                 .sessionAttributes = 0,
-                                                 .nonce = emptyNonce,
-                                                 .hmac = emptyAuth
-                                              }}
-                                   };
-	//Clear all persistent storage to remove SRK and make TPM2_PERSISTENT_FIRST available
-	Tss2_Sys_Clear(sapi_ctx, TPM2_RH_PLATFORM, &cmdAuth, &cmdRsp);
-	next = 0;
-	srk_handle = 0;
-	//Get the existing handle and verify it is 0
-	get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
-	CU_ASSERT(srk_handle == 0)
-	srk_handle = next;
-	//Load the srk
-	CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, srk_handle, auth) == 0);
-	get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
-	//Verify it has loaded correctly
-	CU_ASSERT(srk_handle == TPM2_PERSISTENT_FIRST);
+  //NULL context
+  CU_ASSERT(put_srk_into_persistent_storage(NULL, 0, auth) != 0);
 
-	free_tpm2_resources(&sapi_ctx);
+  //Valid test - load SRK into next available persistent handle, clear TPM
+  TPM2_HANDLE next = 0;
+  TPM2_HANDLE srk_handle = 0;
+
+  //Other tests will hvae already persisted the key
+  get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
+  TPM2_HANDLE old_srk = srk_handle;
+
+  srk_handle = next;
+  //Test for failure if we try to load at a location that is already in use
+  CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, old_srk, auth) != 0);
+  //Loading second copy of SRK at next available persistent handle should work
+  CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, srk_handle, auth) == 0);
+  TPM2B_AUTH emptyAuth = {.size = 0 };
+  TPM2B_NONCE emptyNonce = {.size = 0 };
+  TSS2L_SYS_AUTH_RESPONSE cmdRsp;
+
+  TSS2L_SYS_AUTH_COMMAND cmdAuth = {
+    .count = 1,
+    .auths = {{
+               .sessionHandle = TPM2_RS_PW,
+               .sessionAttributes = 0,
+               .nonce = emptyNonce,
+               .hmac = emptyAuth}}
+  };
+  //Clear all persistent storage to remove SRK and make TPM2_PERSISTENT_FIRST available
+  Tss2_Sys_Clear(sapi_ctx, TPM2_RH_PLATFORM, &cmdAuth, &cmdRsp);
+  next = 0;
+  srk_handle = 0;
+  //Get the existing handle and verify it is 0
+  get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
+  CU_ASSERT(srk_handle == 0) srk_handle = next;
+  //Load the srk
+  CU_ASSERT(put_srk_into_persistent_storage(sapi_ctx, srk_handle, auth) == 0);
+  get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
+  //Verify it has loaded correctly
+  CU_ASSERT(srk_handle == TPM2_PERSISTENT_FIRST);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -192,36 +199,40 @@ void test_put_srk_into_persistent_storage(void)
 //----------------------------------------------------------------------------
 void test_create_and_load_sk(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	TPM2_HANDLE srk_handle = 0;
-	TPM2B_AUTH owner_auth = {.size=0,};
-	get_srk_handle(sapi_ctx, &srk_handle, &owner_auth);
+  init_tpm2_connection(&sapi_ctx);
 
-	//Valid test
-	TPM2B_AUTH obj_auth = {.size = 0, };
-	create_authVal(NULL, 0, &obj_auth);
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
-	TPM2B_DIGEST auth_policy = {.size=0,};
-	init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct);
+  TPM2_HANDLE srk_handle = 0;
+  TPM2B_AUTH owner_auth = {.size = 0, };
+  get_srk_handle(sapi_ctx, &srk_handle, &owner_auth);
 
-	create_policy_digest(sapi_ctx, pcrs_struct, &auth_policy);
-	TPM2B_PRIVATE sk_priv = {.size = 0,};
-	TPM2B_PUBLIC sk_pub = {.size = 0,};
-	TPM2_HANDLE sk_handle = 0;
-	CU_ASSERT(create_and_load_sk(sapi_ctx, srk_handle, owner_auth, obj_auth,
-                               pcrs_struct, auth_policy, &sk_handle, &sk_priv, &sk_pub) == 0);
-	CU_ASSERT(sk_handle != 0);
-	CU_ASSERT(sk_handle != srk_handle);
+  //Valid test
+  TPM2B_AUTH obj_auth = {.size = 0, };
+  create_authVal(NULL, 0, &obj_auth);
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
+  TPM2B_DIGEST auth_policy = {.size = 0, };
+  init_pcr_selection(sapi_ctx, NULL, 0, &pcrs_struct);
 
-	//Invalid context
-	TPM2B_PRIVATE invalid_priv = {.size = 0,};
-	TPM2B_PUBLIC invalid_pub = {.size = 0,};
-	sk_handle = 0;
-	CU_ASSERT(create_and_load_sk(NULL, srk_handle, owner_auth, obj_auth,
-                               pcrs_struct, auth_policy, &sk_handle, &invalid_priv, &invalid_pub) != 0);
-	CU_ASSERT(sk_handle == 0 && invalid_priv.size == 0 && invalid_pub.size == 0);
+  create_policy_digest(sapi_ctx, pcrs_struct, &auth_policy);
+  TPM2B_PRIVATE sk_priv = {.size = 0, };
+  TPM2B_PUBLIC sk_pub = {.size = 0, };
+  TPM2_HANDLE sk_handle = 0;
 
-	free_tpm2_resources(&sapi_ctx);
+  CU_ASSERT(create_and_load_sk(sapi_ctx, srk_handle, owner_auth, obj_auth,
+                               pcrs_struct, auth_policy, &sk_handle, &sk_priv,
+                               &sk_pub) == 0);
+  CU_ASSERT(sk_handle != 0);
+  CU_ASSERT(sk_handle != srk_handle);
+
+  //Invalid context
+  TPM2B_PRIVATE invalid_priv = {.size = 0, };
+  TPM2B_PUBLIC invalid_pub = {.size = 0, };
+  sk_handle = 0;
+  CU_ASSERT(create_and_load_sk(NULL, srk_handle, owner_auth, obj_auth,
+                               pcrs_struct, auth_policy, &sk_handle,
+                               &invalid_priv, &invalid_pub) != 0);
+  CU_ASSERT(sk_handle == 0 && invalid_priv.size == 0 && invalid_pub.size == 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }

--- a/tpm2/test/src/tpm/tpm2_interface_test.c
+++ b/tpm2/test/src/tpm/tpm2_interface_test.c
@@ -4,7 +4,6 @@
 // Tests for TPM 2.0 interface functions in tpm2/src/tpm/tpm2_interface.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -19,119 +18,144 @@
 //----------------------------------------------------------------------------
 int tpm2_interface_add_tests(CU_pSuite suite)
 {
-	//We don't want to do any of the tpm2_interface tests if on hardware
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	bool emulator = true;
-	get_tpm2_impl_type(sapi_ctx, &emulator);
-	if(!emulator)
-	{
-		return(0);
-	}
-	if (NULL == CU_add_test(suite, "init_tpm2_connection() Tests", test_init_tpm2_connection))
-	{
-		return 1;
-	}
+  //We don't want to do any of the tpm2_interface tests if on hardware
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	if (NULL == CU_add_test(suite, "init_tcti_abrmd() Tests", test_init_tcti_abrmd))
-	{
-		return 1;
-	}
+  init_tpm2_connection(&sapi_ctx);
+  bool emulator = true;
 
-	if (NULL == CU_add_test(suite, "init_sapi() Tests", test_init_sapi))
-	{
-		return 1;
-	}
+  get_tpm2_impl_type(sapi_ctx, &emulator);
+  if (!emulator)
+  {
+    return (0);
+  }
+  if (NULL ==
+      CU_add_test(suite, "init_tpm2_connection() Tests",
+                  test_init_tpm2_connection))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "free_tpm2_resources() Tests", test_free_tpm2_resources))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "init_tcti_abrmd() Tests", test_init_tcti_abrmd))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "startup_tpm2() Tests", test_startup_tpm2))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "init_sapi() Tests", test_init_sapi))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "get_tpm2_properties() Tests", test_get_tpm2_properties))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "free_tpm2_resources() Tests",
+                  test_free_tpm2_resources))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "get_tpm2_impl_type() Tests", test_get_tpm2_impl_type))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "startup_tpm2() Tests", test_startup_tpm2))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "getErrorString() Tests", test_getErrorString))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "get_tpm2_properties() Tests",
+                  test_get_tpm2_properties))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "init_password_cmd_auth() Tests", test_init_password_cmd_auth))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "get_tpm2_impl_type() Tests", test_get_tpm2_impl_type))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "init_policy_cmd_auth() Tests", test_init_policy_cmd_auth))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "getErrorString() Tests", test_getErrorString))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "check_response_auth() Tests", test_check_response_auth))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "init_password_cmd_auth() Tests",
+                  test_init_password_cmd_auth))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "create_authVal() Tests", test_create_authVal))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "init_policy_cmd_auth() Tests",
+                  test_init_policy_cmd_auth))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "compute_cpHash() Tests", test_compute_cpHash))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "check_response_auth() Tests",
+                  test_check_response_auth))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "compute_rpHash() Tests", test_compute_rpHash))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "create_authVal() Tests", test_create_authVal))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "compute_authHMAC() Tests", test_compute_authHMAC))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "compute_cpHash() Tests", test_compute_cpHash))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "create_policy_digest() Tests", test_create_policy_digest))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "compute_rpHash() Tests", test_compute_rpHash))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "create_policy_auth_session() Tests", test_create_policy_auth_session))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "compute_authHMAC() Tests", test_compute_authHMAC))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "start_policy_auth_session() Tests", test_start_policy_auth_session))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "create_policy_digest() Tests",
+                  test_create_policy_digest))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "apply_policy() Tests", test_apply_policy))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "create_policy_auth_session() Tests",
+                  test_create_policy_auth_session))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "create_caller_nonce() Tests", test_create_caller_nonce))
-	{
-		return 1;
-	}
+  if (NULL ==
+      CU_add_test(suite, "start_policy_auth_session() Tests",
+                  test_start_policy_auth_session))
+  {
+    return 1;
+  }
 
-	if (NULL == CU_add_test(suite, "rollNonces() Tests", test_rollNonces))
-	{
-		return 1;
-	}
+  if (NULL == CU_add_test(suite, "apply_policy() Tests", test_apply_policy))
+  {
+    return 1;
+  }
+
+  if (NULL ==
+      CU_add_test(suite, "create_caller_nonce() Tests",
+                  test_create_caller_nonce))
+  {
+    return 1;
+  }
+
+  if (NULL == CU_add_test(suite, "rollNonces() Tests", test_rollNonces))
+  {
+    return 1;
+  }
 
   return 0;
 }
@@ -141,15 +165,15 @@ int tpm2_interface_add_tests(CU_pSuite suite)
 //----------------------------------------------------------------------------
 void test_init_tpm2_connection(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	CU_ASSERT(init_tpm2_connection(&sapi_ctx) == 0);
-	CU_ASSERT(sapi_ctx != NULL);
+  //Valid test
+  CU_ASSERT(init_tpm2_connection(&sapi_ctx) == 0);
+  CU_ASSERT(sapi_ctx != NULL);
 
-	//Must have null sapi_ctx to init
-	CU_ASSERT(init_tpm2_connection(&sapi_ctx) != 0);
-	free_tpm2_resources(&sapi_ctx);
+  //Must have null sapi_ctx to init
+  CU_ASSERT(init_tpm2_connection(&sapi_ctx) != 0);
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -157,15 +181,15 @@ void test_init_tpm2_connection(void)
 //----------------------------------------------------------------------------
 void test_init_tcti_abrmd(void)
 {
-	TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
+  TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
 
-	//Valid test
-	CU_ASSERT(init_tcti_abrmd(&tcti_ctx) == 0);
-	CU_ASSERT(tcti_ctx != NULL);
+  //Valid test
+  CU_ASSERT(init_tcti_abrmd(&tcti_ctx) == 0);
+  CU_ASSERT(tcti_ctx != NULL);
 
-	//Must have null sapi_ctx to init
-	CU_ASSERT(init_tcti_abrmd(&tcti_ctx) != 0);
-	free(tcti_ctx);
+  //Must have null sapi_ctx to init
+  CU_ASSERT(init_tcti_abrmd(&tcti_ctx) != 0);
+  free(tcti_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -173,25 +197,25 @@ void test_init_tcti_abrmd(void)
 //----------------------------------------------------------------------------
 void test_init_sapi(void)
 {
-	TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+  TSS2_TCTI_CONTEXT *tcti_ctx = NULL;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	init_tcti_abrmd(&tcti_ctx);
-	CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) == 0);
-	CU_ASSERT(sapi_ctx != NULL);
+  //Valid test
+  init_tcti_abrmd(&tcti_ctx);
+  CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) == 0);
+  CU_ASSERT(sapi_ctx != NULL);
 
-	//Must have null sapi_ctx
-	CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) != 0);
+  //Must have null sapi_ctx
+  CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) != 0);
 
-	free(tcti_ctx);
-	free(sapi_ctx);
-	sapi_ctx = NULL;
-	tcti_ctx = NULL;
+  free(tcti_ctx);
+  free(sapi_ctx);
+  sapi_ctx = NULL;
+  tcti_ctx = NULL;
 
-	//tcti_ctx must be initialized
-	CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) != 0);
-	CU_ASSERT(sapi_ctx == NULL);
+  //tcti_ctx must be initialized
+  CU_ASSERT(init_sapi(&sapi_ctx, tcti_ctx) != 0);
+  CU_ASSERT(sapi_ctx == NULL);
 }
 
 //----------------------------------------------------------------------------
@@ -199,17 +223,18 @@ void test_init_sapi(void)
 //----------------------------------------------------------------------------
 void test_free_tpm2_resources(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid NULL test
-	TSS2_SYS_CONTEXT **sapi_ctx_test = NULL;
-	CU_ASSERT(free_tpm2_resources(&sapi_ctx) == 0);
-	CU_ASSERT(free_tpm2_resources(sapi_ctx_test) == 0);
+  //Valid NULL test
+  TSS2_SYS_CONTEXT **sapi_ctx_test = NULL;
 
-	//Valid initialized sapi_ctx test
-	init_tpm2_connection(&sapi_ctx);
-	CU_ASSERT(free_tpm2_resources(&sapi_ctx) == 0);
-	CU_ASSERT(sapi_ctx == NULL);
+  CU_ASSERT(free_tpm2_resources(&sapi_ctx) == 0);
+  CU_ASSERT(free_tpm2_resources(sapi_ctx_test) == 0);
+
+  //Valid initialized sapi_ctx test
+  init_tpm2_connection(&sapi_ctx);
+  CU_ASSERT(free_tpm2_resources(&sapi_ctx) == 0);
+  CU_ASSERT(sapi_ctx == NULL);
 }
 
 //----------------------------------------------------------------------------
@@ -217,15 +242,16 @@ void test_free_tpm2_resources(void)
 //----------------------------------------------------------------------------
 void test_startup_tpm2(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	CU_ASSERT(startup_tpm2(&sapi_ctx) == 0);
-	free_tpm2_resources(&sapi_ctx);
+  init_tpm2_connection(&sapi_ctx);
 
-	//Test that it fails if sapi_ctx isn't initialized
-	CU_ASSERT(startup_tpm2(&sapi_ctx) != 0);
+  //Valid test
+  CU_ASSERT(startup_tpm2(&sapi_ctx) == 0);
+  free_tpm2_resources(&sapi_ctx);
+
+  //Test that it fails if sapi_ctx isn't initialized
+  CU_ASSERT(startup_tpm2(&sapi_ctx) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -233,18 +259,23 @@ void test_startup_tpm2(void)
 //----------------------------------------------------------------------------
 void test_get_tpm2_properties(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	TPMS_CAPABILITY_DATA cap_data = {.capability=TPM2_CAP_TPM_PROPERTIES+1,}; //We expect this to change
-	CU_ASSERT(get_tpm2_properties(sapi_ctx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER, TPM2_PT_GROUP, &cap_data) == 0);
-	CU_ASSERT(cap_data.capability == TPM2_CAP_TPM_PROPERTIES); //TPM_PROPERTIES constant
+  init_tpm2_connection(&sapi_ctx);
 
-	//Test null input
-	CU_ASSERT(get_tpm2_properties(NULL, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER, TPM2_PT_GROUP, &cap_data) != 0);
+  //Valid test
+  TPMS_CAPABILITY_DATA cap_data = {.capability = TPM2_CAP_TPM_PROPERTIES + 1, };  //We expect this to change
+  CU_ASSERT(get_tpm2_properties
+            (sapi_ctx, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER,
+             TPM2_PT_GROUP, &cap_data) == 0);
+  CU_ASSERT(cap_data.capability == TPM2_CAP_TPM_PROPERTIES);  //TPM_PROPERTIES constant
 
-	free_tpm2_resources(&sapi_ctx);
+  //Test null input
+  CU_ASSERT(get_tpm2_properties
+            (NULL, TPM2_CAP_TPM_PROPERTIES, TPM2_PT_MANUFACTURER, TPM2_PT_GROUP,
+             &cap_data) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -252,21 +283,23 @@ void test_get_tpm2_properties(void)
 //----------------------------------------------------------------------------
 void test_get_tpm2_impl_type(void)
 {
-	TSS2_SYS_CONTEXT *sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//This should only be executed on a simulator, otherwise these tests should not
-	//be called for execution at all.
+  init_tpm2_connection(&sapi_ctx);
 
-	//Valid Test
-	bool em = false;
-	CU_ASSERT(get_tpm2_impl_type(sapi_ctx, &em) == 0);
-	CU_ASSERT(em);
+  //This should only be executed on a simulator, otherwise these tests should not
+  //be called for execution at all.
 
-	//NULL input
-	CU_ASSERT(get_tpm2_impl_type(NULL, &em) != 0);
+  //Valid Test
+  bool em = false;
 
-	free_tpm2_resources(&sapi_ctx);
+  CU_ASSERT(get_tpm2_impl_type(sapi_ctx, &em) == 0);
+  CU_ASSERT(em);
+
+  //NULL input
+  CU_ASSERT(get_tpm2_impl_type(NULL, &em) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -274,13 +307,13 @@ void test_get_tpm2_impl_type(void)
 //----------------------------------------------------------------------------
 void test_getErrorString(void)
 {
-	//This function exists purely as a wrapper around Tss2_RC_Decode
-	//We do one test to confirm the API is correct
-	TSS2_RC err_num = 0x00080005;
-	char* err_str = "sys:A pointer is NULL that isn't allowed to be NULL.";
+  //This function exists purely as a wrapper around Tss2_RC_Decode
+  //We do one test to confirm the API is correct
+  TSS2_RC err_num = 0x00080005;
+  char *err_str = "sys:A pointer is NULL that isn't allowed to be NULL.";
 
-	CU_ASSERT(memcmp(getErrorString(err_num), err_str, strlen(err_str)) == 0);
-	CU_ASSERT(strlen(getErrorString(err_num)) == strlen(err_str));
+  CU_ASSERT(memcmp(getErrorString(err_num), err_str, strlen(err_str)) == 0);
+  CU_ASSERT(strlen(getErrorString(err_num)) == strlen(err_str));
 }
 
 //----------------------------------------------------------------------------
@@ -288,18 +321,19 @@ void test_getErrorString(void)
 //----------------------------------------------------------------------------
 void test_init_password_cmd_auth(void)
 {
-	TSS2L_SYS_AUTH_COMMAND cmd_out;
-	TSS2L_SYS_AUTH_RESPONSE res_out;
+  TSS2L_SYS_AUTH_COMMAND cmd_out;
+  TSS2L_SYS_AUTH_RESPONSE res_out;
 
-	//Valid test for NULL auth
-	TPM2B_AUTH auth = {.size = 0, };
-	CU_ASSERT(init_password_cmd_auth(auth, &cmd_out, &res_out) == 0);
+  //Valid test for NULL auth
+  TPM2B_AUTH auth = {.size = 0, };
+  CU_ASSERT(init_password_cmd_auth(auth, &cmd_out, &res_out) == 0);
 
-	//Valid test non-null auth
-	uint8_t* auth_bytes = (uint8_t*)"0123";
-	create_authVal(auth_bytes, 4, &auth);
-	CU_ASSERT(auth.size > 0);
-	CU_ASSERT(init_password_cmd_auth(auth, &cmd_out, &res_out) == 0);
+  //Valid test non-null auth
+  uint8_t *auth_bytes = (uint8_t *) "0123";
+
+  create_authVal(auth_bytes, 4, &auth);
+  CU_ASSERT(auth.size > 0);
+  CU_ASSERT(init_password_cmd_auth(auth, &cmd_out, &res_out) == 0);
 }
 
 //----------------------------------------------------------------------------
@@ -307,33 +341,31 @@ void test_init_password_cmd_auth(void)
 //----------------------------------------------------------------------------
 void test_init_policy_cmd_auth(void)
 {
-	SESSION session;
-	TPM2B_AUTH auth = {.size=0,};
-	TSS2L_SYS_AUTH_COMMAND cmd_out;
-	TSS2L_SYS_AUTH_RESPONSE res_out;
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	TPM2_CC cc = 0;
-	TPM2B_NAME auth_name = {.size=0,};
-	uint8_t *cmdParams = NULL;
-	size_t cmdParams_size = 0;
+  SESSION session;
+  TPM2B_AUTH auth = {.size = 0, };
+  TSS2L_SYS_AUTH_COMMAND cmd_out;
+  TSS2L_SYS_AUTH_RESPONSE res_out;
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+  TPM2_CC cc = 0;
+  TPM2B_NAME auth_name = {.size = 0, };
+  uint8_t *cmdParams = NULL;
+  size_t cmdParams_size = 0;
 
-	init_tpm2_connection(&sapi_ctx);
-	create_policy_auth_session(sapi_ctx, &session);
-	init_password_cmd_auth(auth, &cmd_out, &res_out);
+  init_tpm2_connection(&sapi_ctx);
+  create_policy_auth_session(sapi_ctx, &session);
+  init_password_cmd_auth(auth, &cmd_out, &res_out);
 
-	//Valid test
-	CU_ASSERT(init_policy_cmd_auth(&session,
-                         cc,
-                         auth_name,
-                         auth,
-                         cmdParams,
-                         cmdParams_size,
-                         pcrs_struct,
-                         &cmd_out,
-                         &res_out) == 0);
+  //Valid test
+  CU_ASSERT(init_policy_cmd_auth(&session,
+                                 cc,
+                                 auth_name,
+                                 auth,
+                                 cmdParams,
+                                 cmdParams_size,
+                                 pcrs_struct, &cmd_out, &res_out) == 0);
 
-	free_tpm2_resources(&sapi_ctx);
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -341,50 +373,58 @@ void test_init_policy_cmd_auth(void)
 //----------------------------------------------------------------------------
 void test_check_response_auth(void)
 {
-	//Initialize session to a valid state
-	SESSION session;
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	TSS2L_SYS_AUTH_RESPONSE res_out;
-	TPM2_CC cc = 0;
-	TPM2B_AUTH auth = {.size=0,};
-	uint8_t *cmdParams = NULL;
-	size_t cmdParams_size = 0;
-	init_tpm2_connection(&sapi_ctx);
-	session.nonceOlder.size = KMYTH_DIGEST_SIZE;
-	session.nonceNewer.size = KMYTH_DIGEST_SIZE;
-	res_out.auths[0].nonce.size = KMYTH_DIGEST_SIZE;
+  //Initialize session to a valid state
+  SESSION session;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
+  TSS2L_SYS_AUTH_RESPONSE res_out;
+  TPM2_CC cc = 0;
+  TPM2B_AUTH auth = {.size = 0, };
+  uint8_t *cmdParams = NULL;
+  size_t cmdParams_size = 0;
 
-	//Valid failure before hashes are set
-	CU_ASSERT(check_response_auth(&session, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
+  init_tpm2_connection(&sapi_ctx);
+  session.nonceOlder.size = KMYTH_DIGEST_SIZE;
+  session.nonceNewer.size = KMYTH_DIGEST_SIZE;
+  res_out.auths[0].nonce.size = KMYTH_DIGEST_SIZE;
 
-	//Specify empty nonces for hash comparisons
-	//Calculate the expected hash
-	memset(session.nonceOlder.buffer, 0x00, KMYTH_DIGEST_SIZE);
-	memset(session.nonceNewer.buffer, 0x00, KMYTH_DIGEST_SIZE);
-	memset(res_out.auths[0].nonce.buffer, 0x00, KMYTH_DIGEST_SIZE);
+  //Valid failure before hashes are set
+  CU_ASSERT(check_response_auth
+            (&session, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
 
-	TPM2B_DIGEST rpHash;
-	compute_rpHash(TPM2_RC_SUCCESS, cc, cmdParams, cmdParams_size, &rpHash);
-	TPM2B_DIGEST checkHMAC;
-	checkHMAC.size = 0;
-	compute_authHMAC(session, rpHash, auth, res_out.auths[0].sessionAttributes, &checkHMAC);
-	res_out.auths[0].hmac.size = checkHMAC.size;
-	for (int i = 0; i < checkHMAC.size; i++)
-	{
-		res_out.auths[0].hmac.buffer[i] = checkHMAC.buffer[i];
-	}
+  //Specify empty nonces for hash comparisons
+  //Calculate the expected hash
+  memset(session.nonceOlder.buffer, 0x00, KMYTH_DIGEST_SIZE);
+  memset(session.nonceNewer.buffer, 0x00, KMYTH_DIGEST_SIZE);
+  memset(res_out.auths[0].nonce.buffer, 0x00, KMYTH_DIGEST_SIZE);
 
-	//Valid test
-	CU_ASSERT(check_response_auth(&session, cc, cmdParams, cmdParams_size, auth, &res_out) == 0);
+  TPM2B_DIGEST rpHash;
 
-	session.nonceNewer.size = 1;
-	//Valid failure
-	CU_ASSERT(check_response_auth(&session, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
+  compute_rpHash(TPM2_RC_SUCCESS, cc, cmdParams, cmdParams_size, &rpHash);
+  TPM2B_DIGEST checkHMAC;
 
-	//NULL session
-	CU_ASSERT(check_response_auth(NULL, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
+  checkHMAC.size = 0;
+  compute_authHMAC(session, rpHash, auth, res_out.auths[0].sessionAttributes,
+                   &checkHMAC);
+  res_out.auths[0].hmac.size = checkHMAC.size;
+  for (int i = 0; i < checkHMAC.size; i++)
+  {
+    res_out.auths[0].hmac.buffer[i] = checkHMAC.buffer[i];
+  }
 
-	free_tpm2_resources(&sapi_ctx);
+  //Valid test
+  CU_ASSERT(check_response_auth
+            (&session, cc, cmdParams, cmdParams_size, auth, &res_out) == 0);
+
+  session.nonceNewer.size = 1;
+  //Valid failure
+  CU_ASSERT(check_response_auth
+            (&session, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
+
+  //NULL session
+  CU_ASSERT(check_response_auth
+            (NULL, cc, cmdParams, cmdParams_size, auth, &res_out) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -392,48 +432,49 @@ void test_check_response_auth(void)
 //----------------------------------------------------------------------------
 void test_create_authVal(void)
 {
-	uint8_t* ab = NULL;
-	size_t ab_size = 0;
-	TPM2B_AUTH auth = {.size=0,};
+  uint8_t *ab = NULL;
+  size_t ab_size = 0;
+  TPM2B_AUTH auth = {.size = 0, };
 
-	//Valid test, empty auth
-	CU_ASSERT(create_authVal(ab, ab_size, &auth) == 0);
-	CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
-	uint8_t result = 0;
-	for(int i=0;i<auth.size;i++)
-	{
-		result |= auth.buffer[i];
-	}
-	CU_ASSERT(result == 0);
+  //Valid test, empty auth
+  CU_ASSERT(create_authVal(ab, ab_size, &auth) == 0);
+  CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
+  uint8_t result = 0;
 
-	//Valid test with non-empty auth
-	ab = (uint8_t*)"0123";
-	ab_size = 4;
-	auth.size = 0;
-	CU_ASSERT(create_authVal(ab, ab_size, &auth) == 0);
-	CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
-	result = 0;
-	for(int i=0;i<auth.size;i++)
-	{
-		result |= auth.buffer[i];
-	}
-	CU_ASSERT(result != 0);
+  for (int i = 0; i < auth.size; i++)
+  {
+    result |= auth.buffer[i];
+  }
+  CU_ASSERT(result == 0);
 
-	//Valid auth string with size 0
-	ab = (uint8_t*)"0123";
-	ab_size = 4;
-	auth.size = 0;
-	CU_ASSERT(create_authVal(ab, 0, &auth) == 0);
-	CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
-	result = 0;
-	for(int i=0;i<auth.size;i++)
-	{
-		result |= auth.buffer[i];
-	}
-	CU_ASSERT(result == 0); //Treats as if input string was NULL
+  //Valid test with non-empty auth
+  ab = (uint8_t *) "0123";
+  ab_size = 4;
+  auth.size = 0;
+  CU_ASSERT(create_authVal(ab, ab_size, &auth) == 0);
+  CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
+  result = 0;
+  for (int i = 0; i < auth.size; i++)
+  {
+    result |= auth.buffer[i];
+  }
+  CU_ASSERT(result != 0);
 
-	//NULL output
-	CU_ASSERT(create_authVal(ab, ab_size, NULL) != 0);
+  //Valid auth string with size 0
+  ab = (uint8_t *) "0123";
+  ab_size = 4;
+  auth.size = 0;
+  CU_ASSERT(create_authVal(ab, 0, &auth) == 0);
+  CU_ASSERT(auth.size == KMYTH_DIGEST_SIZE);
+  result = 0;
+  for (int i = 0; i < auth.size; i++)
+  {
+    result |= auth.buffer[i];
+  }
+  CU_ASSERT(result == 0);       //Treats as if input string was NULL
+
+  //NULL output
+  CU_ASSERT(create_authVal(ab, ab_size, NULL) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -441,51 +482,50 @@ void test_create_authVal(void)
 //----------------------------------------------------------------------------
 void test_compute_cpHash(void)
 {
-	TPM2_CC cc = 0;
-	TPM2B_NAME auth_name = {.size=0,};
-	uint8_t* cmd = NULL;
-	uint8_t cmd_size = 0;
-	TPM2B_DIGEST out = {.size=0,};
+  TPM2_CC cc = 0;
+  TPM2B_NAME auth_name = {.size = 0, };
+  uint8_t *cmd = NULL;
+  uint8_t cmd_size = 0;
+  TPM2B_DIGEST out = {.size = 0, };
 
-	//Valid test with empty input
-	CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, &out) == 0);
-	CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
+  //Valid test with empty input
+  CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, &out) == 0);
+  CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
 
-	//Valid test with non-NULL cmd
-	cmd = (uint8_t*)"0123";
-	cmd_size = 4;
-	out.size = 0;
-	CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, &out) == 0);
-	CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
+  //Valid test with non-NULL cmd
+  cmd = (uint8_t *) "0123";
+  cmd_size = 4;
+  out.size = 0;
+  CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, &out) == 0);
+  CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
 
-	//NULL output
-	CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, NULL) != 0)
-}
+  //NULL output
+CU_ASSERT(compute_cpHash(cc, auth_name, cmd, cmd_size, NULL) != 0)}
 
 //----------------------------------------------------------------------------
 // test_compute_rpHash
 //----------------------------------------------------------------------------
 void test_compute_rpHash(void)
 {
-	TPM2_RC rc = 0;
-	TPM2_CC cc = 0;
-	uint8_t* cmd = NULL;
-	uint8_t cmd_size = 0;
-	TPM2B_DIGEST out = {.size=0,};
+  TPM2_RC rc = 0;
+  TPM2_CC cc = 0;
+  uint8_t *cmd = NULL;
+  uint8_t cmd_size = 0;
+  TPM2B_DIGEST out = {.size = 0, };
 
-	//Valid test with empty input
-	CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, &out) == 0);
-	CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
+  //Valid test with empty input
+  CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, &out) == 0);
+  CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
 
-	//Valid test with non-NULL cmd
-	cmd = (uint8_t*)"0123";
-	cmd_size = 4;
-	out.size = 0;
-	CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, &out) == 0);
-	CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
+  //Valid test with non-NULL cmd
+  cmd = (uint8_t *) "0123";
+  cmd_size = 4;
+  out.size = 0;
+  CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, &out) == 0);
+  CU_ASSERT(out.size == KMYTH_DIGEST_SIZE);
 
-	//NULL output
-	CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, NULL) != 0);
+  //NULL output
+  CU_ASSERT(compute_rpHash(rc, cc, cmd, cmd_size, NULL) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -493,27 +533,27 @@ void test_compute_rpHash(void)
 //----------------------------------------------------------------------------
 void test_compute_authHMAC(void)
 {
-	SESSION session;
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
+  SESSION session;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	init_tpm2_connection(&sapi_ctx);
-	create_policy_auth_session(sapi_ctx, &session);
-	TPM2_CC cc = 0;
-	TPM2B_NAME auth_name = {.size=0,};
-	uint8_t* cmd = NULL;
-	uint8_t cmd_size = 0;
-	TPM2B_DIGEST hash = {.size=0,};
-	compute_cpHash(cc, auth_name, cmd, cmd_size, &hash);
-	TPMA_SESSION session_attr = 0;
-	TPM2B_AUTH auth = {.size=0,};
-	TPM2B_AUTH hmac = {.size=0,};
-	CU_ASSERT(compute_authHMAC(session, hash, auth, session_attr, &hmac) == 0);
-	CU_ASSERT(hmac.size != 0);
+  //Valid test
+  init_tpm2_connection(&sapi_ctx);
+  create_policy_auth_session(sapi_ctx, &session);
+  TPM2_CC cc = 0;
+  TPM2B_NAME auth_name = {.size = 0, };
+  uint8_t *cmd = NULL;
+  uint8_t cmd_size = 0;
+  TPM2B_DIGEST hash = {.size = 0, };
+  compute_cpHash(cc, auth_name, cmd, cmd_size, &hash);
+  TPMA_SESSION session_attr = 0;
+  TPM2B_AUTH auth = {.size = 0, };
+  TPM2B_AUTH hmac = {.size = 0, };
+  CU_ASSERT(compute_authHMAC(session, hash, auth, session_attr, &hmac) == 0);
+  CU_ASSERT(hmac.size != 0);
 
-	//NULL output
-	CU_ASSERT(compute_authHMAC(session, hash, auth, session_attr, NULL) != 0);
-	free_tpm2_resources(&sapi_ctx);
+  //NULL output
+  CU_ASSERT(compute_authHMAC(session, hash, auth, session_attr, NULL) != 0);
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -521,45 +561,50 @@ void test_compute_authHMAC(void)
 //----------------------------------------------------------------------------
 void test_create_policy_digest(void)
 {
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test with no PCRs selected
-	TPM2B_DIGEST out;
-	CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
-	CU_ASSERT(out.size != 0);
-	BYTE pcr0_buf[KMYTH_DIGEST_SIZE];
-	memcpy(pcr0_buf, out.buffer, KMYTH_DIGEST_SIZE);
+  init_tpm2_connection(&sapi_ctx);
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
 
-	//Valid test with one PCR selected
-	int pcrs[2] = {};
-	pcrs[0] = 5;
-	init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct);
-	out.size = 0;
-	CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
-	CU_ASSERT(out.size != 0);
-	BYTE pcr1_buf[KMYTH_DIGEST_SIZE];
-	memcpy(pcr1_buf, out.buffer, KMYTH_DIGEST_SIZE);
+  //Valid test with no PCRs selected
+  TPM2B_DIGEST out;
 
-	//Valid test with multiple PCRs selected
-	out.size = 0;
-	pcrs[1] = 3;
-	init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct);
-	CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
-	CU_ASSERT(out.size != 0);
-	BYTE pcr2_buf[KMYTH_DIGEST_SIZE];
-	memcpy(pcr2_buf, out.buffer, KMYTH_DIGEST_SIZE);
+  CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
+  CU_ASSERT(out.size != 0);
+  BYTE pcr0_buf[KMYTH_DIGEST_SIZE];
 
-	//Verify output digests are different
-	CU_ASSERT(memcmp(pcr0_buf, pcr1_buf, KMYTH_DIGEST_SIZE) != 0);
-	CU_ASSERT(memcmp(pcr0_buf, pcr2_buf, KMYTH_DIGEST_SIZE) != 0);
-	CU_ASSERT(memcmp(pcr1_buf, pcr2_buf, KMYTH_DIGEST_SIZE) != 0);
+  memcpy(pcr0_buf, out.buffer, KMYTH_DIGEST_SIZE);
 
-	//Failure with null sapi_ctx
-	CU_ASSERT(create_policy_digest(NULL, pcrs_struct, &out) !=0);
+  //Valid test with one PCR selected
+  int pcrs[2] = { };
+  pcrs[0] = 5;
+  init_pcr_selection(sapi_ctx, pcrs, 1, &pcrs_struct);
+  out.size = 0;
+  CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
+  CU_ASSERT(out.size != 0);
+  BYTE pcr1_buf[KMYTH_DIGEST_SIZE];
 
-	free_tpm2_resources(&sapi_ctx);
+  memcpy(pcr1_buf, out.buffer, KMYTH_DIGEST_SIZE);
+
+  //Valid test with multiple PCRs selected
+  out.size = 0;
+  pcrs[1] = 3;
+  init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct);
+  CU_ASSERT(create_policy_digest(sapi_ctx, pcrs_struct, &out) == 0);
+  CU_ASSERT(out.size != 0);
+  BYTE pcr2_buf[KMYTH_DIGEST_SIZE];
+
+  memcpy(pcr2_buf, out.buffer, KMYTH_DIGEST_SIZE);
+
+  //Verify output digests are different
+  CU_ASSERT(memcmp(pcr0_buf, pcr1_buf, KMYTH_DIGEST_SIZE) != 0);
+  CU_ASSERT(memcmp(pcr0_buf, pcr2_buf, KMYTH_DIGEST_SIZE) != 0);
+  CU_ASSERT(memcmp(pcr1_buf, pcr2_buf, KMYTH_DIGEST_SIZE) != 0);
+
+  //Failure with null sapi_ctx
+  CU_ASSERT(create_policy_digest(NULL, pcrs_struct, &out) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -567,19 +612,20 @@ void test_create_policy_digest(void)
 //----------------------------------------------------------------------------
 void test_create_policy_auth_session(void)
 {
-	SESSION session;
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  SESSION session;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	CU_ASSERT(create_policy_auth_session(sapi_ctx, &session) == 0);
-	CU_ASSERT(session.nonceNewer.size == KMYTH_DIGEST_SIZE);
-	CU_ASSERT(session.nonceOlder.size == KMYTH_DIGEST_SIZE);
+  init_tpm2_connection(&sapi_ctx);
 
-	//NULL context
-	CU_ASSERT(create_policy_auth_session(NULL, &session) != 0);
+  //Valid test
+  CU_ASSERT(create_policy_auth_session(sapi_ctx, &session) == 0);
+  CU_ASSERT(session.nonceNewer.size == KMYTH_DIGEST_SIZE);
+  CU_ASSERT(session.nonceOlder.size == KMYTH_DIGEST_SIZE);
 
-	free_tpm2_resources(&sapi_ctx);
+  //NULL context
+  CU_ASSERT(create_policy_auth_session(NULL, &session) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -587,33 +633,34 @@ void test_create_policy_auth_session(void)
 //----------------------------------------------------------------------------
 void test_start_policy_auth_session(void)
 {
-	SESSION session;
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  SESSION session;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test SE_TRIAL
-	create_policy_auth_session(sapi_ctx, &session);
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) == 0);
+  init_tpm2_connection(&sapi_ctx);
 
-	//Valid test SE_POLICY
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_POLICY) == 0);
+  //Valid test SE_TRIAL
+  create_policy_auth_session(sapi_ctx, &session);
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) == 0);
 
-	//Valid failure if session_type isn't trial/policy
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_HMAC) != 0);
+  //Valid test SE_POLICY
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_POLICY) == 0);
 
-	//Fail if session has uninitialized nonce
-	session.nonceNewer.size = 0;
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) != 0);
-	session.nonceNewer.size = KMYTH_DIGEST_SIZE;
-	session.nonceOlder.size = 0;
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) != 0);
-	session.nonceOlder.size = KMYTH_DIGEST_SIZE;
-	CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) == 0);
+  //Valid failure if session_type isn't trial/policy
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_HMAC) != 0);
 
-	//Fail if context is NULL
-	CU_ASSERT(start_policy_auth_session(NULL, &session, TPM2_SE_TRIAL) != 0);
+  //Fail if session has uninitialized nonce
+  session.nonceNewer.size = 0;
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) != 0);
+  session.nonceNewer.size = KMYTH_DIGEST_SIZE;
+  session.nonceOlder.size = 0;
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) != 0);
+  session.nonceOlder.size = KMYTH_DIGEST_SIZE;
+  CU_ASSERT(start_policy_auth_session(sapi_ctx, &session, TPM2_SE_TRIAL) == 0);
 
-	free_tpm2_resources(&sapi_ctx);
+  //Fail if context is NULL
+  CU_ASSERT(start_policy_auth_session(NULL, &session, TPM2_SE_TRIAL) != 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -621,29 +668,30 @@ void test_start_policy_auth_session(void)
 //----------------------------------------------------------------------------
 void test_apply_policy(void)
 {
-	SESSION session;
-	TSS2_SYS_CONTEXT* sapi_ctx = NULL;
-	init_tpm2_connection(&sapi_ctx);
+  SESSION session;
+  TSS2_SYS_CONTEXT *sapi_ctx = NULL;
 
-	//Valid test
-	create_policy_auth_session(sapi_ctx, &session);
-	TPML_PCR_SELECTION pcrs_struct = {.count = 0,};
-	CU_ASSERT(apply_policy(sapi_ctx, session.sessionHandle, pcrs_struct) == 0);
+  init_tpm2_connection(&sapi_ctx);
 
-	//NULL context
-	CU_ASSERT(apply_policy(NULL, session.sessionHandle, pcrs_struct) != 0);
+  //Valid test
+  create_policy_auth_session(sapi_ctx, &session);
+  TPML_PCR_SELECTION pcrs_struct = {.count = 0, };
+  CU_ASSERT(apply_policy(sapi_ctx, session.sessionHandle, pcrs_struct) == 0);
 
-	//Invalid Handle
-	CU_ASSERT(apply_policy(sapi_ctx, 0, pcrs_struct) != 0);
+  //NULL context
+  CU_ASSERT(apply_policy(NULL, session.sessionHandle, pcrs_struct) != 0);
 
-	//Multiple pcrs
-	int pcrs[2] = {};
-	pcrs[0] = 5;
-	pcrs[1] = 3;
-	init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct);
-	CU_ASSERT(apply_policy(sapi_ctx, session.sessionHandle, pcrs_struct) == 0);
+  //Invalid Handle
+  CU_ASSERT(apply_policy(sapi_ctx, 0, pcrs_struct) != 0);
 
-	free_tpm2_resources(&sapi_ctx);
+  //Multiple pcrs
+  int pcrs[2] = { };
+  pcrs[0] = 5;
+  pcrs[1] = 3;
+  init_pcr_selection(sapi_ctx, pcrs, 2, &pcrs_struct);
+  CU_ASSERT(apply_policy(sapi_ctx, session.sessionHandle, pcrs_struct) == 0);
+
+  free_tpm2_resources(&sapi_ctx);
 }
 
 //----------------------------------------------------------------------------
@@ -652,16 +700,17 @@ void test_apply_policy(void)
 void test_create_caller_nonce(void)
 {
   TPM2B_NONCE nonce;
-	//Test on uninitialized nonce
-	CU_ASSERT(create_caller_nonce(&nonce) == 0);
-	CU_ASSERT(nonce.size == KMYTH_DIGEST_SIZE);
 
-	//Test that nonce is overwritten
-	memset(nonce.buffer, 0, KMYTH_DIGEST_SIZE);
-	BYTE zeroes[KMYTH_DIGEST_SIZE] = {0};
-	CU_ASSERT(memcmp(nonce.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
-	CU_ASSERT(create_caller_nonce(&nonce) == 0);
-	CU_ASSERT(memcmp(nonce.buffer, zeroes, KMYTH_DIGEST_SIZE) != 0);
+  //Test on uninitialized nonce
+  CU_ASSERT(create_caller_nonce(&nonce) == 0);
+  CU_ASSERT(nonce.size == KMYTH_DIGEST_SIZE);
+
+  //Test that nonce is overwritten
+  memset(nonce.buffer, 0, KMYTH_DIGEST_SIZE);
+  BYTE zeroes[KMYTH_DIGEST_SIZE] = { 0 };
+  CU_ASSERT(memcmp(nonce.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
+  CU_ASSERT(create_caller_nonce(&nonce) == 0);
+  CU_ASSERT(memcmp(nonce.buffer, zeroes, KMYTH_DIGEST_SIZE) != 0);
 }
 
 //----------------------------------------------------------------------------
@@ -669,32 +718,34 @@ void test_create_caller_nonce(void)
 //----------------------------------------------------------------------------
 void test_rollNonces(void)
 {
-	SESSION session;
-	session.nonceOlder.size = KMYTH_DIGEST_SIZE;
-	session.nonceNewer.size = KMYTH_DIGEST_SIZE;
+  SESSION session;
 
-	TPM2B_NONCE new = {.size=KMYTH_DIGEST_SIZE,};
-	memset(new.buffer, 0x01, KMYTH_DIGEST_SIZE);
-	memset(session.nonceOlder.buffer, 0x02, KMYTH_DIGEST_SIZE);
-	memset(session.nonceNewer.buffer, 0x00, KMYTH_DIGEST_SIZE);
+  session.nonceOlder.size = KMYTH_DIGEST_SIZE;
+  session.nonceNewer.size = KMYTH_DIGEST_SIZE;
 
-	//Valid rolls
-	CU_ASSERT(rollNonces(&session, new) == 0);
-	BYTE zeroes[KMYTH_DIGEST_SIZE] = {0};
-	CU_ASSERT(memcmp(session.nonceOlder.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
-	BYTE ones[KMYTH_DIGEST_SIZE];
-	memset(ones, 0x01, KMYTH_DIGEST_SIZE);
-	CU_ASSERT(memcmp(session.nonceNewer.buffer, ones, KMYTH_DIGEST_SIZE) == 0);
-	memset(new.buffer, 0x00, KMYTH_DIGEST_SIZE);
-	CU_ASSERT(rollNonces(&session, new) == 0);
-	CU_ASSERT(memcmp(session.nonceOlder.buffer, ones, KMYTH_DIGEST_SIZE) == 0);
-	CU_ASSERT(memcmp(session.nonceNewer.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
+  TPM2B_NONCE new = {.size = KMYTH_DIGEST_SIZE, };
+  memset(new.buffer, 0x01, KMYTH_DIGEST_SIZE);
+  memset(session.nonceOlder.buffer, 0x02, KMYTH_DIGEST_SIZE);
+  memset(session.nonceNewer.buffer, 0x00, KMYTH_DIGEST_SIZE);
 
-	//NULL session
-	CU_ASSERT(rollNonces(NULL, new) != 0);
+  //Valid rolls
+  CU_ASSERT(rollNonces(&session, new) == 0);
+  BYTE zeroes[KMYTH_DIGEST_SIZE] = { 0 };
+  CU_ASSERT(memcmp(session.nonceOlder.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
+  BYTE ones[KMYTH_DIGEST_SIZE];
 
-	//newNonce is the right size
-	new.size = 0;
-	CU_ASSERT(rollNonces(&session, new) != 0);
+  memset(ones, 0x01, KMYTH_DIGEST_SIZE);
+  CU_ASSERT(memcmp(session.nonceNewer.buffer, ones, KMYTH_DIGEST_SIZE) == 0);
+  memset(new.buffer, 0x00, KMYTH_DIGEST_SIZE);
+  CU_ASSERT(rollNonces(&session, new) == 0);
+  CU_ASSERT(memcmp(session.nonceOlder.buffer, ones, KMYTH_DIGEST_SIZE) == 0);
+  CU_ASSERT(memcmp(session.nonceNewer.buffer, zeroes, KMYTH_DIGEST_SIZE) == 0);
+
+  //NULL session
+  CU_ASSERT(rollNonces(NULL, new) != 0);
+
+  //newNonce is the right size
+  new.size = 0;
+  CU_ASSERT(rollNonces(&session, new) != 0);
 
 }

--- a/tpm2/test/src/util/file_io_test.c
+++ b/tpm2/test/src/util/file_io_test.c
@@ -4,7 +4,6 @@
 // Tests for kmyth I/O utility functions in tpm2/src/util/file_io.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -15,7 +14,6 @@
 #include "file_io_test.h"
 #include "file_io.h"
 
-
 //----------------------------------------------------------------------------
 // file_io_add_tests()
 //----------------------------------------------------------------------------
@@ -24,7 +22,7 @@ int file_io_add_tests(CU_pSuite suite)
   if (NULL == CU_add_test(suite, "verifyInputFilePath() Tests",
                           test_verifyInputFilePath))
   {
-    return 1; 
+    return 1;
   }
 
   if (NULL == CU_add_test(suite, "verifyOutputFilePaths() Tests",
@@ -54,15 +52,15 @@ int file_io_add_tests(CU_pSuite suite)
   return 0;
 }
 
-
 //----------------------------------------------------------------------------
 // test_verifyInputFilePath()
 //----------------------------------------------------------------------------
 void test_verifyInputFilePath(void)
 {
   // create "testfile", with sample data, as test input file path
-  FILE* fp = fopen("testfile", "w");  
-  fprintf(fp, "Testing..."); 
+  FILE *fp = fopen("testfile", "w");
+
+  fprintf(fp, "Testing...");
   fclose(fp);
 
   // NULL input file path should error 
@@ -78,9 +76,8 @@ void test_verifyInputFilePath(void)
 
   // non-existing input file path should error
   remove("testfile");
-  CU_ASSERT(verifyInputFilePath("testfile") == 1); 
+  CU_ASSERT(verifyInputFilePath("testfile") == 1);
 }
-
 
 //----------------------------------------------------------------------------
 // test_verifyOutputFilePath()
@@ -88,17 +85,18 @@ void test_verifyInputFilePath(void)
 void test_verifyOutputFilePath(void)
 {
   // create empty "testfile" as test output file path
-  FILE* fp = fopen("testfile", "w");  
+  FILE *fp = fopen("testfile", "w");
+
   fclose(fp);
 
   // NULL output file path should error 
   CU_ASSERT(verifyOutputFilePath(NULL) == 1);
 
   // fake output path directory should error
-  CU_ASSERT(verifyOutputFilePath("../fake_dir/testfile") == 1); 
+  CU_ASSERT(verifyOutputFilePath("../fake_dir/testfile") == 1);
 
   // output path is directory (even if valid) should error
-  CU_ASSERT(verifyOutputFilePath(".") == 1); 
+  CU_ASSERT(verifyOutputFilePath(".") == 1);
 
   // real file output path without write permission should error
   chmod("testfile", 0555);
@@ -112,7 +110,6 @@ void test_verifyOutputFilePath(void)
   remove("testfile");
   CU_ASSERT(verifyOutputFilePath("testfile") == 0);
 }
- 
 
 //----------------------------------------------------------------------------
 // test_read_bytes_from_file()
@@ -120,11 +117,11 @@ void test_verifyOutputFilePath(void)
 void test_read_bytes_from_file(void)
 {
   // Create a test data (and length) example for use in tests
-  uint8_t * testfile_data = (uint8_t *) "123 & ABC !!";
+  uint8_t *testfile_data = (uint8_t *) "123 & ABC !!";
   size_t testfile_size = strlen((char *) testfile_data);
 
   // Create data amd data_length parameters to use in test function calls
-  uint8_t * testdata = NULL;
+  uint8_t *testdata = NULL;
   size_t testdata_len = 0;
 
   // Trying to read from NULL input path should result in error
@@ -132,7 +129,8 @@ void test_read_bytes_from_file(void)
 
   // Reading from an existing, but empty, file should error. This test should
   // fail check that length of input data read from file is greater than zero.
-  FILE * fp = fopen("testfile", "w");
+  FILE *fp = fopen("testfile", "w");
+
   fclose(fp);
   CU_ASSERT(read_bytes_from_file("te_file", &testdata, &testdata_len) == 1);
 
@@ -143,7 +141,8 @@ void test_read_bytes_from_file(void)
   fclose(fp);
   CU_ASSERT(read_bytes_from_file("testfile", &testdata, &testdata_len) == 0);
   CU_ASSERT(testdata_len == testfile_size);
-  CU_ASSERT(strncmp((char*)testdata, (char *)testfile_data, testfile_size)==0);
+  CU_ASSERT(strncmp((char *) testdata, (char *) testfile_data, testfile_size) ==
+            0);
 
   // Read from existing file without read permission should result in error
   chmod("testfile", 0333);
@@ -157,23 +156,23 @@ void test_read_bytes_from_file(void)
   free(testdata);
 }
 
-
 //----------------------------------------------------------------------------
 // test_write_bytes_to_file()
 //----------------------------------------------------------------------------
 void test_write_bytes_to_file(void)
 {
   // Create a couple test byte arrays (and companion lengths) to use in tests
-  uint8_t * testdata1 = (uint8_t *) "Testing 123 ...";
+  uint8_t *testdata1 = (uint8_t *) "Testing 123 ...";
   size_t testdata1_len = strlen((char *) testdata1);
-  uint8_t * testdata2 = (uint8_t *) "And now for something different!\n";
+  uint8_t *testdata2 = (uint8_t *) "And now for something different!\n";
   size_t testdata2_len = strlen((char *) testdata2);
 
   // Trying to write to NULL output path should result in error
   CU_ASSERT(write_bytes_to_file(NULL, testdata1, testdata1_len) == 1);
 
   // Trying to write to an output path without write permission should error
-  FILE* fp = fopen("testfile", "w"); 
+  FILE *fp = fopen("testfile", "w");
+
   fclose(fp);
   chmod("testfile", 0555);
   CU_ASSERT(write_bytes_to_file("testfile", testdata1, testdata1_len) == 1);
@@ -181,23 +180,23 @@ void test_write_bytes_to_file(void)
 
   // Writing a new file, with permission, should produce expected file
   CU_ASSERT(write_bytes_to_file("testfile", testdata1, testdata1_len) == 0);
-  uint8_t * filedata = NULL;
+  uint8_t *filedata = NULL;
   size_t filedata_len = 0;
+
   read_bytes_from_file("testfile", &filedata, &filedata_len);
   CU_ASSERT(filedata_len == testdata1_len);
-  CU_ASSERT(strncmp((char*) testdata1, (char*) filedata, filedata_len) == 0);
+  CU_ASSERT(strncmp((char *) testdata1, (char *) filedata, filedata_len) == 0);
 
   // Writing to an existing file should correctly overwrite it
   CU_ASSERT(write_bytes_to_file("testfile", testdata2, testdata2_len) == 0);
   read_bytes_from_file("testfile", &filedata, &filedata_len);
   CU_ASSERT(filedata_len == testdata2_len);
-  CU_ASSERT(strncmp((char*) testdata2, (char*) filedata, filedata_len) == 0);
+  CU_ASSERT(strncmp((char *) testdata2, (char *) filedata, filedata_len) == 0);
 
   // Test cleanup
   free(filedata);
   remove("testfile");
 }
-
 
 //----------------------------------------------------------------------------
 // test_print_to_stdout()
@@ -205,7 +204,7 @@ void test_write_bytes_to_file(void)
 void test_print_to_stdout(void)
 {
   // Create some test "print data" (and companion length) to use in tests
-  unsigned char * testdata = (unsigned char *) "Display to user's console\n";
+  unsigned char *testdata = (unsigned char *) "Display to user's console\n";
   size_t testdata_len = strlen((char *) testdata);
 
   // In order to check data written to STDOUT, these tests redirect it to a
@@ -217,14 +216,16 @@ void test_print_to_stdout(void)
 
   // providing data size of zero should print empty string, but not error
   int redir_fd = open("redirect_test1", O_WRONLY | O_TRUNC | O_CREAT, 0777);
+
   dup2(redir_fd, STDOUT_FILENO);
   close(redir_fd);
-  uint8_t * filedata1 = NULL;
+  uint8_t *filedata1 = NULL;
   size_t filedata1_len = testdata_len;
+
   CU_ASSERT(print_to_stdout(testdata, 0) == 0);
   read_bytes_from_file("redirect_test1", &filedata1, &filedata1_len);
   CU_ASSERT(filedata1_len == 0);
-  CU_ASSERT(strncmp("", (char*) filedata1, testdata_len) == 0);
+  CU_ASSERT(strncmp("", (char *) filedata1, testdata_len) == 0);
   free(filedata1);
   remove("redirect_test1");
 
@@ -232,12 +233,13 @@ void test_print_to_stdout(void)
   redir_fd = open("redirect_test2", O_WRONLY | O_TRUNC | O_CREAT, 0777);
   dup2(redir_fd, STDOUT_FILENO);
   close(redir_fd);
-  uint8_t * filedata2 = NULL;
+  uint8_t *filedata2 = NULL;
   size_t filedata2_len = 0;
+
   CU_ASSERT(print_to_stdout(testdata, testdata_len) == 0);
   read_bytes_from_file("redirect_test2", &filedata2, &filedata2_len);
   CU_ASSERT(filedata2_len == testdata_len);
-  CU_ASSERT(strncmp((char*) testdata, (char*) filedata2, filedata2_len) == 0);
+  CU_ASSERT(strncmp((char *) testdata, (char *) filedata2, filedata2_len) == 0);
   free(filedata2);
   remove("redirect_test2");
 

--- a/tpm2/test/src/util/memory_util_test.c
+++ b/tpm2/test/src/util/memory_util_test.c
@@ -4,7 +4,6 @@
 // Tests for kmyth memory utility functions in tpm2/src/util/memory_util.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -15,22 +14,20 @@
 #include "memory_util_test.h"
 #include "memory_util.h"
 
-
 //----------------------------------------------------------------------------
 // memory_util_add_tests()
 //----------------------------------------------------------------------------
 int memory_util_add_tests(CU_pSuite suite)
 {
-  if (NULL == CU_add_test(suite, "Kmyth Memory Clear Tests",
-                          test_kmyth_clear))
+  if (NULL == CU_add_test(suite, "Kmyth Memory Clear Tests", test_kmyth_clear))
   {
-    return 1; 
+    return 1;
   }
 
   if (NULL == CU_add_test(suite, "Kmyth Memory 'Clear and Free' Tests",
                           test_kmyth_clear_and_free))
   {
-    return 1; 
+    return 1;
   }
 
 //  if (NULL == CU_add_test(suite, "Kmyth Secure Memory Set Tests",
@@ -42,7 +39,6 @@ int memory_util_add_tests(CU_pSuite suite)
   return 0;
 }
 
-
 //----------------------------------------------------------------------------
 // test_kmyth_clear()
 //----------------------------------------------------------------------------
@@ -52,7 +48,8 @@ void test_kmyth_clear(void)
 
   // Create block of allocated, non-zero memory
   size_t tmp1_size = 64;
-  unsigned char * tmp1 = malloc(tmp1_size);
+  unsigned char *tmp1 = malloc(tmp1_size);
+
   for (int i = 0; i < tmp1_size; i++)
   {
     *(tmp1 + i) = 0xff;
@@ -86,7 +83,6 @@ void test_kmyth_clear(void)
 
 }
 
-
 //----------------------------------------------------------------------------
 // test_kmyth_clear_and_free()
 //----------------------------------------------------------------------------
@@ -104,9 +100,8 @@ void test_kmyth_clear_and_free(void)
 
   // Test that kmyth_clear_and_free() for a NULL pointer does not crash
   kmyth_clear_and_free(NULL, 16);
-  CU_ASSERT(true);    // if execution reaches here, test did not crash
+  CU_ASSERT(true);              // if execution reaches here, test did not crash
 }
-
 
 //----------------------------------------------------------------------------
 // test_secure_memset()
@@ -117,10 +112,11 @@ void test_secure_memset(void)
 
   // Create block of allocated memory set to alternating ones/zeros
   size_t tmp1_size = 31;
-  unsigned char * tmp1 = malloc(tmp1_size);
+  unsigned char *tmp1 = malloc(tmp1_size);
+
   for (int i = 0; i < tmp1_size; i++)
   {
-    *(tmp1+i) = 0x55;
+    *(tmp1 + i) = 0x55;
   }
 
   // secure_memset() of zero bytes should just return (do nothing)
@@ -149,4 +145,3 @@ void test_secure_memset(void)
   }
   CU_ASSERT(result);
 }
-

--- a/tpm2/test/src/util/tls_util_test.c
+++ b/tpm2/test/src/util/tls_util_test.c
@@ -4,7 +4,6 @@
 // Tests for TLS utility functions in tpm2/src/util/tls_util.c
 //############################################################################
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <CUnit/CUnit.h>
@@ -12,7 +11,6 @@
 
 #include "tls_util_test.h"
 #include "tls_util.h"
-
 
 //----------------------------------------------------------------------------
 // tls_util_add_tests()
@@ -52,7 +50,7 @@ int tls_util_add_tests(CU_pSuite suite)
 void test_create_tls_connection(void)
 {
   char *server_ip = "127.0.0.1";
-  unsigned char *client_private_key = (unsigned char *)"1234";
+  unsigned char *client_private_key = (unsigned char *) "1234";
   size_t client_private_key_len = 5;
   char *client_cert_path = "/path/to/client/cert";
   char *ca_cert_path = "/path/to/ca/cert";
@@ -104,29 +102,29 @@ void test_create_tls_connection(void)
 //----------------------------------------------------------------------------
 void test_tls_set_context(void)
 {
-  char* non_null_ptr = malloc(1);
+  char *non_null_ptr = malloc(1);
   SSL_CTX *ctx = NULL;
-  
+
   // A null client_private_key should produce an error
-  CU_ASSERT(tls_set_context((unsigned char*) NULL, 1, non_null_ptr,
+  CU_ASSERT(tls_set_context((unsigned char *) NULL, 1, non_null_ptr,
                             non_null_ptr, &ctx) == 1);
-  
+
   // A client_private_key of length zero should produce an error
-  CU_ASSERT(tls_set_context((unsigned char*) non_null_ptr, 0, non_null_ptr,
+  CU_ASSERT(tls_set_context((unsigned char *) non_null_ptr, 0, non_null_ptr,
                             non_null_ptr, &ctx) == 1);
 
   // A null client certificate path should produce an error
-  CU_ASSERT(tls_set_context((unsigned char*) non_null_ptr, 1, NULL,
+  CU_ASSERT(tls_set_context((unsigned char *) non_null_ptr, 1, NULL,
                             non_null_ptr, &ctx) == 1);
 
   // A null server certificate path should produce an error
-  CU_ASSERT(tls_set_context((unsigned char*) non_null_ptr, 1, non_null_ptr,
+  CU_ASSERT(tls_set_context((unsigned char *) non_null_ptr, 1, non_null_ptr,
                             NULL, &ctx) == 1);
 
   // A client private key that is too large should produce an error
-  CU_ASSERT(tls_set_context((unsigned char*) non_null_ptr,
-                           ((size_t) INT_MAX) + 1, non_null_ptr,
-                           non_null_ptr, &ctx) == 1);
+  CU_ASSERT(tls_set_context((unsigned char *) non_null_ptr,
+                            ((size_t) INT_MAX) + 1, non_null_ptr,
+                            non_null_ptr, &ctx) == 1);
 
   // TODO: tls_set_context() tests beyond invalid inputs;
 
@@ -146,8 +144,7 @@ void test_get_key_from_tls_server(void)
 
   // A null BIO should produce an error
   CU_ASSERT(get_key_from_tls_server((BIO *) NULL,
-                                    message, message_length,
-                                    &key, &key_size));
+                                    message, message_length, &key, &key_size));
 
   // Cleanup
   BIO_free_all(bio);
@@ -166,8 +163,7 @@ void test_get_key_from_kmip_server(void)
 
   // A null BIO should produce an error
   CU_ASSERT(get_key_from_kmip_server((BIO *) NULL,
-                                     message, message_length,
-                                     &key, &key_size));
+                                     message, message_length, &key, &key_size));
 
   // A message that is too big should produce an error
   CU_ASSERT(get_key_from_kmip_server(bio,
@@ -176,8 +172,7 @@ void test_get_key_from_kmip_server(void)
 
   // A message that is empty should yield no return key.
   CU_ASSERT(get_key_from_kmip_server(bio,
-                                     (char *) NULL, 0,
-                                     &key, &key_size) == 0);
+                                     (char *) NULL, 0, &key, &key_size) == 0);
   CU_ASSERT(key == NULL);
   CU_ASSERT(key_size == 0);
 


### PR DESCRIPTION
Updated the Makefile to correct two issues:

1. The source and header files in the test directory did not use the indent utility to standardize whitespace conventions for the code contained in these files. In the "pretest" target, a call to indent for these functions was added. Updates to compile the list of test source and header files (to be passed to indent) were also made.

2. When the header file directory was re-organized to include sub-folders, the the "pre" target calls to indent no longer included the files in these subfolders. This pull request, then, updates the makefile to compile a comprehensive list of header files and use that as the argument to the indent call intended to reformat the header files.

Running indent on the corrected list of files resulted in a very large number of whitespace edits across the code base. Therefore, this is not a trivial set of changes.