### PR TITLE
added option to build kmyth logger features into separate shared library

### DIFF
--- a/tpm2/INSTALL.md
+++ b/tpm2/INSTALL.md
@@ -100,7 +100,8 @@ Once the dependencies are installed:
    documentation is put in ./doc.
 
 3. In the `tpm2` directory run *make* or  *make all* to create:
-  * ./lib/libkmyth.so
+  * ./lib/libkmyth-logger.so
+  * ./lib/libkmyth-tpm.so
   * ./bin/kmyth-seal
   * ./bin/kmyth-unseal
   * ./bin/kmyth-getkey
@@ -108,19 +109,37 @@ Once the dependencies are installed:
 4. The existing build (executables, object files, and documentation) can be
    cleared away to support a fresh build by using *make clean*.
 
-5. To install the `kmyth` headers, library, and the executables run *sudo make install*. By default this installs:
-  * /usr/local/include/kmyth_log.h
-  * /usr/local/include/kmyth.h
+5. To install the `kmyth` headers, library, and the executables run
+   *sudo make install*. By default this installs:
+  * /usr/local/include/kmyth/kmyth_log.h
+  * /usr/local/include/kmyth/kmyth.h
+  * /usr/local/lib/libkmyth-logger.so
   * /usr/local/lib/libkmyth-tpm.so
   * /usr/local/bin/kmyth-seal
   * /usr/local/bin/kmyth-unseal
 
-These can be uninstalled by running *sudo make uninstall*.
+In addition to a normal (full) build/installation, the following two partial
+approaches are also supported for those applications needing more granular
+control of the process:
 
-6. To build the optional shared library containing only the kmyth logger
-   functionality, run *make logger-lib*. This creates:
+1. To build only the 'kmyth-logger' library run *make logger-lib*. This might
+   be useful if only the logging functionality is required. It creates:
   * ./logger/lib/libkmyth-logger.so
+   Running *sudo make install* after this will install:
+  * /usr/local/lib/libkmyth-logger.so
+  * /uae/local/include/kmyth/kmyth_log.h
 
+2. To build both kmyth shared libraries, but not the kmyth applications, run
+   *make tpm-util-lib*. This will create:
+  * ./lib/libkmyth-logger.so
+  * ./lib/libkmyth-tpm.so
+   Running *sudo make install* after this will install:
+  * /usr/local/include/kmyth/kmyth_log.h
+  * /usr/local/include/kmyth/kmyth.h
+  * /usr/local/lib/libkmyth-logger.so
+  * /usr/local/lib/libkmyth-tpm.so
+
+Any installed files can be uninstalled by running *sudo make uninstall*.
 
 ##### Running Kmyth Unit Tests
 

--- a/tpm2/INSTALL.md
+++ b/tpm2/INSTALL.md
@@ -111,11 +111,15 @@ Once the dependencies are installed:
 5. To install the `kmyth` headers, library, and the executables run *sudo make install*. By default this installs:
   * /usr/local/include/kmyth_log.h
   * /usr/local/include/kmyth.h
-  * /usr/local/lib/libkmyth.so
+  * /usr/local/lib/libkmyth-tpm.so
   * /usr/local/bin/kmyth-seal
   * /usr/local/bin/kmyth-unseal
-  
+
 These can be uninstalled by running *sudo make uninstall*.
+
+6. To build the optional shared library containing only the kmyth logger
+   functionality, run *make logger-lib*. This creates:
+  * ./logger/lib/libkmyth-logger.so
 
 
 ##### Running Kmyth Unit Tests

--- a/tpm2/INSTALL.md
+++ b/tpm2/INSTALL.md
@@ -128,9 +128,11 @@ control of the process:
    Running *sudo make install* after this will install:
   * /usr/local/lib/libkmyth-logger.so
   * /uae/local/include/kmyth/kmyth_log.h
+   Note: As this option does not build the kmyth TPM utilities library, unit
+   testing will not be possible (*make test* will fail).
 
 2. To build both kmyth shared libraries, but not the kmyth applications, run
-   *make tpm-util-lib*. This will create:
+   *make libs*. This will create:
   * ./lib/libkmyth-logger.so
   * ./lib/libkmyth-tpm.so
    Running *sudo make install* after this will install:
@@ -138,6 +140,8 @@ control of the process:
   * /usr/local/include/kmyth/kmyth.h
   * /usr/local/lib/libkmyth-logger.so
   * /usr/local/lib/libkmyth-tpm.so
