### PR TITLE
Add an implementation of Needham-Schroeder-Lowe for key retrieval

### DIFF
--- a/tpm2/Makefile
+++ b/tpm2/Makefile
@@ -259,6 +259,8 @@ all: pre clean-backups \
      $(BIN_DIR)/kmyth-seal \
      $(BIN_DIR)/kmyth-unseal \
      $(BIN_DIR)/kmyth-getkey \
+     $(BIN_DIR)/nsl-client \
+     $(BIN_DIR)/nsl-server \
      $(LIB_DIR)/libkmyth-logger.so \
      $(LIB_DIR)/libkmyth-tpm.so
 
@@ -320,6 +322,26 @@ $(BIN_DIR)/kmyth-getkey: $(MAIN_OBJ_DIR)/getkey.o \
                          $(BIN_DIR)
 	$(CC) $(MAIN_OBJ_DIR)/getkey.o \
 	      -o $(BIN_DIR)/kmyth-getkey \
+	      $(LDFLAGS) \
+	      $(LDLIBS) \
+	      -lkmyth-logger \
+	      -lkmyth-tpm
+
+$(BIN_DIR)/nsl-client: $(MAIN_OBJ_DIR)/nsl_client.o \
+                       $(LIB_DIR)/libkmyth-tpm.so | \
+                       $(BIN_DIR)
+	$(CC) $(MAIN_OBJ_DIR)/nsl_client.o \
+	      -o $(BIN_DIR)/nsl-client \
+	      $(LDFLAGS) \
+	      $(LDLIBS) \
+	      -lkmyth-logger \
+	      -lkmyth-tpm
+
+$(BIN_DIR)/nsl-server: $(MAIN_OBJ_DIR)/nsl_server.o \
+                       $(LIB_DIR)/libkmyth-tpm.so | \
+                       $(BIN_DIR)
+	$(CC) $(MAIN_OBJ_DIR)/nsl_server.o \
+	      -o $(BIN_DIR)/nsl-server \
 	      $(LDFLAGS) \
 	      $(LDLIBS) \
 	      -lkmyth-logger \

--- a/tpm2/include/util/kmip_util.h
+++ b/tpm2/include/util/kmip_util.h
@@ -1,0 +1,152 @@
+/**
+ * @file kmip_util.h
+ *
+ * @brief Utility functions for using the KMIP protocol.
+ */
+
+#ifndef KMYTH_KMIP_UTIL_H
+#define KMYTH_KMIP_UTIL_H
+
+/**
+ * <pre>
+ * This function builds a basic KMIP Get request message.
+ * </pre>
+ *
+ * @param[in]  ctx          the KMIP context used to build the message
+ *
+ * @param[in]  id           the ID of the KMIP object to retrieve
+ *
+ * @param[in]  id_len       length (in bytes) of the ID to retrieve
+ *
+ * @param[out] request      the KMIP Get request message
+ *
+ * @param[out] request_len  length (in bytes) of the request message
+ *
+ * @return 0 on success, 1 on error
+ */
+int build_kmip_get_request(KMIP *ctx,
+                           unsigned char *id, size_t id_len,
+                           unsigned char **request, size_t *request_len);
+
+/**
+ * <pre>
+ * This function parses a basic KMIP Get request message.
+ * </pre>
+ *
+ * @param[in]  ctx          the KMIP context used to parse the message
+ *
+ * @param[in]  request      the KMIP Get request message
+ *
+ * @param[in]  request_len  length (in bytes) of the request message
+ *
+ * @param[out] id           the ID of the KMIP object to retrieve
+ *
+ * @param[out] id_len       length (in bytes) of the ID to retrieve
+ *
+ * @return 0 on success, 1 on error
+ */
+int parse_kmip_get_request(KMIP *ctx,
+                           unsigned char *request, size_t request_len,
+                           unsigned char **id, size_t *id_len);
+
+/**
+ * <pre>
+ * This function builds a KMIP Get response message.
+ * </pre>
+ *
+ * @param[in]  ctx           the KMIP context used to build the message
+ *
+ * @param[in]  id            the key ID
+ *
+ * @param[in]  id_len        length (in bytes) of the key ID
+ *
+ * @param[in]  key           the symmetric key
+ *
+ * @param[in]  key_len       length (in bytes) of the key
+ *
+ * @param[out] response      the KMIP Get response message
+ *
+ * @param[out] response_len  length (in bytes) of the response message
+ *
+ * @return 0 on success, 1 on error
+ */
+int build_kmip_get_response(KMIP *ctx,
+                            unsigned char *id, size_t id_len,
+                            unsigned char *key, size_t key_len,
+                            unsigned char **response, size_t *response_len);
+
+/**
+ * <pre>
+ * This function parses a KMIP Get response message.
+ * </pre>
+ *
+ * @param[in]  ctx           the KMIP context used to parse the message
+ *
+ * @param[in]  response      the KMIP Get response message
+ *
+ * @param[in]  response_len  length (in bytes) of the response message
+ *
+ * @param[out] id            the retrieved key ID
+ *
+ * @param[out] id_len        length (in bytes) of the retrieved key ID
+ *
+ * @param[out] key           the retrieved key
+ *
+ * @param[out] key_len       length (in bytes) of the retrieved key
+ *
+ * @return 0 on success, 1 on error
+ */
+int parse_kmip_get_response(KMIP *ctx,
+                            unsigned char *response, size_t response_len,
+                            unsigned char **id, size_t *id_len,
+                            unsigned char **key, size_t *key_len);
+
+/**
+ * <pre>
+ * This function handles key retrieval using a session key to secure KMIP
+ * protocol messages.
+ * </pre>
+ *
+ * @param[in]  socket_fd        the open socket file descriptor
+ *
+ * @param[in]  session_key      the session key
+ *
+ * @param[in]  session_key_len  length (in bytes) of the session key
+ *
+ * @param[in]  key_id           the ID for the key to retrieve
+ *
+ * @param[in]  key_id_len       length (in bytes) of the key ID
+ *
+ * @param[out] key              the retrieved key
+ *
+ * @param[out] key_len          length (in bytes) of the retrieved key
+ *
+ * @return 0 on success, 1 on error
+ */
+int retrieve_key_with_session_key(int socket_fd,
+                                  unsigned char *session_key, size_t session_key_len,
+                                  unsigned char *key_id, size_t key_id_len,
+                                  unsigned char **key, size_t *key_len);
+
+/**
+ * <pre>
+ * This function handles key delivery using a session key to secure KMIP
+ * protocol messages.
+ * </pre>
+ *
+ * @param[in]  socket_fd        the open socket file descriptor
+ *
+ * @param[in]  session_key      the session key
+ *
+ * @param[in]  session_key_len  length (in bytes) of the session key
+ *
+ * @param[in]  key              the key to deliver
+ *
+ * @param[in]  key_len          length (in bytes) of the key to deliver
+ *
+ * @return 0 on success, 1 on error
+ */
+int send_key_with_session_key(int socket_fd,
+                              unsigned char *session_key, size_t session_key_len,
+                              unsigned char *key, size_t key_len);
+#endif

