### PR TITLE
Fix Method for Finding Next Persistent Storage Handle for SRK

### DIFF
--- a/src/tpm/storage_key_tools.c
+++ b/src/tpm/storage_key_tools.c
@@ -163,7 +163,7 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
   if (ptype != TPM2_PT_HR_PERSISTENT_AVAIL)
   {
     kmyth_log(LOG_ERR, "retrieved unexpected (0x%08X) property ... exiting",
-              property_list.data.tpmProperties.tpmProperty[0].property);
+              ptype);
     return 1;
   }
   if (pval <= 0)

--- a/src/tpm/storage_key_tools.c
+++ b/src/tpm/storage_key_tools.c
@@ -75,52 +75,141 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
   }
 
   // Check to see if the SRK is already in persistent memory by:
+  //
   //   1. Getting a list of all persistent objects
-  //   2. Using the persistent object list to find the next available handle
-  //      in persistent storage (needed for re-derived SRK if not found,
-  //      API returns a valid result regardless)
-  //   3. Searching list for the SRK
+  //
+  //   2. Searching list for the SRK
+  //
+  //   3. Computing the next available persistent storage handle.
+  //      This is accomplished by retrieving the TPM2_PT_HR_PERSISTENT_AVAIL
+  //      property from the TPM, which provides an estimated number of
+  //      additional objects that could be loaded into the TPM's non-volatile
+  //      memory. If the value is at least one, then at least one object of
+  //      any type may be made persistent. While this handle is intended to
+  //      be used for a re-derived SRK, for API safety, a valid next handle
+  //      is provided whether or not the SRK is found to already be in
+  //      persistent storage.
+  //
 
-  // Step 1 - getting the list of persistent handles
-  TPMS_CAPABILITY_DATA capData;
+  // Step 1:  Get the list of persistent handles currently loaded into TPM
+  //
+  //          Note: At the time this was written, TPM2_MAX_CAP_HANDLES=254.
+  //                If more than 254 persistent handles were to exist, the
+  //                get_tpm2_properties() call would return partial data.
+  //                As this limit seems to be much more than the TPM
+  //                hardware is expected to support, for now, this seems
+  //                an acceptable assumption.
+
+  TPMS_CAPABILITY_DATA persistent_handle_list;
 
   if (get_tpm2_properties(sapi_ctx,
                           TPM2_CAP_HANDLES,
-                          TPM2_HR_PERSISTENT, TPM2_MAX_CAP_HANDLES, &capData))
+                          TPM2_HR_PERSISTENT,
+                          TPM2_MAX_CAP_HANDLES, &persistent_handle_list))
   {
-    kmyth_log(LOG_ERR, "get persistent object info error ... exiting");
+    kmyth_log(LOG_ERR, "error getting list of persistent handles ... exiting");
     return 1;
   }
 
-  // Step 2 - find next available persistent storage handle
-  //            - start at first address in range
-  //            - if no currently used handles, first in range is available
-  //            - if currently used handles, increment through addresses in
-  //              range until first unused handle is found
-  *nextSrkHandle = TPM2_PERSISTENT_FIRST; // 0x81010000
-  if (capData.data.handles.count > 0)
+  // Step 2:  Search the list for the SRK
+
+  if (persistent_handle_list.data.handles.count == 0)
   {
-    while (*nextSrkHandle <= TPM2_PERSISTENT_LAST)
+    kmyth_log(LOG_DEBUG, "no handles for existing persistent objects found");
+  }
+  else
+  {
+    kmyth_log(LOG_DEBUG, "checking %d persistent data handle(s) for SRK",
+              persistent_handle_list.data.handles.count);
+  }
+
+  for (int i = 0; i < persistent_handle_list.data.handles.count; i++)
+  {
+    bool SRK_flag = false;
+
+    if (check_if_srk(sapi_ctx,
+                     persistent_handle_list.data.handles.handle[i], &SRK_flag))
+    {
+      kmyth_log(LOG_ERR,
+                "error checking if handle = 0x%08X references SRK ... exiting",
+                persistent_handle_list.data.handles.handle[i]);
+      return 1;
+    }
+    if (SRK_flag)
+    {
+      *srkHandle = persistent_handle_list.data.handles.handle[i];
+      kmyth_log(LOG_DEBUG, "SRK found ... done searching");
+      break;
+    }
+  }
+
+  // Step 3:  Find next available persistent storage handle
+
+  TPMS_CAPABILITY_DATA property_list;
+
+  if (get_tpm2_properties(sapi_ctx,
+                          TPM2_CAP_TPM_PROPERTIES,
+                          TPM2_PT_HR_PERSISTENT_AVAIL,
+                          TPM2_MAX_TPM_PROPERTIES, &property_list))
+  {
+    kmyth_log(LOG_ERR, "error getting TPM properties ... exiting");
+    return 1;
+  }
+
+  // first property in returned list should be TPM2_PT_HR_PERSISTENT_AVAIL
+  uint32_t ptype = property_list.data.tpmProperties.tpmProperty[0].property;
+  uint32_t pval = property_list.data.tpmProperties.tpmProperty[0].value;
+
+  if (ptype != TPM2_PT_HR_PERSISTENT_AVAIL)
+  {
+    kmyth_log(LOG_ERR, "retrieved unexpected (0x%08X) property ... exiting",
+              property_list.data.tpmProperties.tpmProperty[0].property);
+    return 1;
+  }
+  if (pval <= 0)
+  {
+    kmyth_log(LOG_WARNING, "TPM cannot support additional persistent objects");
+    *nextSrkHandle = 0;         // set to "empty handle"
+  }
+  else
+  {
+    kmyth_log(LOG_DEBUG, "TPM supports %u (est) additional persistent objects",
+              pval);
+
+    // step through persistent handles until an unused one is found
+    // (if persistent handle list empty, first handle in range is available)
+    *nextSrkHandle = TPM2_PERSISTENT_FIRST; // 0x81000000 
+    bool avail_handle_found = false;
+
+    while ((*nextSrkHandle < TPM2_PLATFORM_PERSISTENT) && (!avail_handle_found))
     {
       bool handleInUse = false;
 
-      for (int i = 0; i < capData.data.handles.count; i++)
+      for (int i = 0; i < persistent_handle_list.data.handles.count; i++)
       {
-        if (*nextSrkHandle == capData.data.handles.handle[i])
+        if (*nextSrkHandle == persistent_handle_list.data.handles.handle[i])
         {
-          handleInUse = true;
+          handleInUse = true;   // handle being checked is "in use" (on list)
+          break;                // no need to compare with other handles in list
         }
       }
       if (!handleInUse)
       {
         // found available handle
-        break;
+        avail_handle_found = true;
       }
-      // handle just checked was in use -- prepare to check next one
-      *nextSrkHandle = *nextSrkHandle + 1;
+      else
+      {
+        // handle just checked was in use -- prepare to check next one
+        *nextSrkHandle = *nextSrkHandle + 1;
+      }
     }
   }
