### PR TITLE
removed indent

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,6 @@ Table of Contents
 * TPM 2.0 Access Broker and Resource Manager development libraries and headers
 * C compiler
 * Make
-* indent (GNU program for formatting C code)
 * [libkmip](https://github.com/OpenKMIP/libkmip) (used in `getkey`)
 
 With the exception of [libkmip](https://github.com/OpenKMIP/libkmip)
@@ -53,11 +52,9 @@ installed from source.
 
 ```yum install tpm2-abrmd tpm2-tss tpm2-tss-devel tpm2-abrmd-devel```
 
-indent is available in the EPEL repository.
-
 ##### Ubuntu 20.04 Commands
 
-```apt install make indent gcc openssl libssl-dev libffi-dev```
+```apt install make gcc openssl libssl-dev libffi-dev```
 
 ```apt install tss2 libtss2-dev libtss2-tcti-tabrmd-dev tpm2-abrmd```
 

--- a/Makefile
+++ b/Makefile
@@ -278,30 +278,12 @@ SOFLAGS += -fPIC#
 LDFLAGS = -Llib#                         link path for libkmyth-*.so
 LDFLAGS += -Wl,-rpath=lib#               runtime path for libkmyth-*.so
 
-# Specify indentation options
-INDENT_OPTS = -bli0#                     indent braces zero spaces
-INDENT_OPTS += -bap#                     blank lines after procedure bodies
-INDENT_OPTS += -bad#                     blank lines after declarations
-INDENT_OPTS += -sob#                     swallow optional blank lines
-INDENT_OPTS += -cli0#                    case label indent of zero spaces
-INDENT_OPTS += -npcs#                    no space after function in calls
-INDENT_OPTS += -nbc#                     don't force newlines after commas
-INDENT_OPTS += -bls#                     put braces on line after struct decl
-INDENT_OPTS += -blf#                     put braces on line after func def
-INDENT_OPTS += -lp#                      align continued lines at parentheses
-INDENT_OPTS += -ip0#                     indent parameter types zero spaces
-INDENT_OPTS += -ts2#                     set tab size to two spaces
-INDENT_OPTS += -nut#                     use spaces instead of tabs
-INDENT_OPTS += -npsl#                    type of proc on same line as name
-INDENT_OPTS += -bbo#                     prefer break before boolean operator
-INDENT_OPTS += -l80#                     max non-comment line length is 80
-
 #====================== END: TOOL CONFIGURATION ==============================
 
 #====================== START: RULES =========================================
 
 .PHONY: all
-all: pre clean-backups \
+all: clean-backups \
      $(BIN_DIR)/kmyth-seal \
      $(BIN_DIR)/kmyth-unseal \
      $(BIN_DIR)/kmyth-getkey \
@@ -311,22 +293,17 @@ all: pre clean-backups \
      $(LIB_DIR)/libkmyth-logger.so \
      $(LIB_DIR)/libkmyth-tpm.so
 
-.PHONY: pre
-pre:
-	indent $(INDENT_OPTS) $(SOURCE_FILES)
-	indent $(INDENT_OPTS) $(HEADER_FILES)
-
 .PHONY: libs
-libs: pre clean-backups \
+libs: clean-backups \
       $(LIB_DIR)/libkmyth-utils.so \
       $(LIB_DIR)/libkmyth-logger.so \
       $(LIB_DIR)/libkmyth-tpm.so
 
 .PHONY: utils-lib
-utils-lib: pre clean-backups $(LIB_DIR)/libkmyth-utils.so
+utils-lib: clean-backups $(LIB_DIR)/libkmyth-utils.so
 
 .PHONY: logger-lib
-logger-lib: pre clean-backups $(LIB_DIR)/libkmyth-logger.so
+logger-lib: clean-backups $(LIB_DIR)/libkmyth-logger.so
 
 $(LIB_DIR)/libkmyth-utils.so: $(UTILS_OBJECTS) | $(LIB_DIR)
 	$(CC) $(SOFLAGS) \
@@ -511,14 +488,8 @@ docs: $(HEADER_FILES) \
 	doxygen Doxyfile
 
 .PHONY: test
-test: pretest clean-backups $(BIN_DIR)/kmyth-test
+test: clean-backups $(BIN_DIR)/kmyth-test
 	./bin/kmyth-test 2>/dev/null
-
-.PHONY: pretest
-pretest:
-	indent $(INDENT_OPTS) $(TEST_SOURCES)
-	indent $(INDENT_OPTS) $(TEST_HEADERS)
-
 
 $(BIN_DIR)/kmyth-test: $(TEST_OBJECTS) \
 	                     $(LIB_DIR)/libkmyth-utils.so \

--- a/sgx/demo/Makefile
+++ b/sgx/demo/Makefile
@@ -29,26 +29,6 @@
 #
 #
 
-######### Source Code Indentation Settings ###################################
-
-INDENT_OPTS = -bli0#                     indent braces zero spaces
-INDENT_OPTS += -bap#                     blank lines after procedure bodies
-INDENT_OPTS += -bad#                     blank lines after declarations
-INDENT_OPTS += -sob#                     swallow optional blank lines
-INDENT_OPTS += -cli0#                    case label indent of zero spaces
-INDENT_OPTS += -npcs#                    no space after function in calls
-INDENT_OPTS += -nbc#                     don't force newlines after commas
-INDENT_OPTS += -bls#                     put braces on line after struct decl
-INDENT_OPTS += -blf#                     put braces on line after func def
-INDENT_OPTS += -lp#                      align continued lines at parentheses
-INDENT_OPTS += -ip0#                     indent parameter types zero spaces
-INDENT_OPTS += -ts2#                     set tab size to two spaces
-INDENT_OPTS += -nut#                     use spaces instead of tabs
-INDENT_OPTS += -npsl#                    type of proc on same line as name
-INDENT_OPTS += -bbo#                     prefer break before boolean operator
-INDENT_OPTS += -l80#                     max non-comment line length is 80
-
-
 ######## SGX SDK Build Settings ########
 
 SGX_SDK ?= /opt/intel/sgxsdk
@@ -270,12 +250,6 @@ pre:
 	@if [ ! -f enclave/$(Enclave_Signing_Key) ]; then \
 	   openssl genrsa -out enclave/$(Enclave_Signing_Key) -3 3072; \
 	 fi
-	@indent $(INDENT_OPTS) app/*.c
-	@indent $(INDENT_OPTS) server/*.c server/*.h
-	@indent $(INDENT_OPTS) ../common/src/*.c ../common/include/*.h
-	@indent $(INDENT_OPTS) ../untrusted/src/*/*.c ../untrusted/include/*/*.h
-	@indent $(INDENT_OPTS) ../trusted/src/*/*.cpp ../trusted/src/*/*.c
-	@indent $(INDENT_OPTS) ../trusted/include/*.h ../trusted/include/util/*.h
 	@rm -f app/*~
 	@rm -f ../untrusted/src/*/*~ ../untrusted/include/*/*~
 	@rm -f ../trusted/src/*/*~ ../trusted/include/*~ ../trusted/include/*/*~

--- a/sgx/test/Makefile
+++ b/sgx/test/Makefile
@@ -29,26 +29,6 @@
 #
 #
 
-######### Source Code Indentation Settings ###################################
-
-INDENT_OPTS = -bli0#                     indent braces zero spaces
-INDENT_OPTS += -bap#                     blank lines after procedure bodies
-INDENT_OPTS += -bad#                     blank lines after declarations
-INDENT_OPTS += -sob#                     swallow optional blank lines
-INDENT_OPTS += -cli0#                    case label indent of zero spaces
-INDENT_OPTS += -npcs#                    no space after function in calls
-INDENT_OPTS += -nbc#                     don't force newlines after commas
-INDENT_OPTS += -bls#                     put braces on line after struct decl
-INDENT_OPTS += -blf#                     put braces on line after func def
-INDENT_OPTS += -lp#                      align continued lines at parentheses
-INDENT_OPTS += -ip0#                     indent parameter types zero spaces
-INDENT_OPTS += -ts2#                     set tab size to two spaces
-INDENT_OPTS += -nut#                     use spaces instead of tabs
-INDENT_OPTS += -npsl#                    type of proc on same line as name
-INDENT_OPTS += -bbo#                     prefer break before boolean operator
-INDENT_OPTS += -l80#                     max non-comment line length is 80
-
-
 ######## SGX SDK Build Settings ########
 
 SGX_SDK ?= /opt/intel/sgxsdk
@@ -243,10 +223,6 @@ pre:
 	@if [ ! -f enclave/$(Enclave_Signing_Key) ]; then \
 	   openssl genrsa -out enclave/$(Enclave_Signing_Key) -3 3072; \
 	 fi
-	@indent $(INDENT_OPTS) app/*.c
-	@indent $(INDENT_OPTS) ../untrusted/src/*/*.c ../untrusted/include/*/*.h
-	@indent $(INDENT_OPTS) ../trusted/src/*/*.cpp ../trusted/src/*/*.c
-	@indent $(INDENT_OPTS) ../trusted/include/*.h ../trusted/include/*/*.h
 	@rm -f app/*~
 	@rm -f ../untrusted/src/*/*~ ../untrusted/include/*/*~
 	@rm -f ../trusted/src/*/*~ ../trusted/include/*~ ../trusted/include/*/*~


### PR DESCRIPTION
Indent initially helped everyone maintain similar/identical formatting, but over time it has created more noise than it has eliminated. Removing this from the build should help developers track meaningful changes.