### PR TITLE
Made Verbosity of Log Messages sent to User's Screen more Configurable

### DIFF
--- a/logger/src/kmyth_log.c
+++ b/logger/src/kmyth_log.c
@@ -340,10 +340,10 @@ void log_event(const char *src_file,
       //
       //   for stddest:
       //     - timestamp is always omitted
-      //     - if logging severity threshold is <= LOG_INFO (<= 5), simplify
+      //     - if logging severity threshold is <= LOG_INFO (<= 6), simplify
       //       prefix to the severity level and content to the actual message
       //       (routine logging to a user's screen will be simplified).
-      //     - if logging severity threshold is > LOG_INFO (>5), include the
+      //     - if logging severity threshold is > LOG_INFO (> 6), include the
       //       full prefix (with application name/version) and enhance message
       //       with source location information. User can turn on detailed
       //       logging by using the --verbose (or -v) command line option.
@@ -384,10 +384,10 @@ void log_event(const char *src_file,
       //
       //   for stddest:
       //     - timestamp is always omitted
-      //     - if logging severity threshold is <= LOG_INFO (<= 5), simplify
+      //     - if logging severity threshold is <= LOG_INFO (<= 6), simplify
       //       prefix to the severity level and content to the actual message
       //       (routine logging to a user's screen will be simplified).
-      //     - if logging severity threshold is > LOG_INFO (>5), include the
+      //     - if logging severity threshold is > LOG_INFO (> 6), include the
       //       full prefix (with application name/version) and enhance message
       //       with source location information. User can turn on detailed
       //       logging by using the --verbose (or -v) command line option.

--- a/logger/src/kmyth_log.c
+++ b/logger/src/kmyth_log.c
@@ -337,10 +337,28 @@ void log_event(const char *src_file,
     {
       // output mode 0:
       //   print to both stddest (stdout/stderr) and log file (if available)
+      //
+      //   for stddest:
+      //     - timestamp is always omitted
+      //     - if logging severity threshold is <= LOG_INFO (<= 5), simplify
+      //       prefix to the severity level and content to the actual message
+      //       (routine logging to a user's screen will be simplified).
+      //     - if logging severity threshold is > LOG_INFO (>5), include the
+      //       full prefix (with application name/version) and enhance message
+      //       with source location information. User can turn on detailed
+      //       logging by using the --verbose (or -v) command line option.
     case 0:
-      fprintf(stddest, "%s-%s %s - %s(%s:%d) %s\n",
-              log_settings.app_name, log_settings.app_version,
-              severity_string, src_file, src_func, src_line, out);
+      if (log_settings.applog_severity_threshold > LOG_INFO)
+      {
+        fprintf(stddest, "%s-%s %s - %s(%s:%d) %s\n",
+                log_settings.app_name, log_settings.app_version,
+                severity_string, src_file, src_func, src_line, out);
+      }
+      else
+      {
+        fprintf(stddest, "%s - %s\n", severity_string, out);
+      }
+
       if (logfile != NULL)
       {
         fprintf(logfile, "%s-%s %s %s - %s(%s:%d) %s\n",
@@ -352,22 +370,40 @@ void log_event(const char *src_file,
 
       // output mode 2:
       //   only print to log file (if possible), never to stddest (stdout/stderr)
+      //
+      // fall through to output mode 1 if log file is available
     case 2:
       if (logfile == NULL)
       {
         break;
       }
-      // fall through to output mode 1 if log file is available
 
       // output mode 1 (or other - default behavior):
       //   print to log file only (if available) or stddest (stdout/stderr)
       //   otherwise (never both)
+      //
+      //   for stddest:
+      //     - timestamp is always omitted
+      //     - if logging severity threshold is <= LOG_INFO (<= 5), simplify
+      //       prefix to the severity level and content to the actual message
+      //       (routine logging to a user's screen will be simplified).
+      //     - if logging severity threshold is > LOG_INFO (>5), include the
+      //       full prefix (with application name/version) and enhance message
+      //       with source location information. User can turn on detailed
+      //       logging by using the --verbose (or -v) command line option.
     default:
       if (logfile == NULL)
       {
-        fprintf(stddest, "%s-%s %s - %s(%s:%d) %s\n",
-                log_settings.app_name, log_settings.app_version,
-                severity_string, src_file, src_func, src_line, out);
+        if (log_settings.applog_severity_threshold > LOG_INFO)
+        {
+          fprintf(stddest, "%s-%s %s - %s(%s:%d) %s\n",
+                  log_settings.app_name, log_settings.app_version,
+                  severity_string, src_file, src_func, src_line, out);
+        }
+        else
+        {
+          fprintf(stddest, "%s - %s\n", severity_string, out);
+        }
       }
       else
       {

--- a/src/util/kmip_util.c
+++ b/src/util/kmip_util.c
@@ -14,7 +14,7 @@
 //
 int build_kmip_get_request(KMIP * ctx,
                            unsigned char *id, size_t id_len,
-                           unsigned char **request, size_t *request_len)
+                           unsigned char **request, size_t * request_len)
 {
   // Set up the encoding buffer.
   size_t buffer_blocks = 1;
@@ -93,7 +93,7 @@ int build_kmip_get_request(KMIP * ctx,
 //
 int parse_kmip_get_request(KMIP * ctx,
                            unsigned char *request, size_t request_len,
-                           unsigned char **id, size_t *id_len)
+                           unsigned char **id, size_t * id_len)
 {
   // Set up the decoding buffer and data structures.
   kmip_reset(ctx);
@@ -156,7 +156,7 @@ int parse_kmip_get_request(KMIP * ctx,
 int build_kmip_get_response(KMIP * ctx,
                             unsigned char *id, size_t id_len,
                             unsigned char *key, size_t key_len,
-                            unsigned char **response, size_t *response_len)
+                            unsigned char **response, size_t * response_len)
 {
   // Set up the encoding buffer
   size_t buffer_blocks = 1;
@@ -250,8 +250,8 @@ int build_kmip_get_response(KMIP * ctx,
 //
 int parse_kmip_get_response(KMIP * ctx,
                             unsigned char *response, size_t response_len,
-                            unsigned char **id, size_t *id_len,
-                            unsigned char **key, size_t *key_len)
+                            unsigned char **id, size_t * id_len,
+                            unsigned char **key, size_t * key_len)
 {
   // Set up the decoding buffer and data structures.
   kmip_reset(ctx);
@@ -351,7 +351,7 @@ int retrieve_key_with_session_key(int socket_fd,
                                   unsigned char *session_key,
                                   size_t session_key_len, unsigned char *key_id,
                                   size_t key_id_len, unsigned char **key,
-                                  size_t *key_len)
+                                  size_t * key_len)
 {
   KMIP kmip_context = { 0 };
   kmip_init(&kmip_context, NULL, 0, KMIP_2_0);

--- a/src/util/nsl_util.c
+++ b/src/util/nsl_util.c
@@ -27,7 +27,7 @@
 //
 int encrypt_with_key_pair(EVP_PKEY_CTX * ctx,
                           const unsigned char *p, size_t p_len,
-                          unsigned char **c, size_t *c_len)
+                          unsigned char **c, size_t * c_len)
 {
   // Initialize the context for encryption.
   int result = EVP_PKEY_encrypt_init(ctx);
@@ -71,7 +71,7 @@ int encrypt_with_key_pair(EVP_PKEY_CTX * ctx,
 //
 int decrypt_with_key_pair(EVP_PKEY_CTX * ctx,
                           const unsigned char *c, size_t c_len,
-                          unsigned char **p, size_t *p_len)
+                          unsigned char **p, size_t * p_len)
 {
   // Initialize the context for decryption.
   int result = EVP_PKEY_decrypt_init(ctx);
@@ -116,7 +116,7 @@ int decrypt_with_key_pair(EVP_PKEY_CTX * ctx,
 int build_nonce_request(EVP_PKEY_CTX * ctx,
                         unsigned char *nonce, size_t nonce_len,
                         unsigned char *id, size_t id_len,
-                        unsigned char **request, size_t *request_len)
+                        unsigned char **request, size_t * request_len)
 {
   if (NSL_NONCE_LEN != nonce_len)
   {
@@ -171,8 +171,8 @@ int build_nonce_request(EVP_PKEY_CTX * ctx,
 //
 int parse_nonce_request(EVP_PKEY_CTX * ctx,
                         unsigned char *request, size_t request_len,
-                        unsigned char **nonce, size_t *nonce_len,
-                        unsigned char **id, size_t *id_len)
+                        unsigned char **nonce, size_t * nonce_len,
+                        unsigned char **id, size_t * id_len)
 {
   // Decrypt the nonce request.
   unsigned char *message = NULL;
@@ -236,7 +236,7 @@ int build_nonce_response(EVP_PKEY_CTX * ctx,
                          unsigned char *nonce_a, size_t nonce_a_len,
                          unsigned char *nonce_b, size_t nonce_b_len,
                          unsigned char *id, size_t id_len,
-                         unsigned char **response, size_t *response_len)
+                         unsigned char **response, size_t * response_len)
 {
   // Allocate the unencrypted response buffer.
   unsigned char *message = NULL;
@@ -285,9 +285,9 @@ int build_nonce_response(EVP_PKEY_CTX * ctx,
 //
 int parse_nonce_response(EVP_PKEY_CTX * ctx,
                          unsigned char *response, size_t response_len,
-                         unsigned char **nonce_a, size_t *nonce_a_len,
-                         unsigned char **nonce_b, size_t *nonce_b_len,
-                         unsigned char **id, size_t *id_len)
+                         unsigned char **nonce_a, size_t * nonce_a_len,
+                         unsigned char **nonce_b, size_t * nonce_b_len,
+                         unsigned char **id, size_t * id_len)
 {
   // Decrypt the nonce response.
   unsigned char *message = NULL;
@@ -402,7 +402,7 @@ int parse_nonce_response(EVP_PKEY_CTX * ctx,
 int build_nonce_confirmation(EVP_PKEY_CTX * ctx,
                              unsigned char *nonce, size_t nonce_len,
                              unsigned char **confirmation,
-                             size_t *confirmation_len)
+                             size_t * confirmation_len)
 {
   if (NSL_NONCE_LEN != nonce_len)
   {
@@ -453,7 +453,7 @@ int build_nonce_confirmation(EVP_PKEY_CTX * ctx,
 int parse_nonce_confirmation(EVP_PKEY_CTX * ctx,
                              unsigned char *confirmation,
                              size_t confirmation_len, unsigned char **nonce,
-                             size_t *nonce_len)
+                             size_t * nonce_len)
 {
   // Decrypt the nonce confirmation.
   unsigned char *message = NULL;
@@ -588,7 +588,7 @@ EVP_PKEY_CTX *setup_private_evp_context(const char *filepath)
 //
 int generate_session_key(unsigned char *nonce_a, size_t nonce_a_len,
                          unsigned char *nonce_b, size_t nonce_b_len,
-                         unsigned char **key, size_t *key_len)
+                         unsigned char **key, size_t * key_len)
 {
   if (NSL_NONCE_LEN != nonce_a_len)
   {
@@ -699,7 +699,7 @@ int generate_session_key(unsigned char *nonce_a, size_t nonce_a_len,
 // generate_nonce()
 //
 int generate_nonce(size_t desired_min_nonce_len, unsigned char **nonce,
-                   size_t *nonce_len)
+                   size_t * nonce_len)
 {
   size_t size = 1;
 
@@ -738,7 +738,7 @@ int negotiate_client_session_key(int socket_fd,
                                  unsigned char *expected_id,
                                  size_t expected_id_len,
                                  unsigned char **session_key,
-                                 size_t *session_key_len)
+                                 size_t * session_key_len)
 {
   // Generate nonce A
   unsigned char *nonce_a = NULL;
@@ -924,7 +924,7 @@ int negotiate_server_session_key(int socket_fd,
                                  EVP_PKEY_CTX * private_key_ctx,
                                  unsigned char *id, size_t id_len,
                                  unsigned char **session_key,
-                                 size_t *session_key_len)
+                                 size_t * session_key_len)
 {
   // Generate nonce B
   unsigned char *nonce_b = NULL;


### PR DESCRIPTION
Log entries for the kmyth logger can contain information that is distracting when monitoring normal activity via stddest (stdout / stderr). As all of this information is potentially useful, the approach taken in this pull request is to make the logging verbosity slightly more configurable for the user.

The log message prefix currently contains the application name and version. The streamlined (less cluttered) logging view implemented by this pull request removes that information and shows only the severity level of the message (e.g., ERROR, WARNING, INFO, ...) as its prefix.

The log message contents include information about the source file location of the message. While this is important when debugging, it is probably just distracting when performing normal monitoring of an application. Therefore, this information is omitted from the streamlined view.

While not a change, I will point out that the timestamp for the message is currently only included in messages logged to file. It seems less useful for the more real-time monitoring performed by monitoring information via stdout/stderr. This pull request does not change this approach.

This pull request implements the following approach for determining which view to present the user (full or simplified) when logging to the screen:
- lf the logging severity level is LOG_INFO or less (not LOG_DEBUG), the simplified (less cluttered) message is displayed
- If the logging severity level is higher than LOG_INFO (e.g., LOG_DEBUG), however, the full log message would be displayed. 

In practice, then, he user would, for normal operation, be presented simplified log entries, but would be able to obtain the full log entries by selecting the --verbose (-v) command line option.

Closes #123.