### PR TITLE
Update enclave_retrieve_key() API

### DIFF
--- a/sgx/demo/app/kmyth_sgx_retrieve_key_demo.c
+++ b/sgx/demo/app/kmyth_sgx_retrieve_key_demo.c
@@ -47,6 +47,7 @@
 /* These parameters are hard-coded for now. */
 #define SERVER_IP "localhost"
 #define SERVER_PORT "7000"
+#define KEY_ID "fake_key_id"
 
 /*****************************************************************************
  * initialize_enclave
@@ -180,8 +181,10 @@ int main(int argc, char **argv)
 
   const char *server_host = SERVER_IP;
   const char *server_port = SERVER_PORT;
+  unsigned char *req_key_id = (unsigned char *) KEY_ID;
   int server_host_len = strlen(server_host) + 1;
   int server_port_len = strlen(server_port) + 1;
+  int req_key_id_len = strlen(req_key_id) + 1;
 
   sgx_ret = kmyth_enclave_retrieve_key_from_server(eid,
                                                    &retval,
@@ -192,7 +195,9 @@ int main(int argc, char **argv)
                                                    server_host,
                                                    server_host_len,
                                                    server_port,
-                                                   server_port_len);
+                                                   server_port_len,
+                                                   req_key_id,
+                                                   req_key_id_len);
 
   free(client_priv_ec_key_bytes);
   free(server_pub_ec_cert_bytes);

--- a/sgx/demo/app/kmyth_sgx_retrieve_key_demo.c
+++ b/sgx/demo/app/kmyth_sgx_retrieve_key_demo.c
@@ -46,7 +46,7 @@
 
 /* These parameters are hard-coded for now. */
 #define SERVER_IP "localhost"
-#define SERVER_PORT "7000"
+#define SERVER_PORT 7000
 #define KEY_ID "fake_key_id"
 
 /*****************************************************************************
@@ -180,10 +180,9 @@ int main(int argc, char **argv)
   int retval = -1;
 
   const char *server_host = SERVER_IP;
-  const char *server_port = SERVER_PORT;
-  unsigned char *req_key_id = (unsigned char *) KEY_ID;
   int server_host_len = strlen(server_host) + 1;
-  int server_port_len = strlen(server_port) + 1;
+  int server_port = SERVER_PORT;
+  unsigned char *req_key_id = (unsigned char *) KEY_ID;
   int req_key_id_len = strlen(req_key_id) + 1;
 
   sgx_ret = kmyth_enclave_retrieve_key_from_server(eid,
@@ -195,7 +194,6 @@ int main(int argc, char **argv)
                                                    server_host,
                                                    server_host_len,
                                                    server_port,
-                                                   server_port_len,
                                                    req_key_id,
                                                    req_key_id_len);
 

--- a/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
+++ b/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
@@ -54,11 +54,9 @@ extern "C"
  *
  * @param[in]  server_host_len        Length (in bytes) of server_host string.
  *
- * @param[in]  server_port            String TCP port number used to
+ * @param[in]  server_port            TCP port number used to
  *                                    connect to the key server.
  *
- * @param[in]  server_port_len        Length (in bytes) of server_port string.
- * 
  * @param[in]  key_id                 ID string used to specify the key to be
  *                                    retrieved.
  * 
@@ -68,7 +66,7 @@ extern "C"
  */
   int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                            const char *server_host, int server_host_len,
-                           const char *server_port, int server_port_len,
+                           int server_port,
                            unsigned char *key_id, int key_id_len);
 
 #ifdef __cplusplus

--- a/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
+++ b/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
@@ -57,17 +57,29 @@ extern "C"
  * @param[in]  server_port            TCP port number used to
  *                                    connect to the key server.
  *
- * @param[in]  key_id                 ID string used to specify the key to be
- *                                    retrieved.
+ * @param[in/out] key_id              ID string used to specify the key to be
+ *                                    retrieved. The key ID string returned in
+ *                                    the key server's response is returned in 
+ *                                    this parameter and should be checked by
+ *                                    the calling function.
  * 
