### PR TITLE
Made function arguments const char*'s.

### DIFF
--- a/tpm2/logger/include/kmyth_log.h
+++ b/tpm2/logger/include/kmyth_log.h
@@ -150,7 +150,7 @@ extern "C" {
  *
  * @return None
  */
-void set_app_name(char *new_app_name);
+void set_app_name(const char *new_app_name);
 
 /**
  * @brief sets new version string for application being logged
@@ -159,7 +159,7 @@ void set_app_name(char *new_app_name);
  *
  * @return None
  */
-void set_app_version(char *new_app_version);
+void set_app_version(const char *new_app_version);
 
 /**
  * @brief sets new path string for application log file
@@ -168,7 +168,7 @@ void set_app_version(char *new_app_version);
  *
  * @return None
  */
-void set_applog_path(char *new_applog_path);
+void set_applog_path(const char *new_applog_path);
 
 /**
  * @brief sets new max log message length for the application log messages in file

--- a/tpm2/logger/src/kmyth_log.c
+++ b/tpm2/logger/src/kmyth_log.c
@@ -32,7 +32,7 @@ static struct log_params log_settings = {
 //############################################################################
 // set_app_name()
 //############################################################################
-void set_app_name(char *new_app_name)
+void set_app_name(const char *new_app_name)
 {
   bool truncated = false;
   size_t temp_len = 0;
@@ -65,7 +65,7 @@ void set_app_name(char *new_app_name)
 //############################################################################
 // set_app_version()
 //############################################################################
-void set_app_version(char *new_app_version)
+void set_app_version(const char *new_app_version)
 {
   bool truncated = false;
   size_t temp_len = 0;
@@ -99,7 +99,7 @@ void set_app_version(char *new_app_version)
 //############################################################################
 // set_applog_path()
 //############################################################################
-void set_applog_path(char *new_applog_path)
+void set_applog_path(const char *new_applog_path)
 {
   size_t temp_len = 0;
 


### PR DESCRIPTION
These changes make the kmyth_logger play more nicely with (standard-compliant) C++ callers by having some of the setup functions take const char*'s instead of char*'s. 