### PR TITLE
TPM2 Software Stack (TSS2) and TPM 2.0 Simulator related updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ In order to use _kmyth-getkey_ some preliminary setup is required.
   support. Our development efforts preceded the initial release of an
   implementation of this layer ([tss2-esys](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-esys)).
 
-  * The [System API (SAPI)](https://trustedcomputinggroup.org/resource/tss-system-level-api-and-tpm-command-transmission-interface-specification/)
+  * The [System API (SAPI)](https://trustedcomputinggroup.org/resource/tcg-tss-2-0-system-level-api-sapi-specification/)
   provides the developer functionality that maps to the TPM 2.0 commands.
   The Kmyth TPM 2.0 code is currently based primarily on this layer
   ([tss2-sys](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-sys))
   of the TSS2 library.
 
-  * The [TPM Command Transmission Interface (TCTI)](https://trustedcomputinggroup.org/resource/tss-system-level-api-and-tpm-command-transmission-interface-specification/)
+  * The [TPM Command Transmission Interface (TCTI)](https://trustedcomputinggroup.org/resource/tss-tcti-specification/)
   represents the layer where the actual TPM commands and responses are
   exchanged. In the TSS2 library, this layer is implemented by the
   [tss2-tcti](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-tcti)

--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ In order to use _kmyth-getkey_ some preliminary setup is required.
 * TPM 2.0 Software Stack (TSS2)
 
   * The [Feature API (FAPI)](https://trustedcomputinggroup.org/resource/tss-feature-api-specification/)
-  will eventually provide the highest-level of abstraction. This layer has
-  not yet been implemented.
+  provides the highest-level of abstraction and was the last layer implemented ([tss2-fapi](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-fapi).
 
   * [The Enhanced System API (ESAPI)](https://trustedcomputinggroup.org/resource/tcg-tss-2-0-enhanced-system-api-esapi-specification/)
   is the next layer down. While less abstract than the FAPI, it hides much
@@ -199,19 +198,25 @@ In order to use _kmyth-getkey_ some preliminary setup is required.
   handles the physical transmission of data to and from the TPM. This is
   totally abstracted from our Kmyth code, however.
 
-### TPM 2.0 emulator
+### TPM 2.0 Simulator
 
-* [IBM's TPM 2.0 emulator](https://sourceforge.net/projects/ibmswtpm2/)
-defaults to using:
-
-  * hostname : 127.0.0.1 (or local host) 
-
-  * port : 2321 (tpm command) and 2322 (platform)
+* [IBM's Software TPM 2.0](https://sourceforge.net/projects/ibmswtpm2/) is
+  "an implementation of the TCG TPM 2.0 specification. It is based on the
+  TPM specification Parts 3 and 4 source code donated by Microsoft, with
+  additional files to complete the implementation."
 
 * Microsoft provides
-  [the official TCG reference implementation of the TPM 2.0 Specification](https://github.com/microsoft/ms-tpm-20-ref).
-  The project includes Windows (Visual Studio) and Linux (autotools) build
-  scripts. Kmyth has not yet been tested using this TPM 2.0 simulator (mssim).
+  [the official TCG reference implementation of the TPM 2.0 Specification](https://github.com/microsoft/ms-tpm-20-ref)
+  that includes a [TPM 2.0 Simulator](https://github.com/microsoft/ms-tpm-20-ref/tree/master/TPMCmd/Simulator).
+  The project provides Windows (Visual Studio) and Linux (autotools) build scripts.
+
+
+#### Default (typical) settings:
+
+* hostname : 127.0.0.1 (localhost) 
+
+* port : 2321 (TPM command)
+
 
 ### TPM 2.0 Tools (Intel) 
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ In order to use _kmyth-getkey_ some preliminary setup is required.
 * TPM 2.0 Software Stack (TSS2)
 
   * The [Feature API (FAPI)](https://trustedcomputinggroup.org/resource/tss-feature-api-specification/)
-  provides the highest-level of abstraction and was the last layer implemented ([tss2-fapi](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-fapi).
+  provides the highest-level of abstraction and was the last layer implemented ([tss2-fapi](https://github.com/tpm2-software/tpm2-tss/tree/master/src/tss2-fapi)).
 
   * [The Enhanced System API (ESAPI)](https://trustedcomputinggroup.org/resource/tcg-tss-2-0-enhanced-system-api-esapi-specification/)
   is the next layer down. While less abstract than the FAPI, it hides much
@@ -211,7 +211,7 @@ In order to use _kmyth-getkey_ some preliminary setup is required.
   The project provides Windows (Visual Studio) and Linux (autotools) build scripts.
 
 
-#### Default (typical) settings:
+#### Default (typical) TPM 2.0 simulator settings:
 
 * hostname : 127.0.0.1 (localhost) 
 


### PR DESCRIPTION
This pull request attempts to update a few minor README items that have become out of date:

- The FAPI layer of the TSS2 has been implemented for some time now
- We have tested kmyth using the Microsoft simulator (also modifies the format of this section in an attempt to make the default settings apply to both simulators)
- A few links to TCG specifications have changed