### PR TITLE
removed kmyth_log from cipher code

### DIFF
--- a/src/cipher/aes_gcm.c
+++ b/src/cipher/aes_gcm.c
@@ -20,19 +20,16 @@ int aes_gcm_encrypt(unsigned char *key,
                     unsigned char *inData, size_t inData_len,
                     unsigned char **outData, size_t * outData_len)
 {
-  kmyth_log(LOG_DEBUG, "AES/GCM encryption starting");
 
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
   {
-    kmyth_log(LOG_ERR, "no key data ... exiting");
     return 1;
   }
 
   // validate non-NULL input plaintext buffer specified
   if (inData == NULL)
   {
-    kmyth_log(LOG_ERR, "null input data pointer ... exiting");
     return 1;
   }
 
@@ -45,7 +42,6 @@ int aes_gcm_encrypt(unsigned char *key,
   *outData = malloc(*outData_len);
   if (*outData == NULL)
   {
-    kmyth_log(LOG_ERR, "malloc error for AES/GCM output ... exiting");
     return 1;
   }
   unsigned char *iv = *outData;
@@ -60,7 +56,6 @@ int aes_gcm_encrypt(unsigned char *key,
 
   if (!(ctx = EVP_CIPHER_CTX_new()))
   {
-    kmyth_log(LOG_ERR, "failed to create AES/GCM cipher context ... exiting");
     free(*outData);
     return 1;
   }
@@ -78,32 +73,26 @@ int aes_gcm_encrypt(unsigned char *key,
     init_result = EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
     break;
   default:
-    kmyth_log(LOG_ERR, "invalid key length (%d bytes) ", key_len);
+    break;
   }
   if (!init_result)
   {
-    kmyth_log(LOG_ERR, "AES/GCM cipher context initialize error ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG,
-            "initialized AES/GCM/NoPadding/%d cipher context", key_len * 8);
 
   // create the IV
   if (RAND_bytes(iv, GCM_IV_LEN) != 1)
   {
-    kmyth_log(LOG_ERR, "unable to create AES/GCM IV ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "AES/GCM IV = 0x%02X..%02X", iv[0], iv[GCM_IV_LEN - 1]);
 
   // set the IV length in the cipher context
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, GCM_IV_LEN, NULL))
   {
-    kmyth_log(LOG_ERR, "error setting IV length ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -112,7 +101,6 @@ int aes_gcm_encrypt(unsigned char *key,
   // set the key and IV in the cipher context
   if (!EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
   {
-    kmyth_log(LOG_ERR, "error setting key and IV in context ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -121,18 +109,14 @@ int aes_gcm_encrypt(unsigned char *key,
   // encrypt the input plaintext, put result in the output ciphertext buffer
   if (!EVP_EncryptUpdate(ctx, ciphertext, &ciphertext_len, inData, inData_len))
   {
-    kmyth_log(LOG_ERR, "encryption error ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "encryption produced %d CT bytes", ciphertext_len);
 
   // verify that the resultant CT length matches the input PT length
   if (ciphertext_len != inData_len)
   {
-    kmyth_log(LOG_ERR, "expected %lu CT bytes, %d actual bytes) ... exiting",
-              inData_len, ciphertext_len);
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -141,7 +125,6 @@ int aes_gcm_encrypt(unsigned char *key,
   // OpenSSL requires a "finalize" operation. For AES/GCM no data is written.
   if (!EVP_EncryptFinal_ex(ctx, tag, &ciphertext_len))
   {
-    kmyth_log(LOG_ERR, "finalize error ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -150,12 +133,10 @@ int aes_gcm_encrypt(unsigned char *key,
   // get the AES/GCM tag value, appending it to the output ciphertext
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, GCM_TAG_LEN, tag))
   {
-    kmyth_log(LOG_DEBUG, "error writing tag ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "GCM tag: 0x%02X..%02X", tag[0], tag[GCM_TAG_LEN - 1]);
 
   // now that the encryption is complete, clean-up cipher context
   EVP_CIPHER_CTX_free(ctx);
@@ -171,25 +152,19 @@ int aes_gcm_decrypt(unsigned char *key,
                     unsigned char *inData, size_t inData_len,
                     unsigned char **outData, size_t * outData_len)
 {
-  kmyth_log(LOG_DEBUG, "AES/GCM decryption starting");
-
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)
   {
-    kmyth_log(LOG_ERR, "no key data ... exiting");
     return 1;
   }
 
   // validate non-NULL and non-empty input ciphertext buffer specified
   if (inData == NULL || inData_len == 0)
   {
-    kmyth_log(LOG_ERR, "no input data ... exiting");
     return 1;
   }
   if (inData_len < GCM_IV_LEN + GCM_TAG_LEN)
   {
-    kmyth_log(LOG_ERR, "input data incomplete (must be %d bytes, was %lu "
-              "bytes) ... exiting", GCM_IV_LEN + GCM_TAG_LEN + 1, inData_len);
     return 1;
   }
 
@@ -200,8 +175,6 @@ int aes_gcm_decrypt(unsigned char *key,
   *outData = malloc(*outData_len);
   if (*outData == NULL)
   {
-    kmyth_log(LOG_ERR, "malloc (%d bytes) for PT failed ... exiting",
-              *outData_len);
     return 1;
   }
 
@@ -223,7 +196,6 @@ int aes_gcm_decrypt(unsigned char *key,
 
   if (!(ctx = EVP_CIPHER_CTX_new()))
   {
-    kmyth_log(LOG_ERR, "error creating cipher context ... exiting");
     free(*outData);
     return 1;
   }
@@ -241,25 +213,18 @@ int aes_gcm_decrypt(unsigned char *key,
     init_result = EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
     break;
   default:
-    kmyth_log(LOG_ERR, "invalid key length (%d bytes)", key_len);
+    break;
   }
   if (!init_result)
   {
-    kmyth_log(LOG_ERR, "error initializing cipher context ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  else
-    kmyth_log(LOG_DEBUG,
-              "initialized AES/GCM/NoPadding/%d cipher context", key_len * 8);
 
   // set tag to expected tag passed in with input data
-  kmyth_log(LOG_DEBUG, "AES/GCM input tag = 0x%02X..%02X", tag[0],
-            tag[GCM_TAG_LEN - 1]);
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, GCM_TAG_LEN, tag))
   {
-    kmyth_log(LOG_ERR, "error setting tag ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -268,7 +233,6 @@ int aes_gcm_decrypt(unsigned char *key,
   // set the IV length in the cipher context
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, GCM_IV_LEN, NULL))
   {
-    kmyth_log(LOG_ERR, "error setting IV length ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -277,17 +241,14 @@ int aes_gcm_decrypt(unsigned char *key,
   // set the key and IV in the cipher context
   if (!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
   {
-    kmyth_log(LOG_ERR, "error setting key / IV in cipher context ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "AES/GCM IV = 0x%02X..%02X", iv[0], iv[GCM_IV_LEN - 1]);
 
   // decrypt the input ciphertext, put result in the output plaintext buffer
   if (!EVP_DecryptUpdate(ctx, *outData, &len, ciphertext, *outData_len))
   {
-    kmyth_log(LOG_ERR, "decrypt error ... exiting");
     kmyth_clear_and_free(*outData, *outData_len);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -299,19 +260,15 @@ int aes_gcm_decrypt(unsigned char *key,
   //   - should produce no more plaintext bytes in our case
   if (EVP_DecryptFinal_ex(ctx, *outData + plaintext_len, &len) <= 0)
   {
-    kmyth_log(LOG_ERR, "AES/GCM tag error ... exiting");
     kmyth_clear_and_free(*outData, *outData_len);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
   plaintext_len += len;
-  kmyth_log(LOG_DEBUG, "AES/GCM decrypt produced %d PT bytes", plaintext_len);
 
   // verify that the resultant PT length matches the input CT length
   if (plaintext_len != *outData_len)
   {
-    kmyth_log(LOG_ERR, "expected %lu PT bytes, %d actual bytes ... exiting",
-              *outData_len, len);
     kmyth_clear_and_free(*outData, *outData_len);
     EVP_CIPHER_CTX_free(ctx);
     return 1;

--- a/src/cipher/aes_keywrap_5649pad.c
+++ b/src/cipher/aes_keywrap_5649pad.c
@@ -22,21 +22,16 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
   // validate non-NULL and non-empty encryption key specified
   if (key == NULL || key_len == 0)
   {
-    kmyth_log(LOG_ERR, "no key data ... exiting");
     return 1;
   }
 
   // verify non-NULL, non-empty input plaintext buffer of valid size
   if (inData == NULL || inData_len == 0)
   {
-    kmyth_log(LOG_ERR, "no input data provided ... exiting");
     return 1;
   }
   if (inData_len > AES_KEYWRAP_5649PAD_MAX_DATA_LEN)
   {
-    kmyth_log(LOG_ERR, "input data exceeds maximum "
-              "allowable length (%lu provided, %lu maximum) ... exiting",
-              inData_len, AES_KEYWRAP_5649PAD_MAX_DATA_LEN);
     return 1;
   }
 
@@ -49,8 +44,6 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
   *outData = malloc(*outData_len);
   if (*outData == NULL)
   {
-    kmyth_log(LOG_ERR, "malloc error (%d bytes) for output data ... exiting",
-              *outData_len);
     return 1;
   }
 
@@ -61,7 +54,6 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
 
   if (!(ctx = EVP_CIPHER_CTX_new()))
   {
-    kmyth_log(LOG_ERR, "error creating cipher context ... exiting");
     free(*outData);
     return 1;
   }
@@ -83,22 +75,18 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
       EVP_EncryptInit_ex(ctx, EVP_aes_256_wrap_pad(), NULL, NULL, NULL);
     break;
   default:
-    kmyth_log(LOG_ERR, "invalid key length (%d bytes)", key_len);
+    break;
   }
   if (!init_result)
   {
-    kmyth_log(LOG_ERR, "error initializing cipher context ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "AES/KeyWrap/RFC5649Padding/%d cipher context",
-            key_len * 8);
 
   // set the encryption key in the cipher context
   if (!EVP_EncryptInit_ex(ctx, NULL, NULL, key, NULL))
   {
-    kmyth_log(LOG_ERR, "error setting key ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -115,18 +103,15 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
   // encrypt (wrap) the input PT, put result in the output CT buffer
   if (!EVP_EncryptUpdate(ctx, *outData, &tmp_len, inData, inData_len))
   {
-    kmyth_log(LOG_ERR, "error wrapping data ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
   }
   ciphertext_len = tmp_len;
-  kmyth_log(LOG_DEBUG, "key wrap produced %d-byte CT output", ciphertext_len);
 
   // OpenSSL requires a "finalize" operation
   if (!EVP_EncryptFinal_ex(ctx, (*outData) + ciphertext_len, &tmp_len))
   {
-    kmyth_log(LOG_ERR, "error finalizing ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -137,9 +122,6 @@ int aes_keywrap_5649pad_encrypt(unsigned char *key,
   // plus 4-byte IV plus 4-byte counter + any necessary padding)
   if (ciphertext_len != *outData_len)
   {
-    kmyth_log(LOG_ERR, "invalid ciphertext length "
-              "(expected %lu bytes, actual %d bytes) ... exiting",
-              *outData_len, ciphertext_len);
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -163,7 +145,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
   // validate non-NULL and non-empty decryption key specified
   if (key == NULL || key_len == 0)
   {
-    kmyth_log(LOG_ERR, "no key data ... exiting");
     return 1;
   }
 
@@ -175,27 +156,18 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
   //       size) for the AES codebook
   if (inData == NULL || inData_len == 0)
   {
-    kmyth_log(LOG_ERR, "no input data ... exiting");
     return 1;
   }
   if (inData_len < 8)
   {
-    kmyth_log(LOG_ERR,
-              "input data size (%lu bytes) < 8 ... exiting", inData_len);
     return 1;
   }
   if (inData_len % 8 != 0)
   {
-    kmyth_log(LOG_ERR,
-              "data length (%lu bytes) not multiple of 8 ... exiting",
-              inData_len);
     return 1;
   }
   if (inData_len > AES_KEYWRAP_5649PAD_MAX_DATA_LEN)
   {
-    kmyth_log(LOG_ERR,
-              "input data length error (%lu bytes, max = %lu) ... exiting",
-              inData_len, AES_KEYWRAP_5649PAD_MAX_DATA_LEN);
     return 1;
   }
 
@@ -207,8 +179,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
   *outData = malloc(inData_len);
   if (*outData == NULL)
   {
-    kmyth_log(LOG_ERR, "malloc error (%ld bytes) for PT data ... exiting",
-              inData_len);
     return 1;
   }
 
@@ -218,7 +188,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
 
   if (!(ctx = EVP_CIPHER_CTX_new()))
   {
-    kmyth_log(LOG_ERR, "error creating cipher context ... exiting");
     free(*outData);
     return 1;
   }
@@ -241,12 +210,11 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
       EVP_DecryptInit_ex(ctx, EVP_aes_256_wrap_pad(), NULL, NULL, NULL);
     break;
   default:
-    kmyth_log(LOG_ERR, "invalid key length (%d bytes) specified", key_len);
+    break;
   }
 
   if (!init_result)
   {
-    kmyth_log(LOG_ERR, "failed to initialize cipher context ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -254,7 +222,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
 
   if (!EVP_DecryptInit_ex(ctx, NULL, NULL, key, NULL))
   {
-    kmyth_log(LOG_ERR, "error setting key ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -264,7 +231,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
 
   if (!EVP_DecryptUpdate(ctx, *outData, &tmp_len, inData, inData_len))
   {
-    kmyth_log(LOG_ERR, "unwrapping error ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;
@@ -273,7 +239,6 @@ int aes_keywrap_5649pad_decrypt(unsigned char *key,
   *outData_len = tmp_len;
   if (!EVP_DecryptFinal_ex(ctx, *outData + *outData_len, &tmp_len))
   {
-    kmyth_log(LOG_ERR, "finalization error ... exiting");
     free(*outData);
     EVP_CIPHER_CTX_free(ctx);
     return 1;

--- a/src/cipher/cipher.c
+++ b/src/cipher/cipher.c
@@ -115,7 +115,6 @@ size_t get_key_len_from_cipher(cipher_t cipher)
   key_len_string = strrchr(cipher.cipher_name, '/') + 1;
   if (key_len_string == NULL)
   {
-    kmyth_log(LOG_ERR, "Unable to extract key length from cipher");
     return 0;
   }
 
@@ -123,7 +122,6 @@ size_t get_key_len_from_cipher(cipher_t cipher)
 
   if (key_len <= 0)
   {
-    kmyth_log(LOG_ERR, "Unable to convert key length to a positive integer");
     return 0;
   }
 
@@ -142,50 +140,38 @@ int kmyth_encrypt_data(unsigned char *data,
 {
   if (cipher_spec.cipher_name == NULL)
   {
-    kmyth_log(LOG_ERR, "cipher structure uninitialized ... exiting");
     return 1;
   }
   if (data == NULL || data_size == 0)
   {
-    kmyth_log(LOG_ERR, "no data to encrypt ... exiting");
     return 1;
   }
   if (enc_data == NULL)
   {
-    kmyth_log(LOG_ERR, "no buffer to store the encrypted data ... exiting");
     return 1;
   }
   if (enc_key == NULL)
   {
-    kmyth_log(LOG_ERR, "no buffer to store the encryption key ... exiting");
     return 1;
   }
   if (*enc_key_size == 0)
   {
-    kmyth_log(LOG_ERR, "cannot use a 0-bit encryption key ... exiting");
     return 1;
   }
 
   // create symmetric key (wrapping key) of the desired size
   if (!RAND_bytes(*enc_key, *enc_key_size * sizeof(unsigned char)))
   {
-    kmyth_log(LOG_ERR, "error creating %d-bit random symmetric key, error: %s "
-              "... exiting", *enc_key_size * 8,
-              ERR_error_string(ERR_get_error(), NULL));
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "created %d-bit random symmetric key",
-            *enc_key_size * 8);
 
   *enc_data_size = 0;
   if (cipher_spec.encrypt_fn(*enc_key,
                              *enc_key_size,
                              data, data_size, enc_data, enc_data_size))
   {
-    kmyth_log(LOG_ERR, "error encrypting data ... exiting");
     return 1;
   }
-  kmyth_log(LOG_DEBUG, "encrypted data with %s", cipher_spec.cipher_name);
 
   return 0;
 }
@@ -202,22 +188,18 @@ int kmyth_decrypt_data(unsigned char *enc_data,
 {
   if (enc_data == NULL || enc_data_size == 0)
   {
-    kmyth_log(LOG_ERR, "no encrypted data to unencrypt ... exiting");
     return 1;
   }
   if (cipher_spec.cipher_name == NULL)
   {
-    kmyth_log(LOG_ERR, "cipher structure uninitialized ... exiting");
     return 1;
   }
   if (key == NULL || key_size == 0)
   {
-    kmyth_log(LOG_ERR, "no encryption key provided ... exiting");
     return 1;
   }
   if (result == NULL)
   {
-    kmyth_log(LOG_ERR, "no buffer to store the unencrypted data ... exiting");
     return 1;
   }
 
@@ -225,7 +207,6 @@ int kmyth_decrypt_data(unsigned char *enc_data,
   if (cipher_spec.decrypt_fn(key, key_size, enc_data,
                              enc_data_size, result, result_size))
   {
-    kmyth_log(LOG_ERR, "symmetric decryption error ... exiting");
     return 1;
   }
 


### PR DESCRIPTION
There is an issue with portability of kmyth's cipher code with kmyth_log. Specifically, kmyth_log cannot be called within SGX. As these logs were mostly intended for debugging purposes, they are being removed. If this information is important for future applications, creating an enumeration for return values and handling errors outside of the cipher code is a better solution.