- * @param[in]  key_id_len             Length (in bytes) of key ID string
+ * @param[in/out] key_id_len          Length (in bytes) of the ID string
+ *                                    associated with the requested and
+ *                                    retrieved key.
+ *
+ * @param[out] retrieved_key          Pointer to the retrieved key result
+ *                                    (byte array).
+ * 
+ * @param[out] retrieved_key_len      Pointer to the length (in bytes) of the
+ *                                    retrieved key result.
  *
  * @return 0 on success, 1 on error
  */
   int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                            const char *server_host, int server_host_len,
-                           int server_port,
-                           unsigned char *key_id, int key_id_len);
+                           int server_port, unsigned char **key_id,
+                           size_t *key_id_len, uint8_t **retrieved_key,
+                           size_t *retrieved_key_len);
 
 #ifdef __cplusplus
 }

--- a/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
+++ b/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
@@ -57,15 +57,17 @@ extern "C"
  * @param[in]  server_port            TCP port number used to
  *                                    connect to the key server.
  *
- * @param[in/out] key_id              ID string used to specify the key to be
- *                                    retrieved. The key ID string returned in
- *                                    the key server's response is returned in 
- *                                    this parameter and should be checked by
- *                                    the calling function.
+ * @param[in] req_key_id              ID string used to specify the key to be
+ *                                    retrieved.
  * 
- * @param[in/out] key_id_len          Length (in bytes) of the ID string
- *                                    associated with the requested and
- *                                    retrieved key.
+ * @param[in] req_key_id_len          Length (in bytes) of the ID string
+ *                                    associated with the requested key.
+ *
+ * @param[out] retrieved_key_id       Pointer to the key ID string returned in
+ *                                    the key server's response.
+ * 
+ * @param[out] retrieved_key_id_len   Pointer to the length (in bytes) of the
+ *                                    ID string for the retrieved key.
  *
  * @param[out] retrieved_key          Pointer to the retrieved key result
  *                                    (byte array).
@@ -77,9 +79,11 @@ extern "C"
  */
   int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                            const char *server_host, int server_host_len,
-                           int server_port, unsigned char **key_id,
-                           size_t *key_id_len, uint8_t **retrieved_key,
-                           size_t *retrieved_key_len);
+                           int server_port, unsigned char *req_key_id,
+                           size_t req_key_id_len,
+                           unsigned char **retrieved_key_id,
+                           size_t *retrieved_key_id_len,
+                           uint8_t **retrieved_key, size_t *retrieved_key_len);
 
 #ifdef __cplusplus
 }

--- a/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
+++ b/sgx/trusted/include/wrapper/sgx_retrieve_key_impl.h
@@ -58,12 +58,18 @@ extern "C"
  *                                    connect to the key server.
  *
  * @param[in]  server_port_len        Length (in bytes) of server_port string.
+ * 
+ * @param[in]  key_id                 ID string used to specify the key to be
+ *                                    retrieved.
+ * 
+ * @param[in]  key_id_len             Length (in bytes) of key ID string
  *
  * @return 0 on success, 1 on error
  */
   int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                            const char *server_host, int server_host_len,
-                           const char *server_port, int server_port_len);
+                           const char *server_port, int server_port_len,
+                           unsigned char *key_id, int key_id_len);
 
 #ifdef __cplusplus
 }

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -104,7 +104,10 @@ enclave {
                                                       int server_host_len,
                                                       [in, count=server_port_len]
                                                         const char* server_port,
-                                                      int server_port_len);
+                                                      int server_port_len,
+                                                      [in, count=key_id_len]
+                                                        unsigned char* key_id,
+                                                      int key_id_len);
 
   };
 

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -102,9 +102,7 @@ enclave {
                                                       [in, count=server_host_len]
                                                         const char* server_host,
                                                       int server_host_len,
-                                                      [in, count=server_port_len]
-                                                        const char* server_port,
-                                                      int server_port_len,
+                                                      int server_port,
                                                       [in, count=key_id_len]
                                                         unsigned char* key_id,
                                                       int key_id_len);
