### PR TITLE
removed unneeded library dependencies from logger-lib target

### DIFF
--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -230,7 +230,7 @@ SOFLAGS += -fPIC#
 
 # Specify linker flags
 LDFLAGS += -Llib#                        libkmyth
-LDFLAGS += -Wl,-rpath=lib#               runtime path for libkmyth.soa
+LDFLAGS += -Wl,-rpath=lib#               runtime path for libkmyth.so
 
 # Specify indentation options
 INDENT_OPTS = -bli0#                     indent braces zero spaces
@@ -278,8 +278,7 @@ logger-lib: pre clean-backups $(LIB_DIR)/libkmyth-logger.so
 $(LIB_DIR)/libkmyth-logger.so: $(LOGGER_OBJECTS) | $(LIB_DIR)
 	$(CC) $(SOFLAGS) \
 	      $(LOGGER_OBJECTS) \
-	      -o $(LOGGER_LIB_LOCAL_DEST) \
-	      $(LDLIBS)
+	      -o $(LOGGER_LIB_LOCAL_DEST)
 
 $(LIB_DIR)/libkmyth-tpm.so: $(UTIL_OBJECTS) \
                             $(CIPHER_OBJECTS) \


### PR DESCRIPTION
This pull request fixes a bug in the build process.

Building only the logger library (*make logger-lib*) should have no dependencies on having TPM libraries installed. As we were including the *$LDLIBS* options for building *libkmyth-logger.so*, however, this was not the case. The pull request fixes a typo in the comment describing *$LDFLAGS* and removes unneeded *$LDLIBS* options from the *$(LIB_DIR)/kmyth-logger.so* target.

With this fix, *make logger-lib* should build the logger library on a machine with none of the other kmyth software dependencies (e.g., tss2-*, OpenSSL, libkmip) installed.