### PR TITLE
Update libkmip link name.

### DIFF
--- a/sgx/demo/Makefile
+++ b/sgx/demo/Makefile
@@ -217,7 +217,7 @@ Enclave_Link_Flags += -Wl,-Bsymbolic
 Enclave_Link_Flags += -Wl,-pie,-eenclave_entry
 Enclave_Link_Flags += -Wl,--export-dynamic
 Enclave_Link_Flags += -Wl,--defsym,__ImageBase=0
-Enclave_Link_Flags += -lkmip-core
+Enclave_Link_Flags += -lkmip-sgx
 
 Enclave_Name := kmyth_sgx_retrieve_key_demo_enclave
 Enclave_Lib := $(Enclave_Name).so

--- a/sgx/test/Makefile
+++ b/sgx/test/Makefile
@@ -214,7 +214,7 @@ Enclave_Link_Flags += -Wl,-Bsymbolic
 Enclave_Link_Flags += -Wl,-pie,-eenclave_entry
 Enclave_Link_Flags += -Wl,--export-dynamic
 Enclave_Link_Flags += -Wl,--defsym,__ImageBase=0
-Enclave_Link_Flags += -lkmip-core
+Enclave_Link_Flags += -lkmip-sgx
 
 Enclave_Name := kmyth_sgx_test_enclave
 Enclave_Lib := $(Enclave_Name).so


### PR DESCRIPTION
Previously, the sgx demo required custom compile options for libkmip.
Now it will be compatible with the default libkmip install settings
once https://github.com/OpenKMIP/libkmip/pull/65 is merged.