--- a/tpm2/include/util/nsl_util.h
+++ b/tpm2/include/util/nsl_util.h
@@ -1,0 +1,329 @@
+/**
+ * @file nsl_util.h
+ *
+ * @brief Utility functions supporting the Needham-Schroeder-Lowe protocol.
+ */
+
+#ifndef NSL_UTIL_H
+#define NSL_UTIL_H
+
+/* // OpenSSL libraries for TLS connection */
+#include <openssl/bio.h>
+
+/**
+ * <pre>
+ * This function encrypts plaintext using the provided EVP keypair context.
+ * </pre>
+ *
+ * @param[in]  ctx    EVP keypair context used for encryption
+ *
+ * @param[in]  p      plaintext
+ *
+ * @param[in]  p_len  length (in bytes) of the plaintext
+ *
+ * @param[out] c      ciphertext
+ *
+ * @param[out] c_len  length (in bytes) of the ciphertext
+ *
+ * @return 0 on success, 1 on error
+ */
+int encrypt_with_key_pair(EVP_PKEY_CTX ctx,
+                          const unsigned char *p, size_t p_len,
+                          unsigned char **c, size_t *c_len);
+
+/**
+ * <pre>
+ * This function decrypts ciphertext using the provided EVP keypair context.
+ * </pre>
+ *
+ * @param[in]  ctx    EVP keypair context used for decryption
+ *
+ * @param[in]  c      ciphertext
+ *
+ * @param[in]  c_len  length (in bytes) of the ciphertext
+ *
+ * @param[out] p      plaintext
+ *
+ * @param[out] p_len  length (in bytes) of the plaintext
+ *
+ * @return 0 on success, 1 on error
+ */
+int decrypt_with_key_pair(EVP_PKEY_CTX ctx,
+                          const unsigned char *c, size_t c_len,
+                          unsigned char **p, size_t *p_len);
+
+
+/**
+ * <pre>
+ * This function builds the nonce request for the initial NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx          EVP keypair context used for encryption
+ *
+ * @param[in]  nonce        the nonce
+ *
+ * @param[in]  nonce_len    length (in bytes) of the nonce string
+ *
+ * @param[in]  id           the ID of request sender
+ *
+ * @param[in]  id_len       length (in bytes) of the ID string
+ *
+ * @param[out] request      the encrypted request message
+ *
+ * @param[out] request_len  length (in bytes) of the request message
+ *
+ * @return 0 on success, 1 on error
+ */
+int build_nonce_request(EVP_PKEY_CTX *ctx,
+                        unsigned char *nonce, size_t nonce_len,
+                        unsigned char *id, size_t id_len,
+                        unsigned char **request, size_t *request_len);
+
+/**
+ * <pre>
+ * This function parses the nonce request for the initial NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx          EVP keypair context used for decryption
+ *
+ * @param[in]  request      the encrypted request message
+ *
+ * @param[in]  request_len  length (in bytes) of the request message
+ *
+ * @param[out] nonce        the nonce
+ *
+ * @param[out] nonce_len    length (in bytes) of the nonce string
+ *
+ * @param[out] id           the ID of the request sender
+ *
+ * @param[out] id_len       length (in bytes) of the ID string
+ *
+ * @return 0 on success, 1 on error
+ */
+int parse_nonce_request(EVP_PKEY_CTX *ctx,
+                        unsigned char *request, size_t request_len,
+                        unsigned char **nonce, size_t *nonce_len,
+                        unsigned char **id, size_t *id_len);
+
+/**
+ * <pre>
+ * This function builds the nonce response for the NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx           EVP keypair context used for encryption
+ *
+ * @param[in]  nonce_a       nonce A
+ *
+ * @param[in]  nonce_a_len   length (in bytes) of nonce A
+ *
+ * @param[in]  nonce_b       nonce B
+ *
+ * @param[in]  nonce_b_len   length (in bytes) of nonce B
+ *
+ * @param[in]  id            the ID of the response sender
+ *
+ * @param[in]  id_len        length (in bytes) of the ID string
+ *
+ * @param[out] response      the response message
+ *
+ * @param[out] response_len  length (in bytes) of the response message
+ *
+ * @return 0 on success, 1 on error
+ */
+int build_nonce_response(EVP_PKEY_CTX *ctx,
+                         unsigned char *nonce_a, size_t nonce_a_len,
+                         unsigned char *nonce_b, size_t nonce_b_len,
+                         unsigned char *id, size_t id_len,
+                         unsigned char **response, size_t *response_len);
+
+/**
+ * <pre>
+ * This function parses the nonce response for the NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx           EVP keypair context used for decryption
+ *
+ * @param[in]  response      the response message
+ *
+ * @param[in]  response_len  length (in bytes) of the response message
+ *
+ * @param[out] nonce_a       nonce A
+ *
+ * @param[out] nonce_a_len   length (in bytes) of nonce A
+ *
+ * @param[out] nonce_b       nonce B
+ *
+ * @param[out] nonce_b_len   length (in bytes) of nonce B
+ *
+ * @param[out] id            the ID of the response sender
+ *
+ * @param[out] id_len        length (in bytes) of the received ID
+ *
+ * @return 0 on success, 1 on error
+ */
+int parse_nonce_response(EVP_PKEY_CTX *ctx,
+                         unsigned char *response, size_t response_len,
+                         unsigned char **nonce_a, size_t *nonce_a_len,
+                         unsigned char **nonce_b, size_t *nonce_b_len,
+                         unsigned char **id, size_t *id_len);
+
+/**
+ * <pre>
+ * This function builds the nonce confirmation for the NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx               EVP keypair context used for encryption
+ *
+ * @param[in]  nonce             the nonce being confirmed
+ *
+ * @param[in]  nonce_len         length (in bytes) of the nonce
+ *
+ * @param[out] confirmation      the confirmation message
+ *
+ * @param[out] confirmation_len  length (in bytes) of the confirmation message
+ *
+ * @return 0 on success, 1 on error
+ */
+int build_nonce_confirmation(EVP_PKEY_CTX *ctx,
+                             unsigned char *nonce, size_t nonce_len,
+                             unsigned char **confirmation, size_t *confirmation_len);
+
+/**
+ * <pre>
+ * This function parses the nonce confirmation for the NSL handshake.
+ * </pre>
+ *
+ * @param[in]  ctx               EVP keypair context used for decryption
+ *
+ * @param[in]  confirmation      the confirmation message
+ *
+ * @param[in]  confirmation_len  length (in bytes) of the confirmation message
+ *
+ * @param[out] nonce             the nonce being confirmed
+ *
+ * @param[out] nonce_len         length (in bytes) of the nonce
+ *
+ * @return 0 on success, 1 on error
+ */
+int parse_nonce_confirmation(EVP_PKEY_CTX *ctx,
+                             unsigned char *confirmation, size_t confirmation_len,
+                             unsigned char **nonce, size_t *nonce_len);
+
+/**
+ * <pre>
+ * This function sets up the EVP context for a public key.
+ * </pre>
+ *
+ * @param[in] filepath  The file path to the public key file.
+ *
+ * @return EVP_PKEY_CTX object on success, NULL on error
+ */
+EVP_PKEY_CTX *setup_public_evp_context(const char *filepath);
+
+/**
+ * <pre>
+ * This function sets up the EVP context for a private key.
+ * </pre>
+ *
+ * @param[in] filepath  The file path to the private key file.
+ *
+ * @return EVP_PKEY_CTX object on success, NULL on error
+ */
+EVP_PKEY_CTX *setup_private_evp_context(const char *filepath);
+
+/**
+ * <pre>
+ * This function generates a session key from two nonce values.
+ * </pre>
+ *
+ * @param[in]  nonce_a      nonce A
+ *
+ * @param[in]  nonce_a_len  length (in bytes) of nonce A
+ *
+ * @param[in]  nonce_b      nonce B
+ *
+ * @param[in]  nonce_b_len  length (in bytes) of nonce B
+ *
+ * @param[out] key          the generated session key
+ *
+ * @param[out] key_len      length (in bytes) of the session key
+ *
+ * @return 0 on success, 1 on error
+ */
+int generate_session_key(unsigned char *nonce_a, size_t nonce_a_len,
+                         unsigned char *nonce_b, size_t nonce_b_len,
+                         unsigned char **key, size_t *key_len);
+/**
+ * <pre>
+ * This function generates a random nonce value.
+ * </pre>
+ *
+ * @param[in]  desired_min_nonce_len  minimum length (in bytes) of the desired nonce
+ *
+ * @param[out] nonce                  the nonce
+ *
+ * @param[out] nonce_len              length (in bytes) of the nonce value
+ *
+ * @return 0 on success, 1 on error
+ */
+int generate_nonce(size_t desired_min_nonce_len, unsigned char **nonce, size_t *nonce_len);
+
+/**
+ * <pre>
+ * This function runs the client side NSL negotation to obtain a shared session key.
+ * </pre>
+ *
+ * @param[in]  socket_fd        the open socket file descriptor
+ *
+ * @param[in]  public_key_ctx   the EVP_PKEY_CTX containing the remote public key
+ *
+ * @param[in]  private_key_ctx  the EVP_PKEY_CTX containing the local private key
+ *
+ * @param[in]  id               the local ID
+ *
+ * @param[in]  id_len           length (in bytes) of the local ID
+ *
+ * @param[in]  expected_id      the expected ID
+ *
+ * @param[in]  expected_id_len  length (in bytes) of the expected ID
+ *
+ * @param[out] session_key      the session key
+ *
+ * @param[out] session_key_len  length (in bytes) of the session key
+ *
+ * @return 0 on success, 1 on error
+ */ 
+int negotiate_client_session_key(int socket_fd,
+                                 EVP_PKEY_CTX *public_key_ctx,
+                                 EVP_PKEY_CTX *private_key_ctx,
+                                 unsigned char *id, size_t id_len,
+                                 unsigned char *expected_id, size_t expected_id_len,
+                                 unsigned char **session_key, size_t *session_key_len);
+
+/**
+ * <pre>
+ * This function runs the server side NSL negotiation to obtain a shared session key.
+ * </pre>
+ *
+ * @param[in]  socket_fd        the open socket file descriptor
+ *
+ * @param[in]  public_key_ctx   the EVP_PKEY_CTX containing the remote public key
+ *
+ * @param[in]  private_key_ctx  the EVP_PKEY_CTX containing the local private key
+ *
+ * @param[in]  id               the local ID
+ *
+ * @param[in]  id_len           length (in bytes) of the local ID
+ * 
+ * @param[out] session_key      the session key
+ *
+ * @param[out] session_key_len  length (in bytes) of the session key
+ *
+ * @return 0 on success, 1 on error
+ */
+int negotiate_server_session_key(int socket_fd,
+                                 EVP_PKEY_CTX *public_key_ctx,
+                                 EVP_PKEY_CTX *private_key_ctx,
+                                 unsigned char *id, size_t id_len,
+                                 unsigned char **session_key, size_t *session_key_len);
+#endif

--- a/tpm2/include/util/nsl_util.h
+++ b/tpm2/include/util/nsl_util.h
@@ -7,9 +7,6 @@
 #ifndef NSL_UTIL_H
 #define NSL_UTIL_H
 
-/* // OpenSSL libraries for TLS connection */
-#include <openssl/bio.h>
-
 /**
  * <pre>
  * This function encrypts plaintext using the provided EVP keypair context.

--- a/tpm2/include/util/socket_util.h
+++ b/tpm2/include/util/socket_util.h
@@ -1,0 +1,39 @@
+/**
+ * @file socket_util.h
+ *
+ * @brief Utility functions supporting raw socket operations.
+ */
+
+#ifndef SOCKET_UTIL_H
+#define SOCKET_UTIL_H
+
+/**
+ * <pre>
+ * This function sets up a client socket for sending messages.
+ * </pre>
+ *
+ * @param[in]  node       The IP address or hostname to connect to.
+ *
+ * @param[in]  service    The port number or service to bind to.
+ *
+ * @param[out] socket_fd  The new socket file descriptor.
+ *
+ * @return 0 on success, 1 on error
+ */
+int setup_client_socket(const char *node, const char *service,
+                        int *socket_fd);
+
+/**
+ * <pre>
+ * This function sets up a server socket for receiving connections.
+ * </pre>
+ *
+ * @param[in]  service    The port number to bind to.
+ *
+ * @param[out] socket_fd  The new socket file descriptor.
+ *
+ * @return 0 on success, 1 on error
+ */
+int setup_server_socket(const char *service, int *socket_fd);
+
+#endif