@@ -161,10 +159,8 @@ enclave {
      *
      * @param[in]  server_host_len            Length (in bytes) of server_host string.
      *
-     * @param[in]  server_port                String TCP port number used to
+     * @param[in]  server_port                TCP port number used to
      *                                        connect to the key server.
-     *
-     * @param[in]  server_port_len            Length (in bytes) of server_port string.
      *
      * @param[out] socket_fd                  Pointer to the file descriptor
      *                                        number for a socket connected to
@@ -175,9 +171,7 @@ enclave {
     int setup_socket_ocall([in, count=server_host_len]
                              const char *server_host,
                            int server_host_len,
-                           [in, count=server_port_len]
-                             const char *server_port,
-                           int server_port_len,
+                           int server_port,
                            [out] int *socket_fd);
 
     /**

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -105,7 +105,7 @@ enclave {
                                                       int server_port,
                                                       [in, count=key_id_len]
                                                         unsigned char* key_id,
-                                                      int key_id_len);
+                                                      size_t key_id_len);
 
   };
 

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -91,6 +91,31 @@ enclave {
               connection with key server and then retrieves a key from the
               key server using that secure connection.
      *
+     * @param[in]  client_private_bytes      DER-formatted private signing
+     *                                       key for the client (enclave)
+     *
+     * @param[in]  client_private_bytes_len  Length (in bytes) of the client
+     *                                       (enclave) private key
+     *
+     * @param[in]  server_cert_bytes         DER-formatted public certificate
+     *                                       for the key server.
+     *
+     * @param[in]  server_cert_bytes_len     Length (in bytes) of the key
+     *                                       server certificate.
+     *
+     * @param[in]  server_host               Hostname/IP string for key server.
+     *
+     * @param[in]  server_host_len           Length of hostname/IP string for
+     *                                       the key server.
+     *
+     * @param[in]  server_port               TCP port for key server.
+     *
+     * @param[in]  key_id                    ID string used to specify the key
+     *                                       to be retrieved from the server.
+     *
+     * @param[in]  key_id_len                Length of the requested key's ID
+     *                                       string.
+     *
      * @return 0 on success, -1 on failure.
      */
     public int kmyth_enclave_retrieve_key_from_server([in, count=client_private_bytes_len]

--- a/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+++ b/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
@@ -75,8 +75,8 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
 
   char msg[MAX_LOG_MSG_LEN] = { 0 };
 
-  snprintf(msg, MAX_LOG_MSG_LEN, "Retrieved into enclave key with ID: %.*s",
-           (int) retrieve_key_result_id_len, retrieve_key_result_id);
+  snprintf(msg, MAX_LOG_MSG_LEN, "Retrieved into enclave key with ID: %s",
+           retrieve_key_result_id);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
   snprintf(msg, MAX_LOG_MSG_LEN,
@@ -85,6 +85,10 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
            retrieve_key_result[retrieve_key_result_len - 1]);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
+  // Verification that the Key ID received in the response from the key server
+  // matches the requested Key ID eliminates the need to return this parameter
+  // to the ECALL caller. A successful ECALL return indicates that the
+  // returned key ID matches the input value that the caller provided.
   if (strcmp((const char*) retrieve_key_result_id, (const char*) key_id) != 0)
   {
     kmyth_sgx_log(LOG_ERR, "retrieved key ID mismatches requested key ID");

--- a/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+++ b/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
@@ -17,8 +17,7 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
                                            size_t server_cert_bytes_len,
                                            const char *server_host,
                                            int server_host_len,
-                                           const char *server_port,
-                                           int server_port_len,
+                                           int server_port,
                                            unsigned char *key_id,
                                            int key_id_len)
 {
@@ -59,8 +58,7 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
 
   ret_val =
     enclave_retrieve_key(client_sign_privkey, server_cert, server_host,
-                         server_host_len, server_port, server_port_len,
-                         key_id, key_id_len);
+                         server_host_len, server_port, key_id, key_id_len);
   if (ret_val)
   {
     kmyth_sgx_log(LOG_ERR,

--- a/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+++ b/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
@@ -19,7 +19,7 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
                                            int server_host_len,
                                            int server_port,
                                            unsigned char *key_id,
-                                           int key_id_len)
+                                           size_t key_id_len)
 {
   // unmarshal client private signing key
   EVP_PKEY *client_sign_privkey = NULL;
@@ -56,9 +56,13 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
   }
   kmyth_sgx_log(LOG_DEBUG, "unmarshalled server certificate (to X509)");
 
+  unsigned char *retrieve_key_result = NULL;
+  size_t retrieve_key_result_size = 0;
+
   ret_val =
     enclave_retrieve_key(client_sign_privkey, server_cert, server_host,
-                         server_host_len, server_port, key_id, key_id_len);
+                         server_host_len, server_port, &key_id, &key_id_len,
+                         &retrieve_key_result, &retrieve_key_result_size);
   if (ret_val)
   {
     kmyth_sgx_log(LOG_ERR,
@@ -69,6 +73,8 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
   // free memory for parameters passed to 'retrieve key' wrapper function
   EVP_PKEY_free(client_sign_privkey);
   X509_free(server_cert);
+  kmyth_enclave_clear(retrieve_key_result, retrieve_key_result_size);
+  free(retrieve_key_result);
 
   return EXIT_SUCCESS;
 }

--- a/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+++ b/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
@@ -18,7 +18,9 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
                                            const char *server_host,
                                            int server_host_len,
                                            const char *server_port,
-                                           int server_port_len)
+                                           int server_port_len,
+                                           unsigned char *key_id,
+                                           int key_id_len)
 {
   // unmarshal client private signing key
   EVP_PKEY *client_sign_privkey = NULL;
@@ -57,7 +59,8 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
 
   ret_val =
     enclave_retrieve_key(client_sign_privkey, server_cert, server_host,
-                         server_host_len, server_port, server_port_len);
+                         server_host_len, server_port, server_port_len,
+                         key_id, key_id_len);
   if (ret_val)
   {
     kmyth_sgx_log(LOG_ERR,

--- a/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+++ b/sgx/trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
@@ -57,12 +57,12 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
   kmyth_sgx_log(LOG_DEBUG, "unmarshalled server certificate (to X509)");
 
   unsigned char *retrieve_key_result = NULL;
-  size_t retrieve_key_result_size = 0;
+  size_t retrieve_key_result_len = 0;
 
   ret_val =
     enclave_retrieve_key(client_sign_privkey, server_cert, server_host,
                          server_host_len, server_port, &key_id, &key_id_len,
-                         &retrieve_key_result, &retrieve_key_result_size);
+                         &retrieve_key_result, &retrieve_key_result_len);
   if (ret_val)
   {
     kmyth_sgx_log(LOG_ERR,
@@ -70,10 +70,22 @@ int kmyth_enclave_retrieve_key_from_server(uint8_t * client_private_bytes,
     return EXIT_FAILURE;
   }
 
+  char msg[MAX_LOG_MSG_LEN] = { 0 };
+  
+  snprintf(msg, MAX_LOG_MSG_LEN, "Retrieved into enclave key with ID: %.*s",
+           (int) key_id_len, key_id);
+  kmyth_sgx_log(LOG_DEBUG, msg);
+
+  snprintf(msg, MAX_LOG_MSG_LEN,
+           "Retrieved into enclave key: 0x%02X..%02X",
+           retrieve_key_result[0],
+           retrieve_key_result[retrieve_key_result_len - 1]);
+  kmyth_sgx_log(LOG_DEBUG, msg);
+
   // free memory for parameters passed to 'retrieve key' wrapper function
   EVP_PKEY_free(client_sign_privkey);
   X509_free(server_cert);
-  kmyth_enclave_clear(retrieve_key_result, retrieve_key_result_size);
+  kmyth_enclave_clear(retrieve_key_result, retrieve_key_result_len);
   free(retrieve_key_result);
 
   return EXIT_SUCCESS;

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -327,6 +327,10 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
     return EXIT_FAILURE;
   }
 
+  // Note: This implementation requires that Key ID be a valid string that does
+  //       not contain any null terminators as part of the ID itself. If the
+  //       Key ID must be more generic (e.g., any combination of bytes), this
+  //       code will require some re-work to support that correctly.
   if (strlen((char *) *retrieved_key_id) != (*retrieved_key_id_len - 1))
   {
     kmyth_sgx_log(LOG_ERR, "Invalid Key ID string");

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -327,8 +327,14 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
     return EXIT_FAILURE;
   }
 
-  snprintf(msg, MAX_LOG_MSG_LEN, "Received a KMIP object with ID: %.*s",
-           (int) *retrieved_key_id_len, *retrieved_key_id);
+  if (strlen((char *) *retrieved_key_id) != (*retrieved_key_id_len - 1))
+  {
+    kmyth_sgx_log(LOG_ERR, "Invalid Key ID string");
+    return EXIT_FAILURE;
+  }
+
+  snprintf(msg, MAX_LOG_MSG_LEN, "Received a KMIP object with ID: %s",
+           *retrieved_key_id);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
   snprintf(msg, MAX_LOG_MSG_LEN,

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -15,9 +15,11 @@
 //############################################################################
 int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                          const char *server_host, int server_host_len,
-                         int server_port, unsigned char **key_id,
-                         size_t *key_id_len, uint8_t **retrieved_key,
-                         size_t *retrieved_key_len)
+                         int server_port, unsigned char *req_key_id,
+                         size_t req_key_id_len,
+                         unsigned char **retrieved_key_id,
+                         size_t *retrieved_key_id_len,
+                         uint8_t **retrieved_key, size_t *retrieved_key_len)
 {
   int ret_val;
   sgx_status_t ret_ocall;
@@ -250,7 +252,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
   size_t key_request_len = 0;
 
   ret_val = build_kmip_get_request(&kmip_context,
-                                   *key_id, *key_id_len,
+                                   req_key_id, req_key_id_len,
                                    &key_request, &key_request_len);
   if (ret_val)
   {
@@ -314,7 +316,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
 
   ret_val = parse_kmip_get_response(&kmip_context,
                                     response, response_len,
-                                    key_id, key_id_len,
+                                    retrieved_key_id, retrieved_key_id_len,
                                     (unsigned char **) retrieved_key,
                                     retrieved_key_len);
   kmyth_enclave_clear_and_free(response, response_len);
@@ -326,7 +328,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
   }
 
   snprintf(msg, MAX_LOG_MSG_LEN, "Received a KMIP object with ID: %.*s",
-           (int) *key_id_len, *key_id);
+           (int) *retrieved_key_id_len, *retrieved_key_id);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
   snprintf(msg, MAX_LOG_MSG_LEN,

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -15,8 +15,7 @@
 //############################################################################
 int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                          const char *server_host, int server_host_len,
-                         const char *server_port, int server_port_len,
-                         unsigned char *key_id, int key_id_len)
+                         int server_port, unsigned char *key_id, int key_id_len)
 {
   int ret_val;
   sgx_status_t ret_ocall;
@@ -25,7 +24,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
   int socket_fd = -1;
 
   ret_ocall = setup_socket_ocall(&ret_val, server_host, server_host_len,
-                                 server_port, server_port_len, &socket_fd);
+                                 server_port, &socket_fd);
   if (ret_ocall != SGX_SUCCESS || ret_val != EXIT_SUCCESS)
   {
     kmyth_sgx_log(LOG_ERR, "Client socket setup failed.");

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -329,10 +329,10 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
            (int) *key_id_len, *key_id);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
-  snprintf(msg, MAX_LOG_MSG_LEN, "Received operational key: 0x%02X..%02X",
+  snprintf(msg, MAX_LOG_MSG_LEN,
+           "Received KMIP object with key: 0x%02X..%02X",
            (*retrieved_key)[0], (*retrieved_key)[*retrieved_key_len - 1]);
   kmyth_sgx_log(LOG_DEBUG, msg);
 
-  kmyth_sgx_log(LOG_DEBUG, "completed key retrieval from server into enclave");
   return EXIT_SUCCESS;
 }

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -15,7 +15,8 @@
 //############################################################################
 int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                          const char *server_host, int server_host_len,
-                         const char *server_port, int server_port_len)
+                         const char *server_port, int server_port_len,
+                         unsigned char *key_id, int key_id_len)
 {
   int ret_val;
   sgx_status_t ret_ocall;
@@ -244,12 +245,11 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
   KMIP kmip_context = { 0 };
   kmip_init(&kmip_context, NULL, 0, KMIP_2_0);
 
-  unsigned char *key_id = (unsigned char *) "fake_key_id";
   unsigned char *key_request = NULL;
   size_t key_request_len = 0;
 
   ret_val = build_kmip_get_request(&kmip_context,
-                                   key_id, sizeof(key_id),
+                                   key_id, key_id_len,
                                    &key_request, &key_request_len);
   if (ret_val)
   {

--- a/sgx/untrusted/include/ocall/ecdh_ocall.h
+++ b/sgx/untrusted/include/ocall/ecdh_ocall.h
@@ -42,10 +42,8 @@ extern "C"
  *
  * @param[in]  server_host_len            Length (in bytes) of server_host string.
  *
- * @param[in]  server_port                String TCP port number used to
+ * @param[in]  server_port                TCP port number used to
  *                                        connect to the key server.
- *
- * @param[in]  server_port_len            Length (in bytes) of server_port string.
  *
  * @param[out] socket_fd                  Pointer to the file descriptor
  *                                        number for a socket connected to
@@ -54,8 +52,7 @@ extern "C"
  * @return 0 on success, 1 on failure
  */
   int setup_socket_ocall(const char *server_host, int server_host_len,
-                         const char *server_port, int server_port_len,
-                         int *socket_fd);
+                         int server_port, int *socket_fd);
 
 /**
  * @brief Closes a socket connected to the external key server.

--- a/sgx/untrusted/src/ocall/ecdh_ocall.c
+++ b/sgx/untrusted/src/ocall/ecdh_ocall.c
@@ -14,15 +14,19 @@
  * setup_socket_ocall()
  ****************************************************************************/
 int setup_socket_ocall(const char *server_host, int server_host_len,
-                       const char *server_port, int server_port_len,
-                       int *socket_fd)
+                       int server_port, int *socket_fd)
 {
   *socket_fd = UNSET_FD;
 
+  // create "service" string from integer port number
+  char server_service[6]; // max port is 65535, so max string is 5 char + '\0'
+  snprintf(server_service, 6, "%d", server_port);
+
   // connect to server
-  kmyth_log(LOG_DEBUG, "Setting up client socket, remote host: %s, port: %s",
+  kmyth_log(LOG_DEBUG, "Setting up client socket, remote host: %s, port: %d",
             server_host, server_port);
-  if (setup_client_socket(server_host, server_port, socket_fd))
+
+  if (setup_client_socket(server_host, server_service, socket_fd))
   {
     kmyth_log(LOG_ERR, "Failed to connect to the server.");
     return EXIT_FAILURE;


### PR DESCRIPTION
This pull request addresses Issue #153.

A pointer to the retrieved key (and its length) were added to the parameter list in order to provide the caller (within the enclave) access to the retrieved key.

Key ID string (and length) parameters were added to support caller specification of the key to be retrieved from the server.
- for enclave_retrieve_key() the input value (used to format the 'retrieve key' request) and the output value (parsed from the 'retrieve key' response were passed as separate parameters.
- for the kmyth_enclave_retrieve_key_from_server() ECALL, only the input requested 'key ID' was added as a parameter. After its call to enclave_retrieve_key() returns, however, the ECALL code checks that the output (key ID parsed from the response) matches the input key ID requested and errors if the two mismatch.

The server's TCP port value parameter was changed from a string to an integer. In the setup_socket_ocall() function, a "service" parameter string, which is a string version of the port value is required, so integer to string conversion is added in this one place.

The parameter description documentation was missing for the kmyth_enclave_retrieve_key_from_server() ECALL, so this pull request added some to the .edl file.