-  if (*nextSrkHandle > TPM2_PERSISTENT_LAST)
+
+  // although the TPM will never be able to load objects at all possible
+  // persistent storage handles, this check that we didn't find all handles
+  // in use is for completeness (i.e., this check should probably never fail)
+  if (*nextSrkHandle >= TPM2_PLATFORM_PERSISTENT)
   {
     kmyth_log(LOG_ERR, "no available persistent storage handles");
     return 1;
@@ -128,34 +217,12 @@ int get_existing_srk_handle(TSS2_SYS_CONTEXT * sapi_ctx,
   kmyth_log(LOG_DEBUG, "next available persistent storage handle at 0x%08X",
             *nextSrkHandle);
 
-  // Step 3 - searching the list for the SRK
-  if (capData.data.handles.count == 0)
+  // if SRK must be re-derived, check valid next handle was also supplied
+  if ((*srkHandle == 0) && (*nextSrkHandle == 0))
   {
-    kmyth_log(LOG_DEBUG, "no handles for existing persistent objects found");
-  }
-  else
-  {
-    kmyth_log(LOG_DEBUG, "checking %d persistent data handle(s) for SRK",
-              capData.data.handles.count);
-  }
-
-  for (int i = 0; i < capData.data.handles.count; i++)
-  {
-    bool SRK_flag = false;
-
-    if (check_if_srk(sapi_ctx, capData.data.handles.handle[i], &SRK_flag))
-    {
-      kmyth_log(LOG_ERR,
-                "error checking if handle = 0x%08X references SRK ... exiting",
-                capData.data.handles.handle[i]);
-      return 1;
-    }
-    if (SRK_flag)
-    {
-      *srkHandle = capData.data.handles.handle[i];
-      kmyth_log(LOG_DEBUG, "SRK found ... done searching");
-      break;
-    }
+    kmyth_log(LOG_ERR, "SRK must be re-derived, but TPM cannot support %s"
+              "loading additional persistent objects ... exiting");
+    return 1;
   }
 
   return 0;

--- a/test/src/tpm/storage_key_tools_test.c
+++ b/test/src/tpm/storage_key_tools_test.c
@@ -157,7 +157,7 @@ void test_put_srk_into_persistent_storage(void)
   TPM2_HANDLE next = 0;
   TPM2_HANDLE srk_handle = 0;
 
-  //Other tests will hvae already persisted the key
+  //Other tests will have already persisted the key
   get_existing_srk_handle(sapi_ctx, &srk_handle, &next);
   TPM2_HANDLE old_srk = srk_handle;
 


### PR DESCRIPTION
Testing with a hardware TPM uncovered errors when the TPM contained values placed there by non-kmyth applications. This pull request addresses the following issues that were found:
- The "next handle" available in persistent storage, to be used for loading a re-derived SRK object into the TPM, was assigned as the last handle in the list of currently loaded objects incremented by one. This assumed a simplistic scheme of incrementally assigning handles starting at the lowest in the range. This pull request modifies that approach and instead increments through the range of handles, from lowest to highest, till one that is not in the "handle-in-use" list is found. This requires no assumption of how other applications assign handles to persistent TPM objects.
- The existing code would assign a handle for the SRK to any within the TPM's persistent storage range (0x81000000-0x81FFFFFF). The TPM2 specification, however, states "The Owner is allocated persistent handles in the range of 0x81000000 to 0x817FFFFF inclusive and the TPM will return an error if Owner Authorization is used to attempt to assign a persistent handle outside of this range." As the SRK is part of the owner hierarchy (requiring owner authorization), this pull request modifies the code to select a handle for the re-derived SRK object from this smaller range.
- The existing code did not detect the potential condition that the TPM has insufficient resources to load a new persistent object. This pull request, therefore, adds code to retrieve a TPM property to indicate this and exit gracefully if the SRK must be re-derived and loaded into persistent storage when the TPM cannot load another object into its persistent storage.
- A log message was reporting the value of the 'isSRK' boolean variable incorrectly. This pull request correctly de-references the pointer when displaying the value of 'isSRK' in the log message.
- A typo in a comment in source code for of the unit tests was encountered, so this pull request makes that minor spelling correction.