--- a/tpm2/src/main/nsl_client.c
+++ b/tpm2/src/main/nsl_client.c
@@ -22,11 +22,11 @@ static void usage(const char *prog)
           "\nusage: %s [options]\n\n"
           "options are:\n\n"
           "Client Information --\n"
-          "  -k or --key   Path to the file containing the client's private key.\n"
+          "  -r or --priv   Path to the file containing the client's private key.\n"
           "Server Information --\n"
           "  -i or --ip    The IP address or hostname of the server.\n"
           "  -p or --port  The port number to connect to.\n"
-          "  -c or --cert  Path to the file containing the server's public certificate.\n"
+          "  -u or --pub  Path to the file containing the server's public key.\n"
           "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
 }
 
@@ -42,11 +42,11 @@ int check_string_arg(const char *arg, size_t arg_len,
 
 const struct option longopts[] = {
   // Client info
-  {"key", required_argument, 0, 'k'},
+  {"priv", required_argument, 0, 'r'},
   // Server info
   {"ip", required_argument, 0, 'i'},
   {"port", required_argument, 0, 'p'},
-  {"cert", required_argument, 0, 'c'},
+  {"pub", required_argument, 0, 'u'},
   // Misc
   {"help", no_argument, 0, 'h'},
   {0, 0, 0, 0}
@@ -70,12 +70,12 @@ int main(int argc, char **argv)
   int option_index;
 
   while ((options =
-          getopt_long(argc, argv, "k:i:p:c:h", longopts, &option_index)) != -1)
+          getopt_long(argc, argv, "r:i:p:u:h", longopts, &option_index)) != -1)
   {
     switch (options)
     {
       // Client info
-    case 'k':
+    case 'r':
       key = optarg;
       break;
       // Server info
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
     case 'p':
       port = optarg;
       break;
-    case 'c':
+    case 'u':
       cert = optarg;
       break;
       // Misc
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     }
   }
 
-  //set_applog_severity_threshold(7);
+  set_applog_severity_threshold(LOG_INFO);
 
   // Create socket to B
   int socket_fd = -1;

--- a/tpm2/src/main/nsl_client.c
+++ b/tpm2/src/main/nsl_client.c
@@ -1,0 +1,181 @@
+/**
+ * @file nsl_client.c
+ * @brief A client app for testing the Needham-Schroeder-Lowe protocol
+ */
+
+#include <getopt.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <kmip/kmip.h>
+
+#include "defines.h"
+#include "memory_util.h"
+#include "nsl_util.h"
+#include "socket_util.h"
+#include "kmip_util.h"
+#include "aes_gcm.h"
+
+static void usage(const char *prog)
+{
+  fprintf(stdout,
+          "\nusage: %s [options]\n\n"
+          "options are:\n\n"
+          "Client Information --\n"
+          "  -k or --key   Path to the file containing the client's private key.\n"
+          "Server Information --\n"
+          "  -i or --ip    The IP address or hostname of the server.\n"
+          "  -p or --port  The port number to connect to.\n"
+          "  -c or --cert  Path to the file containing the server's public certificate.\n"
+          "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
+}
+
+int check_string_arg(const char *arg, size_t arg_len,
+                     const char *value, size_t value_len)
+{
+  if ((arg_len != value_len) || strncmp(arg, value, value_len))
+  {
+    return 0;
+  }
+  return 1;
+}
+
+const struct option longopts[] = {
+  // Client info
+  {"key", required_argument, 0, 'k'},
+  // Server info
+  {"ip", required_argument, 0, 'i'},
+  {"port", required_argument, 0, 'p'},
+  {"cert", required_argument, 0, 'c'},
+  // Misc
+  {"help", no_argument, 0, 'h'},
+  {0, 0, 0, 0}
+};
+
+int main(int argc, char **argv)
+{
+  // Exit early if there are no arguments
+  if (1 == argc)
+  {
+    usage(argv[0]);
+    return 0;
+  }
+
+  char *key = NULL;
+  char *ip = NULL;
+  char *port = NULL;
+  char *cert = NULL;
+
+  int options;
+  int option_index;
+
+  while ((options =
+          getopt_long(argc, argv, "k:i:p:c:h", longopts, &option_index)) != -1)
+  {
+    switch (options)
+    {
+      // Client info
+    case 'k':
+      key = optarg;
+      break;
+      // Server info
+    case 'i':
+      ip = optarg;
+      break;
+    case 'p':
+      port = optarg;
+      break;
+    case 'c':
+      cert = optarg;
+      break;
+      // Misc
+    case 'h':
+      usage(argv[0]);
+      return 0;
+    default:
+      return 1;
+    }
+  }
+
+  //set_applog_severity_threshold(7);
+
+  // Create socket to B
+  int socket_fd = -1;
+  int result = setup_client_socket(ip, port, &socket_fd);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup socket.");
+    return 1;
+  }
+
+  // Load public/private keys; create EVP contexts
+  EVP_PKEY_CTX *public_key_ctx = setup_public_evp_context(cert);
+
+  if (NULL == public_key_ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup public EVP context.");
+    close(socket_fd);
+    return 1;
+  }
+  EVP_PKEY_CTX *private_key_ctx = setup_private_evp_context(key);
+
+  if (NULL == private_key_ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup the private EVP context.");
+    EVP_PKEY_CTX_free(public_key_ctx);
+    close(socket_fd);
+    return 1;
+  }
+
+  // Conduct NSL to obtain a shared session key
+  unsigned char *session_key = NULL;
+  size_t session_key_len = 0;
+
+  unsigned char *id = (unsigned char *) "A\0";
+  size_t id_len = 2;
+
+  unsigned char *remote_id = (unsigned char *) "B\0";
+  size_t remote_id_len = 2;
+
+  result = negotiate_client_session_key(socket_fd,
+                                        public_key_ctx,
+                                        private_key_ctx,
+                                        id, id_len,
+                                        remote_id, remote_id_len,
+                                        &session_key, &session_key_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to negotiate the client session key.");
+    close(socket_fd);
+    return 1;
+  }
+
+  EVP_PKEY_CTX_free(public_key_ctx);
+  EVP_PKEY_CTX_free(private_key_ctx);
+
+  // Request key K from B; encrypt message with S
+  unsigned char *key_id = (unsigned char *) "1\0";
+  size_t key_id_len = 2;
+
+  unsigned char *retrieved_key = NULL;
+  size_t retrieved_key_len = 0;
+
+  result = retrieve_key_with_session_key(socket_fd,
+                                         session_key, session_key_len,
+                                         key_id, key_id_len,
+                                         &retrieved_key, &retrieved_key_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to retrieve key: %.*s", key_id_len, key_id);
+    close(socket_fd);
+    return 1;
+  }
+  kmyth_log(LOG_INFO, "Received symmetric key: 0x%02X..%02X",
+            retrieved_key[0], retrieved_key[retrieved_key_len - 1]);
+
+  kmyth_clear_and_free(retrieved_key, retrieved_key_len);
+  close(socket_fd);
+
+  return 0;
+}

--- a/tpm2/src/main/nsl_server.c
+++ b/tpm2/src/main/nsl_server.c
@@ -18,10 +18,10 @@ static void usage(const char *prog)
           "\nusage: %s [options]\n\n"
           "options are :\n\n"
           "Server Information --\n"
-          "  -k or --key   Path to the file containing the server's private key.\n"
+          "  -r or --priv   Path to the file containing the server's private key.\n"
           "  -p or --port  The port number to connect to.\n"
           "Client Information --\n"
-          "  -c or --cert  Path to the file containing the client's public key.\n"
+          "  -u or --pub  Path to the file containing the client's public key.\n"
           "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
 }
 
@@ -37,10 +37,10 @@ int check_string_arg(const char *arg, size_t arg_len,
 
 const struct option longopts[] = {
   // Server info
-  {"key", required_argument, 0, 'k'},
+  {"priv", required_argument, 0, 'r'},
   {"port", required_argument, 0, 'p'},
   // Client info
-  {"cert", required_argument, 0, 'c'},
+  {"pub", required_argument, 0, 'u'},
   // Misc
   {"help", no_argument, 0, 'h'},
   {0, 0, 0, 0}
@@ -63,19 +63,19 @@ int main(int argc, char **argv)
   int option_index;
 
   while ((options =
-          getopt_long(argc, argv, "k:p:c:h", longopts, &option_index)) != -1)
+          getopt_long(argc, argv, "r:p:u:h", longopts, &option_index)) != -1)
   {
     switch (options)
     {
       // Server info
-    case 'k':
+    case 'r':
       key = optarg;
       break;
     case 'p':
       port = optarg;
       break;
       // Client info
-    case 'c':
+    case 'u':
       cert = optarg;
       break;
       // Misc
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     }
   }
 
-  //set_applog_severity_threshold(7);
+  set_applog_severity_threshold(LOG_INFO);
 
   // Create server socket
   kmyth_log(LOG_INFO, "Setting up server socket");

