### PR TITLE
Allocating memory for an empty file now returns a NULL pointer.

### DIFF
--- a/include/util/file_io.h
+++ b/include/util/file_io.h
@@ -33,7 +33,8 @@ int verifyOutputFilePath(char *path);
 
 /**
  * @brief Reads raw bytes from a file, located at input_path,
- *        and stores them in the data buffer passed in.
+ *        and stores them in the data buffer passed in. If input_path
+ *        is an empty file, returns NULL pointer as data.
  * 
  * @param[in]  input_path  String representing the path to the file being read
  *
@@ -43,7 +44,8 @@ int verifyOutputFilePath(char *path);
  *                         caller can pass in a pointer to an
  *                         empty data buffer (function allocates memory
  *                         that the caller must free when it is no
- *                         longer needed)
+ *                         longer needed). NULL if input_path points to
+ *                         an empty file.
  *
  * @param[out] data_length The size, in bytes, of the resultant data buffer -
  *                         passed as a pointer to the length value

--- a/src/util/file_io.c
+++ b/src/util/file_io.c
@@ -164,8 +164,7 @@ int read_bytes_from_file(char *input_path, uint8_t ** data,
 
   if (input_size == 0)
   {
-    kmyth_log(LOG_DEBUG, "input file size is zero, returning NULL ... exiting");
-	if (!BIO_free(bio))
+    if (!BIO_free(bio))
     {
       kmyth_log(LOG_ERR, "error freeing BIO ... exiting");
     }

--- a/src/util/file_io.c
+++ b/src/util/file_io.c
@@ -162,6 +162,18 @@ int read_bytes_from_file(char *input_path, uint8_t ** data,
   }
   int input_size = st.st_size;
 
+  if (input_size == 0)
+  {
+    kmyth_log(LOG_DEBUG, "input file size is zero, returning NULL ... exiting");
+	if (!BIO_free(bio))
+    {
+      kmyth_log(LOG_ERR, "error freeing BIO ... exiting");
+    }
+    *data_length = 0;
+    *data = NULL;
+    return 0;
+  }
+
   // Create data buffer and read file into it
   *data = (uint8_t *) malloc(input_size);
   if (data == NULL)

--- a/test/src/util/file_io_test.c
+++ b/test/src/util/file_io_test.c
@@ -225,7 +225,7 @@ void test_print_to_stdout(void)
   CU_ASSERT(print_to_stdout(testdata, 0) == 0);
   read_bytes_from_file("redirect_test1", &filedata1, &filedata1_len);
   CU_ASSERT(filedata1_len == 0);
-  CU_ASSERT(strncmp("", (char *) filedata1, testdata_len) == 0);
+  CU_ASSERT(filedata1 == NULL);
   free(filedata1);
   remove("redirect_test1");
 


### PR DESCRIPTION
malloc(0) is implementation dependent and may have unexpected results. Now returning a NULL pointer instead.