+   Note: as this option builds all kmyth library functionality, unit testing
+   should be possible (*make test* should run unit tests).
 
 Any installed files can be uninstalled by running *sudo make uninstall*.
 

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -478,7 +478,11 @@ endif
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(TPM_UTIL_LIB_SONAME)
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(LOGGER_LIB_SONAME)
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
+ifeq ($(wildcard $(DESTDIR)$(PREFIX)/include/kmyth/*.h),)
 	rm -rf $(DESTDIR)$(PREFIX)/include/kmyth
+endif
 	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-seal
 	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-unseal
 

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -297,7 +297,6 @@ $(LIB_DIR)/libkmyth-tpm.so: $(UTIL_OBJECTS) \
 
 
 $(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o \
-                       $(LIB_DIR)/libkmyth-logger.so \
                        $(LIB_DIR)/libkmyth-tpm.so | \
                        $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/seal.o \
@@ -308,7 +307,6 @@ $(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o \
 	      -lkmyth-tpm
 
 $(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o \
-                         $(LIB_DIR)/libkmyth-logger.so \
                          $(LIB_DIR)/libkmyth-tpm.so | \
 												 $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/unseal.o \
@@ -319,7 +317,6 @@ $(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o \
 	      -lkmyth-tpm
 
 $(BIN_DIR)/kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o \
-                         $(LIB_DIR)/libkmyth-logger.so \
                          $(LIB_DIR)/libkmyth-tpm.so | \
                          $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/getkey.o \
@@ -410,7 +407,9 @@ pretest:
 	indent $(INDENT_OPTS) $(TEST_HEADERS)
 
 
-$(BIN_DIR)/kmyth-test: $(TEST_OBJECTS) | $(BIN_DIR)
+$(BIN_DIR)/kmyth-test: $(TEST_OBJECTS) \
+                       $(LIB_DIR)/libkmyth-tpm.so | \
+                       $(BIN_DIR)
 	$(CC) $(TEST_OBJECTS) \
 	      -o $(BIN_DIR)/kmyth-test \
 	      $(LDFLAGS) \

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -394,7 +394,7 @@ pretest:
 	indent $(INDENT_OPTS) $(TEST_HEADERS)
 
 .PHONY: kmyth-test
-kmyth-test: $(TEST_OBJECTS)
+kmyth-test: $(TEST_OBJECTS) | $(BIN_DIR)
 	$(CC) $(TEST_OBJECTS) \
 	      -o $(BIN_DIR)/kmyth-test \
 	      $(LDFLAGS) \

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -64,27 +64,26 @@ HEADER_FILES += $(UTIL_HEADERS)
 HEADER_FILES += $(CIPHER_HEADERS)
 HEADER_FILES += $(TPM_HEADERS)
 
-# Consolidate created directories to simplify mkdir call for 'pre' target
-OBJECT_DIRS = $(MAIN_OBJ_DIR)
-OBJECT_DIRS += $(UTIL_OBJ_DIR)
-OBJECT_DIRS += $(CIPHER_OBJ_DIR)
-OBJECT_DIRS += $(TPM_OBJ_DIR)
-OBJECT_DIRS += $(LOGGER_OBJ_DIR)
-
 # Specify Kmyth logger shared library directories/files
 LOGGER_SRC_DIR = $(LOGGER_DIR)/src
 LOGGER_SOURCES = $(wildcard $(LOGGER_SRC_DIR)/*.c)
 LOGGER_INC_DIR = $(LOGGER_DIR)/include
 LOGGER_OBJ_DIR = $(LOGGER_DIR)/obj
+LOGGER_LIB_DIR = $(LOGGER_DIR)/lib
 LOGGER_OBJECTS = $(subst $(LOGGER_SRC_DIR), \
                          $(LOGGER_OBJ_DIR), \
                          $(LOGGER_SOURCES:%.c=%.o))
 LOGGER_HEADER_FILES = $(wildcard $(LOGGER_INC_DIR)/*.h)
 
-# Specify path for logger output of shared library
-KMYTH_LIB_NAME = kmyth
-KMYTH_LIB_SONAME = lib$(KMYTH_LIB_NAME)-tpm.so
-KMYTH_LIB_LOCAL_DEST = $(LIB_DIR)/$(KMYTH_LIB_SONAME)
+# Specify details for kmyth TPM utilities shared (.so) library
+TPM_UTIL_LIB_NAME = kmyth-tpm
+TPM_UTIL_LIB_SONAME = lib$(TPM_UTIL_LIB_NAME).so
+TPM_UTIL_LIB_LOCAL_DEST = $(LIB_DIR)/$(TPM_UTIL_LIB_SONAME)
+
+# Specify details for optional kmyth logger shared (.so) library
+LOGGER_LIB_NAME = kmyth-logger
+LOGGER_LIB_SONAME = lib$(LOGGER_LIB_NAME).so
+LOGGER_LIB_LOCAL_DEST = $(LOGGER_LIB_DIR)/$(LOGGER_LIB_SONAME)
 
 #====================== END: BUILD ENVIRONMENT DEFINITION ====================
 
@@ -254,35 +253,46 @@ INDENT_OPTS += -l80#                     max non-comment line length is 80
 #====================== START: RULES =========================================
 
 .PHONY: all
-all: pre kmyth-lib kmyth-seal kmyth-unseal kmyth-getkey
+all: pre tpm-util-lib kmyth-seal kmyth-unseal kmyth-getkey
 
-kmyth-lib: $(LOGGER_OBJECTS) \
-           $(UTIL_OBJECTS) \
-           $(CIPHER_OBJECTS) \
-           $(TPM_OBJECTS)
+.PHONY: pre
+pre:
+	indent $(INDENT_OPTS) $(SOURCE_FILES)
+	indent $(INDENT_OPTS) $(HEADER_FILES)
+	rm -f $(shell find -name "*~" -print)
+
+.PHONY: tpm-util-lib
+tpm-util-lib: $(UTIL_OBJECTS) \
+	            $(CIPHER_OBJECTS) \
+              $(TPM_OBJECTS) \
+              $(LOGGER_OBJECTS) | \
+	            $(LIB_DIR)
 	$(CC) $(SOFLAGS) \
-	      $(LOGGER_OBJECTS) \
+				$(LOGGER_OBJECTS) \
 	      $(UTIL_OBJECTS) \
 	      $(CIPHER_OBJECTS) \
 	      $(TPM_OBJECTS) \
-	      -o $(KMYTH_LIB_LOCAL_DEST) \
-	      $(LDLIBS)
+	      -o $(TPM_UTIL_LIB_LOCAL_DEST) \
+	      $(LDLIBS) \
 
-kmyth-seal: $(MAIN_OBJ_DIR)/seal.o
+.PHONY: kmyth-seal
+kmyth-seal: $(MAIN_OBJ_DIR)/seal.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/seal.o \
 	      -o $(BIN_DIR)/kmyth-seal \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
 	      -lkmyth-tpm
 
-kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o
+.PHONY: kmyth-unseal
+kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/unseal.o \
 	      -o $(BIN_DIR)/kmyth-unseal \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
 	      -lkmyth-tpm
 
-kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o
+.PHONY: kmyth-getkey
+kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/getkey.o \
 	      -o $(BIN_DIR)/kmyth-getkey \
 	      $(LDFLAGS) \
@@ -290,54 +300,74 @@ kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o
 	      -lkmyth-tpm
 
 $(LOGGER_OBJECTS): $(LOGGER_SOURCES) \
-                   $(LOGGER_HEADER_FILES)
+                   $(LOGGER_HEADER_FILES) | \
+                   $(LOGGER_OBJ_DIR)
 	$(CC) $(LOGGER_CFLAGS) \
 	      -I$(LOGGER_INC_DIR) \
 	      $< \
 	      -o $@
 
-$(MAIN_OBJ_DIR)/%.o: $(MAIN_SRC_DIR)/%.c \
-                     | $(MAIN_OBJ_DIR) 
+$(MAIN_OBJ_DIR)/%.o: $(MAIN_SRC_DIR)/%.c | \
+                     $(MAIN_OBJ_DIR) 
 	$(CC) $(KMYTH_CFLAGS) \
 	      $(KMYTH_INCLUDE_FLAGS) \
 	      $< \
 	      -o $@
 
 $(UTIL_OBJ_DIR)/%.o: $(UTIL_SRC_DIR)/%.c \
-                     $(UTIL_INC_DIR)/%.h \
-                     | $(UTIL_OBJ_DIR)
+                     $(UTIL_INC_DIR)/%.h | \
+                     $(UTIL_OBJ_DIR)
 	$(CC) $(KMYTH_CFLAGS) \
 	      $(KMYTH_INCLUDE_FLAGS) \
 	      $< \
 	      -o $@
 
 $(TPM_OBJ_DIR)/%.o: $(TPM_SRC_DIR)/%.c \
-                    $(TPM_INC_DIR)/%.h \
-                    | $(TPM_OBJ_DIR)
+                    $(TPM_INC_DIR)/%.h | \
+                    $(TPM_OBJ_DIR)
 	$(CC) $(KMYTH_CFLAGS) \
 	      $(KMYTH_INCLUDE_FLAGS) \
 	      $< \
 	      -o $@
 
 $(CIPHER_OBJ_DIR)/%.o: $(CIPHER_SRC_DIR)/%.c \
-                       $(CIPHER_INC_DIR)/%.h \
-                       | $(CIPHER_OBJ_DIR)
+                       $(CIPHER_INC_DIR)/%.h | \
+                       $(CIPHER_OBJ_DIR)
 	$(CC) $(KMYTH_CFLAGS) \
 	      $(KMYTH_INCLUDE_FLAGS) \
 	      $< \
 	      -o $@
 
-.PHONY: pre
-pre:
-	indent $(INDENT_OPTS) $(SOURCE_FILES)
-	indent $(INDENT_OPTS) $(HEADER_FILES)
-	rm -f src/*.c~
-	rm -f src/*/*.c~
-	rm -f include/*.h~
-	rm -f include/*/*.h~
+$(BIN_DIR):
 	mkdir -p $(BIN_DIR)
-	mkdir -p $(OBJECT_DIRS)
+
+$(LIB_DIR):
 	mkdir -p $(LIB_DIR)
+
+$(MAIN_OBJ_DIR):
+	mkdir -p $(MAIN_OBJ_DIR)
+
+$(UTIL_OBJ_DIR):
+	mkdir -p $(UTIL_OBJ_DIR)
+
+$(CIPHER_OBJ_DIR):
+	mkdir -p $(CIPHER_OBJ_DIR)
+
+$(TPM_OBJ_DIR):
+	mkdir -p $(TPM_OBJ_DIR)
+
+$(LOGGER_OBJ_DIR):
+	mkdir -p $(LOGGER_OBJ_DIR)
+
+.PHONY: logger-lib
+logger-lib: $(LOGGER_OBJECTS) | $(LOGGER_LIB_DIR)
+	$(CC) $(SOFLAGS) \
+	      $(LOGGER_OBJECTS) \
+	      -o $(LOGGER_LIB_LOCAL_DEST) \
+	      $(LDLIBS)
+
+$(LOGGER_LIB_DIR):
+	mkdir -p $(LOGGER_LIB_DIR)
 
 .PHONY: doc
 doc: $(HEADER_FILES) \
@@ -354,6 +384,89 @@ doc: $(HEADER_FILES) \
 test: pretest kmyth-test
 	./bin/kmyth-test 2>/dev/null
 
+.PHONY: pretest
+pretest:
+	indent $(INDENT_OPTS) $(TEST_SOURCES)
+	indent $(INDENT_OPTS) $(TEST_HEADERS)
+	rm -f $(shell find $(TEST_DIR) -name "*~" -print)
+
+.PHONY: kmyth-test
+kmyth-test: $(TEST_OBJECTS)
+	$(CC) $(TEST_OBJECTS) \
+	      -o $(BIN_DIR)/kmyth-test \
+	      $(LDFLAGS) \
+	      $(LDLIBS) \
+	      -lcunit \
+	      -lkmyth-tpm
+
+$(TEST_OBJ_DIR)/kmyth-test.o: $(TEST_SRC_DIR)/kmyth-test.c | \
+                              $(TEST_OBJ_DIR)
+	$(CC) $(KMYTH_CFLAGS) $(KMYTH_INCLUDE_FLAGS) $(TEST_INCLUDE_FLAGS) $< -o $@
+
+$(TEST_UTIL_OBJ_DIR)/%.o: $(TEST_UTIL_SRC_DIR)/%.c \
+                          $(TEST_UTIL_INC_DIR)/%.h | \
+                          $(TEST_UTIL_OBJ_DIR)
+	$(CC) $(KMYTH_CFLAGS) \
+	      $(KMYTH_INCLUDE_FLAGS) \
+	      $(TEST_INCLUDE_FLAGS) \
+	      $< \
+	      -o $@
+
+$(TEST_TPM_OBJ_DIR)/%.o: $(TEST_TPM_SRC_DIR)/%.c \
+                         $(TEST_TPM_INC_DIR)/%.h | \
+                         $(TEST_TPM_OBJ_DIR)
+	$(CC) $(KMYTH_CFLAGS) \
+	      $(KMYTH_INCLUDE_FLAGS) \
+	      $(TEST_INCLUDE_FLAGS) \
+	      $< -o \
+	      $@
+
+$(TEST_CIPHER_OBJ_DIR)/%.o: $(TEST_CIPHER_SRC_DIR)/%.c \
+                            $(TEST_CIPHER_INC_DIR)/%.h | \
+                            $(TEST_CIPHER_OBJ_DIR)
+	$(CC) $(KMYTH_CFLAGS) \
+	      $(KMYTH_INCLUDE_FLAGS) \
+	      $(TEST_INCLUDE_FLAGS) \
+	      $< \
+	      -o $@
+
+$(TEST_OBJ_DIR):
+	mkdir -p $(TEST_OBJ_DIR)
+
+$(TEST_MAIN_OBJ_DIR):
+	mkdir -p $(TEST_MAIN_OBJ_DIR)
+
+$(TEST_UTIL_OBJ_DIR):
+	mkdir -p $(TEST_UTIL_OBJ_DIR)
+
+$(TEST_TPM_OBJ_DIR):
+	mkdir -p $(TEST_TPM_OBJ_DIR)
+
+$(TEST_CIPHER_OBJ_DIR):
+	mkdir -p $(TEST_CIPHER_OBJ_DIR)
+
+
+.PHONY: install
+install:
+	install -d $(DESTDIR)$(PREFIX)/lib
+	install -m 755 $(LIB_DIR)/$(TPM_UTIL_LIB_SONAME) $(DESTDIR)$(PREFIX)/lib/
+	install -d $(DESTDIR)$(PREFIX)/include/kmyth/
+	install -m 644 $(LOGGER_INC_DIR)/kmyth_log.h \
+	               $(DESTDIR)$(PREFIX)/include/kmyth/
+	install -m 644 $(INC_DIR)/kmyth.h $(DESTDIR)$(PREFIX)/include/kmyth/
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m 755 $(BIN_DIR)/kmyth-seal $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 $(BIN_DIR)/kmyth-unseal $(DESTDIR)$(PREFIX)/bin/
+	ldconfig
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/lib/$(TPM_UTIL_LIB_SONAME)
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth.h
+	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-seal
+	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-unseal
+
 .PHONY: install-test-vectors
 install-test-vectors: uninstall-test-vectors
 	mkdir -p $(TEST_VEC_DIRS)
@@ -368,76 +481,6 @@ install-test-vectors: uninstall-test-vectors
 uninstall-test-vectors:
 	rm -rf $(TEST_VEC_DIRS)
 
-.PHONY: pretest
-pretest:
-	indent $(INDENT_OPTS) $(TEST_SOURCES)
-	indent $(INDENT_OPTS) $(TEST_HEADERS)
-	rm -f test/src/*.c~
-	rm -f test/src/*/*.c~
-	rm -f test/include/*.h~
-	rm -f test/include/*/*.h~
-	mkdir -p $(TEST_OBJECT_DIRS)
-
-kmyth-test: $(TEST_OBJECTS)
-	$(CC) $(TEST_OBJECTS) \
-	      -o $(BIN_DIR)/kmyth-test \
-	      $(LDFLAGS) \
-	      $(LDLIBS) \
-	      -lcunit \
-	      -lkmyth-tpm
-
-$(TEST_OBJ_DIR)/kmyth-test.o: $(TEST_SRC_DIR)/kmyth-test.c \
-                              | $(TEST_OBJ_DIR)
-	$(CC) $(KMYTH_CFLAGS) $(KMYTH_INCLUDE_FLAGS) $(TEST_INCLUDE_FLAGS) $< -o $@
-
-$(TEST_UTIL_OBJ_DIR)/%.o: $(TEST_UTIL_SRC_DIR)/%.c \
-                          $(TEST_UTIL_INC_DIR)/%.h \
-                          | $(TEST_UTIL_OBJ_DIR)
-	$(CC) $(KMYTH_CFLAGS) \
-	      $(KMYTH_INCLUDE_FLAGS) \
-	      $(TEST_INCLUDE_FLAGS) \
-	      $< \
-	      -o $@
-
-$(TEST_TPM_OBJ_DIR)/%.o: $(TEST_TPM_SRC_DIR)/%.c \
-                         $(TEST_TPM_INC_DIR)/%.h \
-                         | $(TEST_TPM_OBJ_DIR)
-	$(CC) $(KMYTH_CFLAGS) \
-	      $(KMYTH_INCLUDE_FLAGS) \
-	      $(TEST_INCLUDE_FLAGS) \
-	      $< -o \
-	      $@
-
-$(TEST_CIPHER_OBJ_DIR)/%.o: $(TEST_CIPHER_SRC_DIR)/%.c \
-                            $(TEST_CIPHER_INC_DIR)/%.h \
-                            | $(TEST_CIPHER_OBJ_DIR)
-	$(CC) $(KMYTH_CFLAGS) \
-	      $(KMYTH_INCLUDE_FLAGS) \
-	      $(TEST_INCLUDE_FLAGS) \
-	      $< \
-	      -o $@
-
-.PHONY: install
-install:
-	install -d $(DESTDIR)$(PREFIX)/lib
-	install -m 755 $(LIB_DIR)/$(KMYTH_LIB_SONAME) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth/
-	install -m 644 $(LOGGER_INC_DIR)/kmyth_log.h \
-	               $(DESTDIR)$(PREFIX)/include/kmyth/
-	install -m 644 $(INC_DIR)/kmyth.h $(DESTDIR)$(PREFIX)/include/kmyth/
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 $(BIN_DIR)/kmyth-seal $(DESTDIR)$(PREFIX)/bin/
-	install -m 755 $(BIN_DIR)/kmyth-unseal $(DESTDIR)$(PREFIX)/bin/
-	ldconfig
-
-.PHONY: uninstall
-uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/lib/$(KMYTH_LIB_SONAME)
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth.h
-	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-seal
-	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-unseal
-
 .PHONY: clean
 clean:
 	rm -rf $(BIN_DIR)
@@ -446,5 +489,7 @@ clean:
 	rm -rf $(LIB_DIR)
 	rm -rf $(TEST_OBJ_DIR)
 	rm -rf $(LOGGER_OBJ_DIR)
+	rm -rf $(LOGGER_LIB_DIR)
+	rm -f $(shell find -name "*~" -print)
 
 #====================== END: RULES =========================================

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -401,7 +401,7 @@ doc: $(HEADER_FILES) \
 	doxygen Doxyfile
 
 .PHONY: test
-test: pretest clean-backups kmyth-test
+test: pretest clean-backups $(BIN_DIR)/kmyth-test
 	./bin/kmyth-test 2>/dev/null
 
 .PHONY: pretest
@@ -409,8 +409,8 @@ pretest:
 	indent $(INDENT_OPTS) $(TEST_SOURCES)
 	indent $(INDENT_OPTS) $(TEST_HEADERS)
 
-.PHONY: kmyth-test
-kmyth-test: $(TEST_OBJECTS) | $(BIN_DIR)
+
+$(BIN_DIR)/kmyth-test: $(TEST_OBJECTS) | $(BIN_DIR)
 	$(CC) $(TEST_OBJECTS) \
 	      -o $(BIN_DIR)/kmyth-test \
 	      $(LDFLAGS) \
@@ -418,8 +418,7 @@ kmyth-test: $(TEST_OBJECTS) | $(BIN_DIR)
 	      -lcunit \
 	      -lkmyth-tpm
 
-$(TEST_OBJ_DIR)/kmyth-test.o: $(TEST_SRC_DIR)/kmyth-test.c | \
-                              $(TEST_OBJ_DIR)
+$(TEST_OBJ_DIR)/kmyth-test.o: $(TEST_SRC_DIR)/kmyth-test.c | $(TEST_OBJ_DIR)
 	$(CC) $(KMYTH_CFLAGS) $(KMYTH_INCLUDE_FLAGS) $(TEST_INCLUDE_FLAGS) $< -o $@
 
 $(TEST_UTIL_OBJ_DIR)/%.o: $(TEST_UTIL_SRC_DIR)/%.c \

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -386,6 +386,9 @@ $(TPM_OBJ_DIR):
 $(LOGGER_OBJ_DIR):
 	mkdir -p $(LOGGER_OBJ_DIR)
 
+$(DOC_DIR):
+	mkdir -p $(DOC_DIR)
+
 .PHONY: doc
 doc: $(HEADER_FILES) \
      $(UTIL_SOURCES) \
@@ -393,8 +396,8 @@ doc: $(HEADER_FILES) \
      $(MAIN_SOURCES) \
      $(LOGGER_HEADERS) \
      $(LOGGER_SOURCES) \
-     Doxyfile
-	mkdir -p $(DOC_DIR)
+     Doxyfile | \
+		 $(DOC_DIR)
 	doxygen Doxyfile
 
 .PHONY: test

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -69,7 +69,6 @@ LOGGER_SRC_DIR = $(LOGGER_DIR)/src
 LOGGER_SOURCES = $(wildcard $(LOGGER_SRC_DIR)/*.c)
 LOGGER_INC_DIR = $(LOGGER_DIR)/include
 LOGGER_OBJ_DIR = $(LOGGER_DIR)/obj
-LOGGER_LIB_DIR = $(LOGGER_DIR)/lib
 LOGGER_OBJECTS = $(subst $(LOGGER_SRC_DIR), \
                          $(LOGGER_OBJ_DIR), \
                          $(LOGGER_SOURCES:%.c=%.o))
@@ -83,7 +82,10 @@ TPM_UTIL_LIB_LOCAL_DEST = $(LIB_DIR)/$(TPM_UTIL_LIB_SONAME)
 # Specify details for optional kmyth logger shared (.so) library
 LOGGER_LIB_NAME = kmyth-logger
 LOGGER_LIB_SONAME = lib$(LOGGER_LIB_NAME).so
-LOGGER_LIB_LOCAL_DEST = $(LOGGER_LIB_DIR)/$(LOGGER_LIB_SONAME)
+LOGGER_LIB_LOCAL_DEST = $(LIB_DIR)/$(LOGGER_LIB_SONAME)
+
+# Specify backup files to be cleaned up
+BACKUP_FILES = $(shell find -name "*~" -print)
 
 #====================== END: BUILD ENVIRONMENT DEFINITION ====================
 
@@ -253,16 +255,26 @@ INDENT_OPTS += -l80#                     max non-comment line length is 80
 #====================== START: RULES =========================================
 
 .PHONY: all
-all: pre tpm-util-lib kmyth-seal kmyth-unseal kmyth-getkey
+all: pre clean-backups logger-lib tpm-util-lib \
+     $(BIN_DIR)/kmyth-seal \
+     $(BIN_DIR)/kmyth-unseal \
+     $(BIN_DIR)/kmyth-getkey
 
 .PHONY: pre
 pre:
 	indent $(INDENT_OPTS) $(SOURCE_FILES)
 	indent $(INDENT_OPTS) $(HEADER_FILES)
-	rm -f $(shell find -name "*~" -print)
+
+.PHONY: logger-lib
+logger-lib: pre  clean-backups $(LOGGER_OBJECTS) | $(LIB_DIR)
+	$(CC) $(SOFLAGS) \
+	      $(LOGGER_OBJECTS) \
+	      -o $(LOGGER_LIB_LOCAL_DEST) \
+	      $(LDLIBS)
 
 .PHONY: tpm-util-lib
-tpm-util-lib: $(UTIL_OBJECTS) \
+tpm-util-lib: pre clean-backups logger-lib \
+              $(UTIL_OBJECTS) \
 	            $(CIPHER_OBJECTS) \
               $(TPM_OBJECTS) \
               $(LOGGER_OBJECTS) | \
@@ -273,30 +285,32 @@ tpm-util-lib: $(UTIL_OBJECTS) \
 	      $(CIPHER_OBJECTS) \
 	      $(TPM_OBJECTS) \
 	      -o $(TPM_UTIL_LIB_LOCAL_DEST) \
+	      $(LDFLAGS) \
 	      $(LDLIBS) \
+	      -lkmyth-logger
 
-.PHONY: kmyth-seal
-kmyth-seal: $(MAIN_OBJ_DIR)/seal.o | $(BIN_DIR)
+$(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/seal.o \
 	      -o $(BIN_DIR)/kmyth-seal \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
+	      -lkmyth-logger \
 	      -lkmyth-tpm
 
-.PHONY: kmyth-unseal
-kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o | $(BIN_DIR)
+$(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/unseal.o \
 	      -o $(BIN_DIR)/kmyth-unseal \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
+	      -lkmyth-logger \
 	      -lkmyth-tpm
 
-.PHONY: kmyth-getkey
-kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o | $(BIN_DIR)
+$(BIN_DIR)/kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o | $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/getkey.o \
 	      -o $(BIN_DIR)/kmyth-getkey \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
+	      -lkmyth-logger \
 	      -lkmyth-tpm
 
 $(LOGGER_OBJECTS): $(LOGGER_SOURCES) \
@@ -359,16 +373,6 @@ $(TPM_OBJ_DIR):
 $(LOGGER_OBJ_DIR):
 	mkdir -p $(LOGGER_OBJ_DIR)
 
-.PHONY: logger-lib
-logger-lib: $(LOGGER_OBJECTS) | $(LOGGER_LIB_DIR)
-	$(CC) $(SOFLAGS) \
-	      $(LOGGER_OBJECTS) \
-	      -o $(LOGGER_LIB_LOCAL_DEST) \
-	      $(LDLIBS)
-
-$(LOGGER_LIB_DIR):
-	mkdir -p $(LOGGER_LIB_DIR)
-
 .PHONY: doc
 doc: $(HEADER_FILES) \
      $(UTIL_SOURCES) \
@@ -381,14 +385,13 @@ doc: $(HEADER_FILES) \
 	doxygen Doxyfile
 
 .PHONY: test
-test: pretest kmyth-test
+test: pretest clean-backups kmyth-test
 	./bin/kmyth-test 2>/dev/null
 
 .PHONY: pretest
 pretest:
 	indent $(INDENT_OPTS) $(TEST_SOURCES)
 	indent $(INDENT_OPTS) $(TEST_HEADERS)
-	rm -f $(shell find $(TEST_DIR) -name "*~" -print)
 
 .PHONY: kmyth-test
 kmyth-test: $(TEST_OBJECTS)
@@ -445,25 +448,37 @@ $(TEST_TPM_OBJ_DIR):
 $(TEST_CIPHER_OBJ_DIR):
 	mkdir -p $(TEST_CIPHER_OBJ_DIR)
 
-
 .PHONY: install
 install:
+ifeq ($(wildcard $(LOGGER_LIB_LOCAL_DEST)), $(LOGGER_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
-	install -m 755 $(LIB_DIR)/$(TPM_UTIL_LIB_SONAME) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth/
+	install -m 755 $(LOGGER_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
+	install -d $(DESTDIR)$(PREFIX)/include/kmyth
 	install -m 644 $(LOGGER_INC_DIR)/kmyth_log.h \
 	               $(DESTDIR)$(PREFIX)/include/kmyth/
+	ldconfig
+endif
+ifeq ($(wildcard $(TPM_UTIL_LIB_LOCAL_DEST)), $(TPM_UTIL_LIB_LOCAL_DEST))
+	install -d $(DESTDIR)$(PREFIX)/lib
+	install -m 755 $(TPM_UTIL_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
+	install -d $(DESTDIR)$(PREFIX)/include/kmyth
 	install -m 644 $(INC_DIR)/kmyth.h $(DESTDIR)$(PREFIX)/include/kmyth/
+	ldconfig
+endif
+ifeq ($(wildcard $(BIN_DIR)/kmyth-seal), $(BIN_DIR)/kmyth-seal)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 $(BIN_DIR)/kmyth-seal $(DESTDIR)$(PREFIX)/bin/
+endif
+ifeq ($(wildcard $(BIN_DIR)/kmyth-unseal), $(BIN_DIR)/kmyth-unseal)
+	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 $(BIN_DIR)/kmyth-unseal $(DESTDIR)$(PREFIX)/bin/
-	ldconfig
+endif
 
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(TPM_UTIL_LIB_SONAME)
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth.h
+	rm -f $(DESTDIR)$(PREFIX)/lib/$(LOGGER_LIB_SONAME)
+	rm -rf $(DESTDIR)$(PREFIX)/include/kmyth
 	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-seal
 	rm -f $(DESTDIR)$(PREFIX)/bin/kmyth-unseal
 
@@ -482,14 +497,18 @@ uninstall-test-vectors:
 	rm -rf $(TEST_VEC_DIRS)
 
 .PHONY: clean
-clean:
+clean: clean-backups
 	rm -rf $(BIN_DIR)
 	rm -rf $(OBJ_DIR)
 	rm -rf $(DOC_DIR)
 	rm -rf $(LIB_DIR)
 	rm -rf $(TEST_OBJ_DIR)
 	rm -rf $(LOGGER_OBJ_DIR)
-	rm -rf $(LOGGER_LIB_DIR)
-	rm -f $(shell find -name "*~" -print)
+
+.PHONY: clean-backups
+clean-backups:
+ifneq ($(BACKUP_FILES),)
+	rm -f $(BACKUP_FILES)
+endif
 
 #====================== END: RULES =========================================

--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -255,32 +255,38 @@ INDENT_OPTS += -l80#                     max non-comment line length is 80
 #====================== START: RULES =========================================
 
 .PHONY: all
-all: pre clean-backups logger-lib tpm-util-lib \
+all: pre clean-backups \
      $(BIN_DIR)/kmyth-seal \
      $(BIN_DIR)/kmyth-unseal \
-     $(BIN_DIR)/kmyth-getkey
+     $(BIN_DIR)/kmyth-getkey \
+     $(LIB_DIR)/libkmyth-logger.so \
+     $(LIB_DIR)/libkmyth-tpm.so
 
 .PHONY: pre
 pre:
 	indent $(INDENT_OPTS) $(SOURCE_FILES)
 	indent $(INDENT_OPTS) $(HEADER_FILES)
 
+.PHONY: libs
+libs: pre clean-backups \
+      $(LIB_DIR)/libkmyth-logger.so \
+      $(LIB_DIR)/libkmyth-tpm.so
+
 .PHONY: logger-lib
-logger-lib: pre  clean-backups $(LOGGER_OBJECTS) | $(LIB_DIR)
+logger-lib: pre clean-backups $(LIB_DIR)/libkmyth-logger.so
+
+$(LIB_DIR)/libkmyth-logger.so: $(LOGGER_OBJECTS) | $(LIB_DIR)
 	$(CC) $(SOFLAGS) \
 	      $(LOGGER_OBJECTS) \
 	      -o $(LOGGER_LIB_LOCAL_DEST) \
 	      $(LDLIBS)
 
-.PHONY: tpm-util-lib
-tpm-util-lib: pre clean-backups logger-lib \
-              $(UTIL_OBJECTS) \
-	            $(CIPHER_OBJECTS) \
-              $(TPM_OBJECTS) \
-              $(LOGGER_OBJECTS) | \
-	            $(LIB_DIR)
+$(LIB_DIR)/libkmyth-tpm.so: $(UTIL_OBJECTS) \
+                            $(CIPHER_OBJECTS) \
+                            $(TPM_OBJECTS) \
+                            $(LIB_DIR)/libkmyth-logger.so | \
+                            $(LIB_DIR)
 	$(CC) $(SOFLAGS) \
-				$(LOGGER_OBJECTS) \
 	      $(UTIL_OBJECTS) \
 	      $(CIPHER_OBJECTS) \
 	      $(TPM_OBJECTS) \
@@ -289,7 +295,11 @@ tpm-util-lib: pre clean-backups logger-lib \
 	      $(LDLIBS) \
 	      -lkmyth-logger
 
-$(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o | $(BIN_DIR)
+
+$(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o \
+                       $(LIB_DIR)/libkmyth-logger.so \
+                       $(LIB_DIR)/libkmyth-tpm.so | \
+                       $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/seal.o \
 	      -o $(BIN_DIR)/kmyth-seal \
 	      $(LDFLAGS) \
@@ -297,7 +307,10 @@ $(BIN_DIR)/kmyth-seal: $(MAIN_OBJ_DIR)/seal.o | $(BIN_DIR)
 	      -lkmyth-logger \
 	      -lkmyth-tpm
 
-$(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o | $(BIN_DIR)
+$(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o \
+                         $(LIB_DIR)/libkmyth-logger.so \
+                         $(LIB_DIR)/libkmyth-tpm.so | \
+												 $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/unseal.o \
 	      -o $(BIN_DIR)/kmyth-unseal \
 	      $(LDFLAGS) \
@@ -305,7 +318,10 @@ $(BIN_DIR)/kmyth-unseal: $(MAIN_OBJ_DIR)/unseal.o | $(BIN_DIR)
 	      -lkmyth-logger \
 	      -lkmyth-tpm
 
-$(BIN_DIR)/kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o | $(BIN_DIR)
+$(BIN_DIR)/kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o \
+                         $(LIB_DIR)/libkmyth-logger.so \
+                         $(LIB_DIR)/libkmyth-tpm.so | \
+                         $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/getkey.o \
 	      -o $(BIN_DIR)/kmyth-getkey \
 	      $(LDFLAGS) \


### PR DESCRIPTION
Added "logger-lib" target to the Makefile, so that a shared library containing only the logger functionality can be optionally built. This is not a requirement for kmyth, but provides a way to build a kmyth-logger library so that the logger functionality can be exported, potentially, to other applications.

Moved build directory creation out of the "pre" target and implemented instead with makefile rules.

Moved a few things around in an attempt to make the grouping more logical.

Re-implemented the "delete back-ups" (i.e., file names ending in tilde) with a call to find.

Added a short blurb about how to build the "logger only" library to the INSTALL.md file.