--- a/tpm2/src/main/nsl_server.c
+++ b/tpm2/src/main/nsl_server.c
@@ -1,0 +1,167 @@
+#include <getopt.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <netdb.h>
+
+#include <kmip/kmip.h>
+
+#include "defines.h"
+#include "nsl_util.h"
+#include "socket_util.h"
+#include "kmip_util.h"
+#include "aes_gcm.h"
+
+static void usage(const char *prog)
+{
+  fprintf(stdout,
+          "\nusage: %s [options]\n\n"
+          "options are :\n\n"
+          "Server Information --\n"
+          "  -k or --key   Path to the file containing the server's private key.\n"
+          "  -p or --port  The port number to connect to.\n"
+          "Client Information --\n"
+          "  -c or --cert  Path to the file containing the client's public key.\n"
+          "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
+}
+
+int check_string_arg(const char *arg, size_t arg_len,
+                     const char *value, size_t value_len)
+{
+  if ((arg_len != value_len) || strncmp(arg, value, value_len))
+  {
+    return 0;
+  }
+  return 1;
+}
+
+const struct option longopts[] = {
+  // Server info
+  {"key", required_argument, 0, 'k'},
+  {"port", required_argument, 0, 'p'},
+  // Client info
+  {"cert", required_argument, 0, 'c'},
+  // Misc
+  {"help", no_argument, 0, 'h'},
+  {0, 0, 0, 0}
+};
+
+int main(int argc, char **argv)
+{
+  // Exit early if there are no arguments.
+  if (1 == argc)
+  {
+    usage(argv[0]);
+    return 0;
+  }
+
+  char *key = NULL;
+  char *port = NULL;
+  char *cert = NULL;
+
+  int options;
+  int option_index;
+
+  while ((options =
+          getopt_long(argc, argv, "k:p:c:h", longopts, &option_index)) != -1)
+  {
+    switch (options)
+    {
+      // Server info
+    case 'k':
+      key = optarg;
+      break;
+    case 'p':
+      port = optarg;
+      break;
+      // Client info
+    case 'c':
+      cert = optarg;
+      break;
+      // Misc
+    case 'h':
+      usage(argv[0]);
+      return 0;
+    default:
+      return 1;
+    }
+  }
+
+  //set_applog_severity_threshold(7);
+
+  // Create server socket
+  kmyth_log(LOG_INFO, "Setting up server socket");
+
+  int socket_fd = -1;
+  int result = setup_server_socket(port, &socket_fd);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup server socket.");
+    return 1;
+  }
+
+  // Load public/private keys; create EVP contexts
+  EVP_PKEY_CTX *public_key_ctx = setup_public_evp_context(cert);
+
+  if (NULL == public_key_ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup public EVP context.");
+    close(socket_fd);
+    return 1;
+  }
+  EVP_PKEY_CTX *private_key_ctx = setup_private_evp_context(key);
+
+  if (NULL == private_key_ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to setup the private EVP context.");
+    EVP_PKEY_CTX_free(public_key_ctx);
+    close(socket_fd);
+    return 1;
+  }
+
+  // Conduct NSL to obtain a shared session key
+  unsigned char *id = (unsigned char *) "B\0";
+  size_t id_len = 2;
+
+  unsigned char *session_key = NULL;
+  size_t session_key_len = 0;
+
+  result = negotiate_server_session_key(socket_fd,
+                                        public_key_ctx,
+                                        private_key_ctx,
+                                        id, id_len,
+                                        &session_key, &session_key_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to negotiate the server session key.");
+    close(socket_fd);
+    return 1;
+  }
+
+  EVP_PKEY_CTX_free(public_key_ctx);
+  EVP_PKEY_CTX_free(private_key_ctx);
+
+  // Send key K to A; encrypt message with S
+  uint8 static_key[16] = {
+    0xD3, 0x51, 0x91, 0x0F, 0x1D, 0x79, 0x34, 0xD6,
+    0xE2, 0xAE, 0x17, 0x57, 0x65, 0x64, 0xE2, 0xBC
+  };
+  kmyth_log(LOG_INFO, "Loaded symmetric key: 0x%02X..%02X", static_key[0],
+            static_key[15]);
+
+  result = send_key_with_session_key(socket_fd,
+                                     session_key, session_key_len,
+                                     static_key, 16);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to send the static key.");
+    close(socket_fd);
+    return 1;
+  }
+
+  close(socket_fd);
+
+  return 0;
+}

--- a/tpm2/src/util/kmip_util.c
+++ b/tpm2/src/util/kmip_util.c
@@ -399,6 +399,14 @@ int retrieve_key_with_session_key(int socket_fd,
 
   // Read response from B; decrypt with S
   unsigned char *encrypted_response = calloc(8192, sizeof(unsigned char));
+
+  if (NULL == encrypted_response)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the encrypted response buffer.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
   size_t encrypted_response_len = 8192 * sizeof(unsigned char);
 
   int read_result = read(socket_fd, encrypted_response, encrypted_response_len);
@@ -406,6 +414,7 @@ int retrieve_key_with_session_key(int socket_fd,
   if (-1 == read_result)
   {
     kmyth_log(LOG_ERR, "Failed to read the key response.");
+    kmyth_clear_and_free(encrypted_response, encrypted_response_len);
     kmip_destroy(&kmip_context);
     return 1;
   }
@@ -418,6 +427,7 @@ int retrieve_key_with_session_key(int socket_fd,
   result = aes_gcm_decrypt(session_key, session_key_len,
                            encrypted_response, read_result,
                            &response, &response_len);
+  kmyth_clear_and_free(encrypted_response, encrypted_response_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to decrypt the KMIP key response.");
@@ -456,6 +466,13 @@ int send_key_with_session_key(int socket_fd,
                               size_t key_len)
 {
   unsigned char *encrypted_request = calloc(8192, sizeof(unsigned char));
+
+  if (NULL == encrypted_request)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocated the encrypted request buffer.");
+    return 1;
+  }
+
   size_t encrypted_request_len = 8192 * sizeof(unsigned char);
 
   struct sockaddr_storage peer_addr;

--- a/tpm2/src/util/kmip_util.c
+++ b/tpm2/src/util/kmip_util.c
@@ -1,0 +1,584 @@
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <netdb.h>
+
+#include <kmip/kmip.h>
+
+#include "defines.h"
+#include "memory_util.h"
+#include "aes_gcm.h"
+
+//
+// build_kmip_get_request()
+//
+int build_kmip_get_request(KMIP * ctx,
+                           unsigned char *id, size_t id_len,
+                           unsigned char **request, size_t *request_len)
+{
+  // Set up the encoding buffer.
+  size_t buffer_blocks = 1;
+  size_t buffer_block_size = 1024;
+  size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+  uint8 *encoding = calloc(buffer_blocks, buffer_block_size);
+
+  if (encoding == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the KMIP encoding buffer.");
+    return 1;
+  }
+  kmip_reset(ctx);
+  kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+  // Build the KMIP Get request.
+  ProtocolVersion protocol_version = { 0 };
+  kmip_init_protocol_version(&protocol_version, ctx->version);
+
+  RequestHeader header = { 0 };
+  kmip_init_request_header(&header);
+
+  header.protocol_version = &protocol_version;
+  header.maximum_response_size = ctx->max_message_size;
+  header.time_stamp = time(NULL);
+  header.batch_count = 1;
+
+  TextString key_id = { 0 };
+  key_id.value = (char *) id;
+  key_id.size = id_len;
+
+  GetRequestPayload payload = { 0 };
+  payload.unique_identifier = &key_id;
+
+  RequestBatchItem batch_item = { 0 };
+  kmip_init_request_batch_item(&batch_item);
+  batch_item.operation = KMIP_OP_GET;
+  batch_item.request_payload = &payload;
+
+  RequestMessage message = { 0 };
+  message.request_header = &header;
+  message.batch_items = &batch_item;
+  message.batch_count = 1;
+
+  int result = kmip_encode_request_message(ctx, &message);
+
+  if (result != KMIP_OK)
+  {
+    kmyth_log(LOG_ERR, "Failed to encode the KMIP key request.");
+    kmyth_clear_and_free(encoding, buffer_total_size);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  // Set up the official request buffer and clean up.
+  *request_len = ctx->index - ctx->buffer;
+  *request = calloc(*request_len, sizeof(unsigned char));
+  if (request == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the KMIP request buffer.");
+    kmyth_clear_and_free(encoding, buffer_total_size);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  memcpy(*request, encoding, *request_len);
+
+  kmyth_clear_and_free(encoding, buffer_total_size);
+  kmip_set_buffer(ctx, NULL, 0);
+
+  return 0;
+}
+
+//
+// parse_kmip_get_request()
+//
+int parse_kmip_get_request(KMIP * ctx,
+                           unsigned char *request, size_t request_len,
+                           unsigned char **id, size_t *id_len)
+{
+  // Set up the decoding buffer and data structures.
+  kmip_reset(ctx);
+  kmip_set_buffer(ctx, request, request_len);
+  RequestMessage message = { 0 };
+
+  // Parse the request message and handle errors.
+  int result = kmip_decode_request_message(ctx, &message);
+
+  if (result != KMIP_OK)
+  {
+    kmyth_log(LOG_ERR, "Failed to decode the KMIP request message.");
+    kmip_free_request_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  if (message.request_header->batch_count != 1)
+  {
+    kmyth_log(LOG_ERR, "Expected to receive one request; received: %d",
+              message.request_header->batch_count);
+    kmip_free_request_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  RequestBatchItem batch_item = message.batch_items[0];
+
+  if (batch_item.operation != KMIP_OP_GET)
+  {
+    kmyth_log(LOG_ERR, "Did not receive a KMIP Get request.");
+    kmip_free_request_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  GetRequestPayload *payload = (GetRequestPayload *) batch_item.request_payload;
+
+  // Set up the official ID buffer and clean up.
+  *id = calloc(payload->unique_identifier->size, sizeof(unsigned char));
+  if (*id == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
+    kmip_free_request_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  *id_len = payload->unique_identifier->size;
+  memcpy(*id, payload->unique_identifier->value, *id_len);
+
+  kmip_free_request_message(ctx, &message);
+  kmip_set_buffer(ctx, NULL, 0);
+
+  return 0;
+}
+
+//
+// build_kmip_get_response()
+//
+int build_kmip_get_response(KMIP * ctx,
+                            unsigned char *id, size_t id_len,
+                            unsigned char *key, size_t key_len,
+                            unsigned char **response, size_t *response_len)
+{
+  // Set up the encoding buffer
+  size_t buffer_blocks = 1;
+  size_t buffer_block_size = 1024;
+  size_t buffer_total_size = buffer_blocks * buffer_block_size;
+
+  uint8 *encoding = calloc(buffer_blocks, buffer_block_size);
+
+  if (encoding == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the KMIP encoding buffer.");
+    return 1;
+  }
+  kmip_reset(ctx);
+  kmip_set_buffer(ctx, encoding, buffer_total_size);
+
+  // Build the KMIP Get response
+  ProtocolVersion protocol_version = { 0 };
+  kmip_init_protocol_version(&protocol_version, ctx->version);
+
+  ResponseHeader header = { 0 };
+  kmip_init_response_header(&header);
+
+  header.protocol_version = &protocol_version;
+  header.time_stamp = time(NULL);
+  header.batch_count = 1;
+
+  ByteString byte_string = { 0 };
+  byte_string.size = key_len;
+  byte_string.value = key;
+
+  KeyValue key_value = { 0 };
+  key_value.key_material = &byte_string;
+
+  KeyBlock key_block = { 0 };
+  key_block.key_format_type = KMIP_KEYFORMAT_RAW;
+  key_block.key_value = &key_value;
+
+  SymmetricKey symmetric_key = { 0 };
+  symmetric_key.key_block = &key_block;
+
+  TextString key_id = { 0 };
+  key_id.value = (char *) id;
+  key_id.size = id_len;
+
+  GetResponsePayload payload = { 0 };
+  payload.object_type = KMIP_OBJTYPE_SYMMETRIC_KEY;
+  payload.unique_identifier = &key_id;
+  payload.object = &symmetric_key;
+
+  ResponseBatchItem batch_item = { 0 };
+  batch_item.operation = KMIP_OP_GET;
+  batch_item.result_status = KMIP_STATUS_SUCCESS;
+  batch_item.response_payload = &payload;
+
+  ResponseMessage message = { 0 };
+  message.response_header = &header;
+  message.batch_items = &batch_item;
+  message.batch_count = 1;
+
+  int result = kmip_encode_response_message(ctx, &message);
+
+  if (result != KMIP_OK)
+  {
+    kmyth_log(LOG_ERR, "Failed to encode the KMIP Get response.");
+    kmyth_clear_and_free(encoding, buffer_total_size);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  // Set up the official response buffer and clean up.
+  *response_len = ctx->index - ctx->buffer;
+  *response = calloc(*response_len, sizeof(unsigned char));
+  if (response == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the KMIP response buffer.");
+    kmyth_clear_and_free(encoding, buffer_total_size);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  memcpy(*response, encoding, *response_len);
+
+  kmyth_clear_and_free(encoding, buffer_total_size);
+  kmip_set_buffer(ctx, NULL, 0);
+
+  return 0;
+}
+
+//
+// parse_kmip_get_response()
+//
+int parse_kmip_get_response(KMIP * ctx,
+                            unsigned char *response, size_t response_len,
+                            unsigned char **id, size_t *id_len,
+                            unsigned char **key, size_t *key_len)
+{
+  // Set up the decoding buffer and data structures.
+  kmip_reset(ctx);
+  kmip_set_buffer(ctx, response, response_len);
+  ResponseMessage message = { 0 };
+
+  // Parse the response message and handle errors.
+  int result = kmip_decode_response_message(ctx, &message);
+
+  if (result != KMIP_OK)
+  {
+    kmyth_log(LOG_ERR, "Failed to decode the KMIP response message.");
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  if (message.response_header->batch_count != 1)
+  {
+    kmyth_log(LOG_ERR, "Expected to receive one response; received: %d",
+              message.response_header->batch_count);
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  ResponseBatchItem batch_item = message.batch_items[0];
+
+  if (batch_item.operation != KMIP_OP_GET)
+  {
+    kmyth_log(LOG_ERR, "Did not receive a KMIP Get response.");
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  if (batch_item.result_status != KMIP_STATUS_SUCCESS)
+  {
+    kmyth_log(LOG_ERR, "The KMIP Get request failed: %.*s",
+              batch_item.result_message->size,
+              batch_item.result_message->value);
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  GetResponsePayload *payload =
+    (GetResponsePayload *) batch_item.response_payload;
+  if (payload->object_type != KMIP_OBJTYPE_SYMMETRIC_KEY)
+  {
+    kmyth_log(LOG_ERR, "The received KMIP object is not a symmetric key.");
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+
+  SymmetricKey *symmetric_key = (SymmetricKey *) payload->object;
+  KeyBlock *key_block = symmetric_key->key_block;
+  KeyValue *key_value = key_block->key_value;
+  ByteString *key_material = key_value->key_material;
+
+  // Set up the official ID and key buffers and clean up.
+  *id = calloc(payload->unique_identifier->size, sizeof(unsigned char));
+  if (*id == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  *id_len = payload->unique_identifier->size;
+  memcpy(*id, payload->unique_identifier->value, *id_len);
+
+  *key = calloc(key_material->size, sizeof(unsigned char));
+  if (*key == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the key buffer.");
+    kmyth_clear_and_free(*id, *id_len);
+    *id = NULL;
+    *id_len = 0;
+    kmip_free_response_message(ctx, &message);
+    kmip_set_buffer(ctx, NULL, 0);
+    return 1;
+  }
+  *key_len = key_material->size;
+  memcpy(*key, key_material->value, *key_len);
+
+  kmip_free_response_message(ctx, &message);
+  kmip_set_buffer(ctx, NULL, 0);
+
+  return 0;
+}
+
+//
+// retrieve_key_with_session_key()
+//
+int retrieve_key_with_session_key(int socket_fd,
+                                  unsigned char *session_key,
+                                  size_t session_key_len, unsigned char *key_id,
+                                  size_t key_id_len, unsigned char **key,
+                                  size_t *key_len)
+{
+  KMIP kmip_context = { 0 };
+  kmip_init(&kmip_context, NULL, 0, KMIP_2_0);
+
+  unsigned char *key_request = NULL;
+  size_t key_request_len = 0;
+
+  int result = build_kmip_get_request(&kmip_context,
+                                      key_id, key_id_len,
+                                      &key_request, &key_request_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to build the KMIP Get request.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  unsigned char *encrypted_request = NULL;
+  size_t encrypted_request_len = 0;
+
+  result = aes_gcm_encrypt(session_key, session_key_len,
+                           key_request, key_request_len,
+                           &encrypted_request, &encrypted_request_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the KMIP key request.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Sending request for a key with ID: %.*s", key_id_len,
+            key_id);
+  ssize_t write_result =
+    write(socket_fd, encrypted_request, encrypted_request_len);
+
+  if (write_result != encrypted_request_len)
+  {
+    kmyth_log(LOG_ERR, "Failed to fully send the key request.");
+    kmyth_log(LOG_ERR, "Expected to write %zd bytes, only wrote %zd bytes.",
+              encrypted_request_len, write_result);
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  // Read response from B; decrypt with S
+  unsigned char *encrypted_response = calloc(8192, sizeof(unsigned char));
+  size_t encrypted_response_len = 8192 * sizeof(unsigned char);
+
+  int read_result = read(socket_fd, encrypted_response, encrypted_response_len);
+
+  if (-1 == read_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to read the key response.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received %zd bytes.", read_result);
+
+  unsigned char *response = NULL;
+  size_t response_len = 0;
+
+  result = aes_gcm_decrypt(session_key, session_key_len,
+                           encrypted_response, read_result,
+                           &response, &response_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the KMIP key response.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  unsigned char *received_key_id = NULL;
+  size_t received_key_id_len = 0;
+
+  // Parse the key response
+  result = parse_kmip_get_response(&kmip_context,
+                                   response, response_len,
+                                   &received_key_id, &received_key_id_len,
+                                   key, key_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to parse the KMIP Get response.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+  kmyth_log(LOG_DEBUG, "Received a KMIP object with ID: %.*s",
+            received_key_id_len, received_key_id);
+
+  kmip_destroy(&kmip_context);
+
+  return 0;
+}
+
+//
+// send_key_with_session_key()
+//
+int send_key_with_session_key(int socket_fd,
+                              unsigned char *session_key,
+                              size_t session_key_len, unsigned char *key,
+                              size_t key_len)
+{
+  unsigned char *encrypted_request = calloc(8192, sizeof(unsigned char));
+  size_t encrypted_request_len = 8192 * sizeof(unsigned char);
+
+  struct sockaddr_storage peer_addr;
+  socklen_t peer_addr_len = sizeof(peer_addr);
+
+  ssize_t read_result = recvfrom(socket_fd,
+                                 encrypted_request, encrypted_request_len,
+                                 0,
+                                 (struct sockaddr *) &peer_addr,
+                                 &peer_addr_len);
+
+  if (-1 == read_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to receive the key request.");
+    kmyth_clear_and_free(encrypted_request, encrypted_request_len);
+    return 1;
+  }
+
+  char host[NI_MAXHOST] = { 0 };
+  char service[NI_MAXSERV] = { 0 };
+
+  int s = getnameinfo((struct sockaddr *) &peer_addr, peer_addr_len, host,
+                      NI_MAXHOST, service, NI_MAXSERV, NI_NUMERICSERV);
+
+  if (0 != s)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup host and service information.");
+    kmyth_clear_and_free(encrypted_request, encrypted_request_len);
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received %zd bytes from %s:%s", read_result, host,
+            service);
+
+  unsigned char *request = NULL;
+  size_t request_len = 0;
+
+  int result = aes_gcm_decrypt(session_key, session_key_len,
+                               encrypted_request, read_result,
+                               &request, &request_len);
+
+  kmyth_clear_and_free(encrypted_request, encrypted_request_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the KMIP key request.");
+    return 1;
+  }
+
+  KMIP kmip_context = { 0 };
+  kmip_init(&kmip_context, NULL, 0, KMIP_2_0);
+
+  if (request_len > kmip_context.max_message_size)
+  {
+    kmyth_log(LOG_ERR, "KMIP request exceeds max message size.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  unsigned char *key_id = NULL;
+  size_t key_id_len = 0;
+
+  result = parse_kmip_get_request(&kmip_context,
+                                  request, request_len, &key_id, &key_id_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to parse the KMIP Get request.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+  kmyth_log(LOG_INFO, "Received a KMIP Get request for key ID: %.*s",
+            key_id_len, key_id);
+
+  unsigned char *response = NULL;
+  size_t response_len = 0;
+
+  result = build_kmip_get_response(&kmip_context,
+                                   key_id, key_id_len,
+                                   key, key_len, &response, &response_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to build the KMIP Get response.");
+    kmip_destroy(&kmip_context);
+    return 1;
+  }
+
+  kmip_destroy(&kmip_context);
+
+  unsigned char *encrypted_response = NULL;
+  size_t encrypted_response_len = 0;
+
+  result = aes_gcm_encrypt(session_key, session_key_len,
+                           response, response_len,
+                           &encrypted_response, &encrypted_response_len);
+  kmyth_clear_and_free(response, response_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the KMIP key response.");
+    return 1;
+  }
+
+  s = getnameinfo((struct sockaddr *) &peer_addr, peer_addr_len,
+                  host, NI_MAXHOST, service, NI_MAXSERV, NI_NUMERICSERV);
+  if (0 != s)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup host and service information.");
+    kmyth_clear_and_free(encrypted_response, encrypted_response_len);
+    return 1;
+  }
+
+  ssize_t send_result = sendto(socket_fd,
+                               encrypted_response, encrypted_response_len,
+                               0, (struct sockaddr *) &peer_addr,
+                               peer_addr_len);
+
+  if (encrypted_response_len != send_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to fully send the encrypted KMIP key response.");
+    kmyth_clear_and_free(encrypted_response, encrypted_response_len);
+    return 1;
+  }
+  kmyth_log(LOG_INFO, "Successfully sent the encrypted KMIP key response.");
+
+  return 0;
+}

--- a/tpm2/src/util/nsl_util.c
+++ b/tpm2/src/util/nsl_util.c
@@ -1,0 +1,983 @@
+//
+// An implementation of the Needham-Schroeder-Lowe protocol using OpenSSL RSA.
+// 
+
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <netdb.h>
+
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <openssl/aes.h>
+
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/bn.h>
+#include <openssl/engine.h>
+
+#include "defines.h"
+
+//
+// encrypt_with_key_pair()
+//
+int encrypt_with_key_pair(EVP_PKEY_CTX * ctx,
+                          const unsigned char *p, size_t p_len,
+                          unsigned char **c, size_t *c_len)
+{
+  // Initialize the context for encryption.
+  int result = EVP_PKEY_encrypt_init(ctx);
+
+  if (result == 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to initialize the EVP context for encryption.");
+    return 1;
+  }
+
+  // Determine the length of the ciphertext buffer.
+  result = EVP_PKEY_encrypt(ctx, NULL, c_len, p, p_len);
+  if (result <= 0)
+  {
+    kmyth_log(LOG_ERR,
+              "Failed to determine the length of the ciphertext buffer.");
+    return 1;
+  }
+
+  // Allocate the ciphertext buffer.
+  *c = calloc(*c_len, sizeof(unsigned char));
+  if (*c == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the ciphertext buffer.");
+    return 1;
+  }
+
+  // Encrypt the plaintext.
+  result = EVP_PKEY_encrypt(ctx, *c, c_len, p, p_len);
+  if (result <= 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the plaintext.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// decrypt_with_key_pair()
+//
+int decrypt_with_key_pair(EVP_PKEY_CTX * ctx,
+                          const unsigned char *c, size_t c_len,
+                          unsigned char **p, size_t *p_len)
+{
+  // Initialize the context for decryption.
+  int result = EVP_PKEY_decrypt_init(ctx);
+
+  if (result == 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to initialize the EVP context for decryption.");
+    return 1;
+  }
+
+  // Determine the length of the plaintext buffer.
+  result = EVP_PKEY_decrypt(ctx, NULL, p_len, c, c_len);
+  if (result <= 0)
+  {
+    kmyth_log(LOG_ERR,
+              "Failed to determine the length of the plaintext buffer.");
+    return 1;
+  }
+
+  // Allocate the plaintext buffer.
+  *p = calloc(*p_len, sizeof(unsigned char));
+  if (*p == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the plaintext buffer.");
+    return 1;
+  }
+
+  // Decrypt the ciphertext.
+  result = EVP_PKEY_decrypt(ctx, *p, p_len, c, c_len);
+  if (result <= 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the ciphertext.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// build_nonce_request()
+// 
+int build_nonce_request(EVP_PKEY_CTX * ctx,
+                        unsigned char *nonce, size_t nonce_len,
+                        unsigned char *id, size_t id_len,
+                        unsigned char **request, size_t *request_len)
+{
+  // Allocate the unencrypted request buffer.
+  unsigned char *message = NULL;
+  size_t message_len = id_len + nonce_len + (2 * sizeof(size_t));
+
+  message = calloc(message_len, sizeof(unsigned char));
+  if (message == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the message buffer.");
+    return 1;
+  }
+
+  // Build the nonce request message.
+  unsigned char *index = message;
+
+  memcpy(index, &nonce_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, nonce, nonce_len);
+  index += nonce_len;
+  memcpy(index, &id_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, id, id_len);
+
+  // Encrypt the nonce request and then clean up the unencrypted request.
+  int result =
+    encrypt_with_key_pair(ctx, message, message_len, request, request_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  // Handle encryption errors if any occurred.
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the nonce request.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// parse_nonce_request()
+//
+int parse_nonce_request(EVP_PKEY_CTX * ctx,
+                        unsigned char *request, size_t request_len,
+                        unsigned char **nonce, size_t *nonce_len,
+                        unsigned char **id, size_t *id_len)
+{
+  // Decrypt the nonce request.
+  unsigned char *message = NULL;
+  size_t message_len = 0;
+  int result =
+    decrypt_with_key_pair(ctx, request, request_len, &message, &message_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the nonce request.");
+    return 1;
+  }
+  unsigned char *index = message;
+
+  // Parse out the nonce.
+  memcpy(nonce_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *nonce = calloc(*nonce_len, sizeof(unsigned char));
+  if (*nonce == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the nonce buffer.");
+
+    *nonce_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*nonce, index, *nonce_len);
+  index += *nonce_len;
+
+  // Parse out the ID.
+  memcpy(id_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *id = calloc(*id_len, sizeof(unsigned char));
+  if (*id == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
+
+    memset(*nonce, 0, *nonce_len);
+    free(*nonce);
+    *nonce = NULL;
+    *nonce_len = 0;
+
+    *id_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*id, index, *id_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  return 0;
+}
+
+//
+// build_nonce_response()
+//
+int build_nonce_response(EVP_PKEY_CTX * ctx,
+                         unsigned char *nonce_a, size_t nonce_a_len,
+                         unsigned char *nonce_b, size_t nonce_b_len,
+                         unsigned char *id, size_t id_len,
+                         unsigned char **response, size_t *response_len)
+{
+  // Allocate the unencrypted response buffer.
+  unsigned char *message = NULL;
+  size_t message_len =
+    id_len + nonce_a_len + nonce_b_len + (3 * sizeof(size_t));
+  message = calloc(message_len, sizeof(unsigned char));
+  if (message == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the message buffer.");
+    return 1;
+  }
+
+  // Build the nonce response message.
+  unsigned char *index = message;
+
+  memcpy(index, &nonce_a_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, nonce_a, nonce_a_len);
+  index += nonce_a_len;
+  memcpy(index, &nonce_b_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, nonce_b, nonce_b_len);
+  index += nonce_b_len;
+  memcpy(index, &id_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, id, id_len);
+
+  // Encrypt the nonce response and then clean up the unencrypted response.
+  int result =
+    encrypt_with_key_pair(ctx, message, message_len, response, response_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  // Handle encryption errors if any occurred.
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the nonce response.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// parse_nonce_response()
+//
+int parse_nonce_response(EVP_PKEY_CTX * ctx,
+                         unsigned char *response, size_t response_len,
+                         unsigned char **nonce_a, size_t *nonce_a_len,
+                         unsigned char **nonce_b, size_t *nonce_b_len,
+                         unsigned char **id, size_t *id_len)
+{
+  // Decrypt the nonce response.
+  unsigned char *message = NULL;
+  size_t message_len = 0;
+  int result =
+    decrypt_with_key_pair(ctx, response, response_len, &message, &message_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the nonce response.");
+    return 1;
+  }
+  unsigned char *index = message;
+
+  // Parse out the first nonce.
+  memcpy(nonce_a_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *nonce_a = calloc(*nonce_a_len, sizeof(unsigned char));
+  if (*nonce_a == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the first nonce buffer.");
+
+    *nonce_a_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*nonce_a, index, *nonce_a_len);
+  index += *nonce_a_len;
+
+  // Parse out the second nonce.
+  memcpy(nonce_b_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *nonce_b = calloc(*nonce_b_len, sizeof(unsigned char));
+  if (*nonce_b == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the second nonce buffer.");
+
+    *nonce_b_len = 0;
+
+    memset(*nonce_a, 0, *nonce_a_len);
+    free(*nonce_a);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*nonce_b, index, *nonce_b_len);
+  index += *nonce_b_len;
+
+  // Parse out the ID.
+  memcpy(id_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *id = calloc(*id_len, sizeof(unsigned char));
+  if (*id == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
+
+    memset(*nonce_a, 0, *nonce_a_len);
+    free(*nonce_a);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+
+    memset(*nonce_b, 0, *nonce_b_len);
+    free(*nonce_b);
+    *nonce_b = NULL;
+    *nonce_b_len = 0;
+
+    *id_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*id, index, *id_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  return 0;
+}
+
+//
+// build_nonce_confirmation()
+//
+int build_nonce_confirmation(EVP_PKEY_CTX * ctx,
+                             unsigned char *nonce, size_t nonce_len,
+                             unsigned char **confirmation,
+                             size_t *confirmation_len)
+{
+  // Allocate the unencrypted confirmation buffer.
+  unsigned char *message = NULL;
+  size_t message_len = nonce_len + sizeof(size_t);
+
+  message = calloc(message_len, sizeof(unsigned char));
+  if (message == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the message buffer.");
+    return 1;
+  }
+
+  // Build the nonce confirmation message.
+  unsigned char *index = message;
+
+  memcpy(index, &nonce_len, sizeof(size_t));
+  index += sizeof(size_t);
+  memcpy(index, nonce, nonce_len);
+
+  // Encrypt the nonce confirmation and then clean up the unencrypted
+  // confirmation.
+  int result = encrypt_with_key_pair(ctx, message, message_len, confirmation,
+                                     confirmation_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  // Handle encryption errors if any occurred.
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to encrypt the nonce confirmation.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// parse_nonce_confirmation()
+//
+int parse_nonce_confirmation(EVP_PKEY_CTX * ctx,
+                             unsigned char *confirmation,
+                             size_t confirmation_len, unsigned char **nonce,
+                             size_t *nonce_len)
+{
+  // Decrypt the nonce confirmation.
+  unsigned char *message = NULL;
+  size_t message_len = 0;
+  int result =
+    decrypt_with_key_pair(ctx, confirmation, confirmation_len, &message,
+                          &message_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to decrypt the nonce confirmation.");
+    return 1;
+  }
+  unsigned char *index = message;
+
+  // Parse out the nonce.
+  memcpy(nonce_len, index, sizeof(size_t));
+  index += sizeof(size_t);
+  *nonce = calloc(*nonce_len, sizeof(unsigned char));
+  if (*nonce == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the nonce buffer.");
+
+    *nonce_len = 0;
+
+    memset(message, 0, message_len);
+    free(message);
+
+    return 1;
+  }
+  memcpy(*nonce, index, *nonce_len);
+
+  memset(message, 0, message_len);
+  free(message);
+
+  return 0;
+}
+
+//
+// setup_public_evp_context
+//
+EVP_PKEY_CTX *setup_public_evp_context(const char *filepath)
+{
+  FILE *f = fopen(filepath, "r");
+
+  if (NULL == f)
+  {
+    kmyth_log(LOG_ERR, "Failed to open public key file.");
+    return NULL;
+  }
+
+  EVP_PKEY *pkey = PEM_read_PUBKEY(f, NULL, NULL, NULL);
+
+  if (NULL == pkey)
+  {
+    kmyth_log(LOG_ERR, "Failed to load public key file.");
+    if (fclose(f) != 0)
+    {
+      kmyth_log(LOG_ERR, "Failed to close public key file.");
+    }
+    return NULL;
+  }
+
+  if (fclose(f) != 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to close public key file.");
+    EVP_PKEY_free(pkey);
+    return NULL;
+  }
+
+  EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(pkey, NULL);
+
+  if (NULL == ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to create public key EVP context.");
+    EVP_PKEY_free(pkey);
+    return NULL;
+  }
+
+  EVP_PKEY_free(pkey);
+
+  return ctx;
+}
+
+//
+// setup_private_evp_context()
+//
+EVP_PKEY_CTX *setup_private_evp_context(const char *filepath)
+{
+  FILE *f = fopen(filepath, "r");
+
+  if (NULL == f)
+  {
+    kmyth_log(LOG_ERR, "Failed to open private key file.");
+    return NULL;
+  }
+
+  EVP_PKEY *pkey = PEM_read_PrivateKey(f, NULL, NULL, NULL);
+
+  if (NULL == pkey)
+  {
+    kmyth_log(LOG_ERR, "Failed to load private key file.");
+    if (fclose(f) != 0)
+    {
+      kmyth_log(LOG_ERR, "Failed to close private key file.");
+    }
+    return NULL;
+  }
+
+  if (fclose(f) != 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to close private key file.");
+    EVP_PKEY_free(pkey);
+    return NULL;
+  }
+
+  EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(pkey, NULL);
+
+  if (NULL == ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to create private key EVP context.");
+    EVP_PKEY_free(pkey);
+
+    return NULL;
+  }
+
+  EVP_PKEY_free(pkey);
+
+  return ctx;
+}
+
+//
+// generate_session_key()
+//
+int generate_session_key(unsigned char *nonce_a, size_t nonce_a_len,
+                         unsigned char *nonce_b, size_t nonce_b_len,
+                         unsigned char **key, size_t *key_len)
+{
+  // Build the combined nonce as the base for key generation.
+  size_t len = nonce_a_len + nonce_b_len;
+  unsigned char *nonces = calloc(len, sizeof(unsigned char));
+  unsigned char *index = nonces;
+
+  memcpy(index, nonce_a, nonce_a_len);
+  index += nonce_a_len;
+  memcpy(index, nonce_b, nonce_b_len);
+
+  // Setup the message digest context.
+  //const EVP_MD *type = EVP_sha3_512();
+  const EVP_MD *type = EVP_shake256();
+
+  if (NULL == type)
+  {
+    //kmyth_log(LOG_ERR, "Failed to obtain the SHA512 MD.");
+    kmyth_log(LOG_ERR, "Failed to obtain the SHAKE-256 MD.");
+    free(nonces);
+    return 1;
+  }
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+
+  if (NULL == ctx)
+  {
+    kmyth_log(LOG_ERR, "Failed to create the MD context.");
+    free(nonces);
+    return 1;
+  }
+
+  // Initialize the context and load in the nonces to generate the session
+  // key.
+  int result = EVP_DigestInit_ex(ctx, type, NULL);
+
+  if (0 == result)
+  {
+    kmyth_log(LOG_ERR, "Failed to initialize the MD context.");
+    EVP_MD_CTX_free(ctx);
+    free(nonces);
+    return 1;
+  }
+
+  result = EVP_DigestUpdate(ctx, nonces, len);
+  if (0 == result)
+  {
+    kmyth_log(LOG_ERR, "Failed to update the MD context.");
+    EVP_MD_CTX_free(ctx);
+    free(nonces);
+    return 1;
+  }
+
+  free(nonces);
+
+  *key = calloc(EVP_MAX_MD_SIZE, sizeof(unsigned char));
+  *key_len = EVP_MAX_MD_SIZE;
+
+  result = EVP_DigestFinal_ex(ctx, *key, (unsigned int *) key_len);
+  if (0 == result)
+  {
+    kmyth_log(LOG_ERR, "Failed to finalize the MD context.");
+    EVP_MD_CTX_free(ctx);
+    free(key);
+    *key = NULL;
+    *key_len = 0;
+    return 1;
+  }
+
+  EVP_MD_CTX_free(ctx);
+
+  //if (*key_len != 64)
+  if (*key_len != 32)
+  {
+    kmyth_log(LOG_ERR, "The generated key length must be 32, not %zd.",
+              *key_len);
+    free(key);
+    *key = NULL;
+    *key_len = 0;
+    return 1;
+  }
+
+  // Only use the top half of the generated key.
+  //*key_len = *key_len / 2;
+
+  return 0;
+}
+
+//
+// generate_nonce()
+//
+int generate_nonce(size_t desired_min_nonce_len, unsigned char **nonce,
+                   size_t *nonce_len)
+{
+  size_t size = 1;
+
+  while ((size * sizeof(int)) < desired_min_nonce_len)
+  {
+    size += 1;
+  }
+
+  *nonce_len = size * sizeof(int);
+  unsigned char *buffer = calloc(size, sizeof(int));
+  unsigned char *index = buffer;
+
+  for (size_t i = 0; i < size; i++)
+  {
+    *index = (unsigned char) rand();
+    index += sizeof(int);
+  }
+
+  *nonce = buffer;
+  return 0;
+}
+
+//
+// negotiate_client_session_key()
+//
+int negotiate_client_session_key(int socket_fd,
+                                 EVP_PKEY_CTX * public_key_ctx,
+                                 EVP_PKEY_CTX * private_key_ctx,
+                                 unsigned char *id, size_t id_len,
+                                 unsigned char *expected_id,
+                                 size_t expected_id_len,
+                                 unsigned char **session_key,
+                                 size_t *session_key_len)
+{
+  // Generate nonce A
+  unsigned char *nonce_a = NULL;
+  size_t nonce_a_len = 0;
+
+  int result = generate_nonce(32, &nonce_a, &nonce_a_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to generate a nonce.");
+    return 1;
+  }
+
+  // Conduct NSL to obtain nonce B
+  unsigned char *nonce_b = NULL;
+  size_t nonce_b_len = 0;
+
+  unsigned char *request = NULL;
+  size_t request_len = 0;
+
+  unsigned char *response = calloc(8192, sizeof(unsigned char));
+  size_t response_len = 8192;
+
+  kmyth_log(LOG_INFO, "Sending nonce A: %zd bytes", nonce_a_len);
+
+  result = build_nonce_request(public_key_ctx,
+                               nonce_a, nonce_a_len,
+                               id, id_len, &request, &request_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to build the nonce request.");
+    return 1;
+  }
+
+  if (write(socket_fd, request, request_len) != request_len)
+  {
+    kmyth_log(LOG_ERR, "Failed to fully send nonce request message.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Successfully sent nonce A.");
+
+  ssize_t read_result = read(socket_fd, response, response_len);
+
+  if (-1 == read_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to read the nonce response message.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received %zd bytes", read_result);
+
+  free(request);
+  request = NULL;
+  request_len = 0;
+
+  unsigned char *received_nonce_a = NULL;
+  size_t received_nonce_a_len = 0;
+
+  unsigned char *received_id = NULL;
+  size_t received_id_len = 0;
+
+  result = parse_nonce_response(private_key_ctx,
+                                response, read_result,
+                                &received_nonce_a, &received_nonce_a_len,
+                                &nonce_b, &nonce_b_len,
+                                &received_id, &received_id_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to parse the nonce response.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received nonce A: %zd bytes", received_nonce_a_len);
+  kmyth_log(LOG_INFO, "Received nonce B: %zd bytes", nonce_b_len);
+  kmyth_log(LOG_INFO, "Received ID: %.*s", received_id_len, received_id);
+
+  if (nonce_a_len != received_nonce_a_len)
+  {
+    kmyth_log(LOG_ERR, "The received nonce A length is invalid.");
+    return 1;
+  }
+  if (strncmp
+      ((const char *) nonce_a, (const char *) received_nonce_a,
+       nonce_a_len) != 0)
+  {
+    kmyth_log(LOG_ERR, "The received nonce A is invalid.");
+    kmyth_log(LOG_ERR, "Expected nonce A: %zd bytes", nonce_a_len);
+    return 1;
+  }
+
+  if (strncmp
+      ((const char *) received_id, (const char *) expected_id,
+       expected_id_len) != 0)
+  {
+    kmyth_log(LOG_ERR, "The received ID is invalid.");
+    return 1;
+  }
+
+  result = build_nonce_confirmation(public_key_ctx,
+                                    nonce_b, nonce_b_len,
+                                    &request, &request_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to build the nonce confirmation.");
+    return 1;
+  }
+
+  if (write(socket_fd, request, request_len) != request_len)
+  {
+    kmyth_log(LOG_ERR, "Failed to fully send the nonce confirmation.");
+    return 1;
+  }
+
+  free(request);
+  request = NULL;
+  request_len = 0;
+
+  // Use nonces to generate shared session key S
+  result = generate_session_key(nonce_a, nonce_a_len,
+                                nonce_b, nonce_b_len,
+                                session_key, session_key_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to generate the session key.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// negotiate_server_session_key()
+//
+int negotiate_server_session_key(int socket_fd,
+                                 EVP_PKEY_CTX * public_key_ctx,
+                                 EVP_PKEY_CTX * private_key_ctx,
+                                 unsigned char *id, size_t id_len,
+                                 unsigned char **session_key,
+                                 size_t *session_key_len)
+{
+  // Generate nonce B
+  unsigned char *nonce_b = NULL;
+  size_t nonce_b_len = 0;
+
+  int result = generate_nonce(32, &nonce_b, &nonce_b_len);
+
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to generate a nonce.");
+    return 1;
+  }
+
+  // Conduct NSL to obtain nonce A
+  unsigned char *response = calloc(8192, sizeof(unsigned char));
+  size_t response_len = 8192;
+
+  struct sockaddr_storage peer_addr;
+  socklen_t peer_addr_len = sizeof(peer_addr);
+
+  ssize_t read_result = recvfrom(socket_fd,
+                                 response, response_len,
+                                 0,
+                                 (struct sockaddr *) &peer_addr,
+                                 &peer_addr_len);
+
+  if (-1 == read_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to receive the nonce request.");
+    return 1;
+  }
+
+  char host[NI_MAXHOST] = { 0 };
+  char service[NI_MAXSERV] = { 0 };
+
+  int s = getnameinfo((struct sockaddr *) &peer_addr, peer_addr_len,
+                      host, NI_MAXHOST, service, NI_MAXSERV, NI_NUMERICSERV);
+
+  if (0 != s)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup host and service information.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received %zd bytes from %s:%s", read_result, host,
+            service);
+
+  unsigned char *received_nonce_a = NULL;
+  size_t received_nonce_a_len = 0;
+
+  unsigned char *received_id = NULL;
+  size_t received_id_len = 0;
+
+  result = parse_nonce_request(private_key_ctx,
+                               response, read_result,
+                               &received_nonce_a, &received_nonce_a_len,
+                               &received_id, &received_id_len);
+
+  kmyth_log(LOG_INFO, "Received nonce A: %zd bytes", received_nonce_a_len);
+
+  free(response);
+  response = NULL;
+  response_len = 0;
+
+  kmyth_log(LOG_INFO, "Sending nonce B: %zd", nonce_b_len);
+
+  result = build_nonce_response(public_key_ctx,
+                                received_nonce_a, received_nonce_a_len,
+                                nonce_b, nonce_b_len,
+                                id, id_len, &response, &response_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to build the nonce response.");
+    return 1;
+  }
+
+  ssize_t send_result = sendto(socket_fd,
+                               response, response_len,
+                               0,
+                               (struct sockaddr *) &peer_addr, peer_addr_len);
+
+  if (response_len != send_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to fully send the nonce response.");
+    return 1;
+  }
+
+  free(response);
+  response = calloc(8192, sizeof(unsigned char));
+  response_len = 8192;
+
+  read_result = recvfrom(socket_fd,
+                         response, response_len,
+                         0, (struct sockaddr *) &peer_addr, &peer_addr_len);
+  if (-1 == read_result)
+  {
+    kmyth_log(LOG_ERR, "Failed to receive the nonce confirmation.");
+    return 1;
+  }
+
+  s = getnameinfo((struct sockaddr *) &peer_addr, peer_addr_len,
+                  host, NI_MAXHOST, service, NI_MAXSERV, NI_NUMERICSERV);
+  if (0 != s)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup host and service information.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received %zd bytes from %s:%s", read_result, host,
+            service);
+
+  unsigned char *received_nonce_b = NULL;
+  size_t received_nonce_b_len = 0;
+
+  result = parse_nonce_confirmation(private_key_ctx,
+                                    response, read_result,
+                                    &received_nonce_b, &received_nonce_b_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to parse the nonce confirmation.");
+    return 1;
+  }
+  if (nonce_b_len != received_nonce_b_len)
+  {
+    kmyth_log(LOG_ERR, "The received nonce B length is invalid.");
+    return 1;
+  }
+  if (strncmp
+      ((const char *) nonce_b, (const char *) received_nonce_b,
+       nonce_b_len) != 0)
+  {
+    kmyth_log(LOG_ERR, "The received nonce B is invalid.");
+    return 1;
+  }
+
+  kmyth_log(LOG_INFO, "Received nonce B: %zd bytes", nonce_b_len);
+
+  // Use nonces to generate shared session key S
+  result = generate_session_key(received_nonce_a, received_nonce_a_len,
+                                nonce_b, nonce_b_len,
+                                session_key, session_key_len);
+  if (result)
+  {
+    kmyth_log(LOG_ERR, "Failed to generate the session key.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//############################################################################
+// get_key_using_nsl()
+//
+// Retrieve a key using the Needham-Schroeder-Lowe protocol.
+//############################################################################
+
+int get_key_using_nsl(char *message, size_t message_length,
+                      unsigned char **key, size_t *key_size)
+{
+  return 0;
+}

--- a/tpm2/src/util/socket_util.c
+++ b/tpm2/src/util/socket_util.c
@@ -1,0 +1,119 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include "defines.h"
+
+//
+// setup_client_socket()
+//
+int setup_client_socket(const char *node, const char *service, int *socket_fd)
+{
+  // Setup socket settings and lookup the target Internet address.
+  *socket_fd = -1;
+
+  struct addrinfo hints = { 0 };
+  struct addrinfo *result = NULL;
+  struct addrinfo *rp = NULL;
+
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_flags = 0;
+  hints.ai_protocol = 0;
+
+  int s = getaddrinfo(node, service, &hints, &result);
+
+  if (s != 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup target Internet address: %s",
+              gai_strerror(s));
+    return 1;
+  }
+
+  // Scan through the set of possible Internet addresses until we find the
+  // right one.
+  for (rp = result; rp != NULL; rp = rp->ai_next)
+  {
+    *socket_fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (*socket_fd == -1)
+    {
+      // Socket creation failed, try the next address.
+      continue;
+    }
+    if (connect(*socket_fd, rp->ai_addr, rp->ai_addrlen) != -1)
+    {
+      // Socket connection succeeded, use this socket.
+      break;
+    }
+    close(*socket_fd);
+  }
+
+  // Cleanup address information and handle errors.
+  freeaddrinfo(result);
+  if (rp == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to establish socket connection.");
+    return 1;
+  }
+
+  return 0;
+}
+
+//
+// setup_server_socket()
+//
+int setup_server_socket(const char *service, int *socket_fd)
+{
+  // Setup socket settings and lookup own Internet address.
+  *socket_fd = -1;
+
+  struct addrinfo hints = { 0 };
+  struct addrinfo *result = NULL;
+  struct addrinfo *rp = NULL;
+
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_flags = AI_PASSIVE;
+  hints.ai_protocol = 0;
+  hints.ai_canonname = NULL;
+  hints.ai_addr = NULL;
+  hints.ai_next = NULL;
+
+  int s = getaddrinfo(NULL, service, &hints, &result);
+
+  if (s != 0)
+  {
+    kmyth_log(LOG_ERR, "Failed to lookup own Internet address: %s",
+              gai_strerror(s));
+    return 1;
+  }
+
+  // Scan through the set of possible Internet addresses until we find the
+  // right one.
+  for (rp = result; rp != NULL; rp = rp->ai_next)
+  {
+    *socket_fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (*socket_fd == -1)
+    {
+      // Socket creation failed, try the next address.
+      continue;
+    }
+    if (bind(*socket_fd, rp->ai_addr, rp->ai_addrlen) == 0)
+    {
+      // Socket successfully bound, use this socket.
+      break;
+    }
+    close(*socket_fd);
+  }
+
+  // Cleanup address information and handle errors.
+  freeaddrinfo(result);
+  if (rp == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to establish bind socket.");
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This change adds a collection of functionality that implements the Needham-Schroeder-Lowe (NSL) protocol to support secure key retrieval without using TLS. NSL is used to create a shared session key between two parties which is then used to secure key requests and responses between the two parties.

NSL utility functions can be found in nsl_util.h/c, socket utility functions can be found in socket_util.h/c, and KMIP utility functions can be found in kmip_util.h/c. Exemplars of the two communicating parties can be found in the nsl_client.c and nsl_server.c applications. Both support CLI arguments; use -h for more information when running them.