### PR TITLE
Refactored log_event_ocall() API

### DIFF
--- a/sgx/common/include/kmyth_enclave_common.h
+++ b/sgx/common/include/kmyth_enclave_common.h
@@ -57,7 +57,7 @@ extern "C"
   const int src_line = __LINE__;\
   int log_level = severity;\
   const char *log_msg = message;\
-  log_event_ocall(src_file, src_func, &src_line, &log_level, log_msg);\
+  log_event_ocall(src_file, src_func, src_line, log_level, log_msg);\
 }
 
 #include "ec_key_cert_marshal.h"

--- a/sgx/common/include/kmyth_enclave_common.h
+++ b/sgx/common/include/kmyth_enclave_common.h
@@ -57,7 +57,7 @@ extern "C"
   const int src_line = __LINE__;\
   int log_level = severity;\
   const char *log_msg = message;\
-  log_event_ocall(&src_file, &src_func, &src_line, &log_level, &log_msg);\
+  log_event_ocall(src_file, src_func, &src_line, &log_level, log_msg);\
 }
 
 #include "ec_key_cert_marshal.h"

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -142,25 +142,24 @@ enclave {
      *        about the event out explicitly since we must invoke the logging API
      *        from untrusted space.
      *
-     * @param[in] src_file_ptr     Pointer to source code filename string
+     * @param[in] src_file         Source code filename string
      *
-     * @param[in] src_func_ptr     Pointer to function name string
+     * @param[in] src_func         Function name string
      *
      * @param[in] src_line_ptr     Pointer to source code line number integer
      *
      * @param[in] severity_ptr     Pointer to integer representing the severity
      *                             level of the event to be logged.
      *
-     * @param[in] message_ptr      Pointer to string containing the message to
-     *                             be logged.
+     * @param[in] msg              String containing the message to be logged.
      *
      * @return                     None
      */
-    void log_event_ocall([in] const char **src_file_ptr,
-                         [in] const char **src_func_ptr,
+    void log_event_ocall([in, string] const char *src_file,
+                         [in, string] const char *src_func,
                          [in] const int *src_line_ptr,
                          [in] int *severity_ptr,
-                         [in] const char **message_ptr);
+                         [in, string] const char *msg);
 
 
     /**

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -174,7 +174,7 @@ enclave {
      *
      * @return                     None
      */
-    void OPENSSL_free_ocall([user_check] void ** mem_block_ptr);
+    void free_ocall([in] void **mem_block_ptr);
 
     /**
      * @brief Creates a socket connected to the external key server.

--- a/sgx/trusted/kmyth_enclave.edl
+++ b/sgx/trusted/kmyth_enclave.edl
@@ -146,9 +146,9 @@ enclave {
      *
      * @param[in] src_func         Function name string
      *
-     * @param[in] src_line_ptr     Pointer to source code line number integer
+     * @param[in] src_line         Integer specifying source code line number
      *
-     * @param[in] severity_ptr     Pointer to integer representing the severity
+     * @param[in] severity         Integer representing the severity
      *                             level of the event to be logged.
      *
      * @param[in] msg              String containing the message to be logged.
@@ -157,8 +157,8 @@ enclave {
      */
     void log_event_ocall([in, string] const char *src_file,
                          [in, string] const char *src_func,
-                         [in] const int *src_line_ptr,
-                         [in] int *severity_ptr,
+                         int src_line,
+                         int severity,
                          [in, string] const char *msg);
 
 

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -126,8 +126,8 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
     EC_KEY_free(client_ephemeral_keypair);
     free(client_ephemeral_pub);
     free(client_eph_pub_signature);
-    OPENSSL_free_ocall((void **) &server_ephemeral_pub);
-    OPENSSL_free_ocall((void **) &server_eph_pub_signature);
+    free_ocall((void **) &server_ephemeral_pub);
+    free_ocall((void **) &server_eph_pub_signature);
     close_socket_ocall(socket_fd);
     return EXIT_FAILURE;
   }
@@ -149,8 +149,8 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
     kmyth_sgx_log(LOG_ERR, "client ephemeral 'public key' signature invalid");
     EVP_PKEY_free(server_sign_pubkey);
     EC_KEY_free(client_ephemeral_keypair);
-    OPENSSL_free_ocall((void **) &server_ephemeral_pub);
-    OPENSSL_free_ocall((void **) &server_eph_pub_signature);
+    free_ocall((void **) &server_ephemeral_pub);
+    free_ocall((void **) &server_eph_pub_signature);
     close_socket_ocall(socket_fd);
     return EXIT_FAILURE;
   }
@@ -159,7 +159,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
 
   // done with signature verification of server contribution
   EVP_PKEY_free(server_sign_pubkey);
-  OPENSSL_free_ocall((void **) &server_eph_pub_signature);
+  free_ocall((void **) &server_eph_pub_signature);
 
   // convert server's ephemeral public octet string to an EC_POINT struct
   EC_POINT *server_ephemeral_pub_pt = NULL;
@@ -182,7 +182,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
                 "reconstructed server ECDH ephemeral 'public key' point");
 
   // done with server_ephemeral_pub
-  OPENSSL_free_ocall((void **) &server_ephemeral_pub);
+  free_ocall((void **) &server_ephemeral_pub);
 
   // generate shared secret value result for ECDH key agreement (client side)
   unsigned char *session_secret = NULL;
@@ -310,7 +310,7 @@ int enclave_retrieve_key(EVP_PKEY * enclave_sign_privkey, X509 * peer_cert,
   ret_val = aes_gcm_decrypt(session_key, session_key_len,
                             encrypted_response, encrypted_response_len,
                             &response, &response_len);
-  OPENSSL_free_ocall((void **) &encrypted_response);
+  free_ocall((void **) &encrypted_response);
   kmyth_enclave_clear_and_free(session_key, session_key_len);
   if (ret_val)
   {

--- a/sgx/untrusted/include/ocall/log_ocall.h
+++ b/sgx/untrusted/include/ocall/log_ocall.h
@@ -24,9 +24,9 @@ extern "C"
  *
  * @param[in] src_func         Function name string
  *
- * @param[in] src_line_ptr     Pointer to source code line number integer
+ * @param[in] src_line         Integer specifying source code line number
  *
- * @param[in] severity_ptr     Pointer to integer representing the severity
+ * @param[in] severity         Integer representing the severity
  *                             level of the event to be logged.
  *
  * @param[in] msg              String containing the message to be logged.
@@ -35,8 +35,8 @@ extern "C"
  */
   void log_event_ocall(const char *src_file,
                        const char *src_func,
-                       const int *src_line_ptr,
-                       int *severity_ptr,
+                       int src_line,
+                       int severity,
                        const char *msg);
 
 #ifdef __cplusplus

--- a/sgx/untrusted/include/ocall/log_ocall.h
+++ b/sgx/untrusted/include/ocall/log_ocall.h
@@ -20,24 +20,24 @@ extern "C"
  *        about the event out explicitly since we must invoke the logging API
  *        from untrusted space.
  *
- * @param[in] src_file_ptr     Pointer to source code filename string
+ * @param[in] src_file         Source code filename string
  *
- * @param[in] src_func_ptr     Pointer to function name string
+ * @param[in] src_func         Function name string
  *
  * @param[in] src_line_ptr     Pointer to source code line number integer
  *
  * @param[in] severity_ptr     Pointer to integer representing the severity
  *                             level of the event to be logged.
  *
- * @param[in] message_ptr      Pointer to string containing the message to
- *                             be logged.
+ * @param[in] msg              String containing the message to be logged.
  *
  * @return                     None
  */
-  void log_event_ocall(const char **src_file_ptr,
-                       const char **src_func_ptr,
+  void log_event_ocall(const char *src_file,
+                       const char *src_func,
                        const int *src_line_ptr,
-                       int *severity_ptr, const char **message_ptr);
+                       int *severity_ptr,
+                       const char *msg);
 
 #ifdef __cplusplus
 }

--- a/sgx/untrusted/include/ocall/memory_ocall.h
+++ b/sgx/untrusted/include/ocall/memory_ocall.h
@@ -20,11 +20,11 @@ extern "C"
  * @brief Supports freeing a memory block that was allocated in untrusted
  *        memory from within enclave.
  *
- * @param[in] mem_block_ptr     Pointer to memory buffer to be freed
+ * @param[in] mem_block_ptr    Pointer to memory buffer to be freed
  *
  * @return                     None
  */
-  void OPENSSL_free_ocall(void **mem_block_ptr);
+  void free_ocall(void ** mem_block_ptr);
 
 #ifdef __cplusplus
 }

--- a/sgx/untrusted/src/ocall/ecdh_ocall.c
+++ b/sgx/untrusted/src/ocall/ecdh_ocall.c
@@ -117,7 +117,8 @@ int ecdh_exchange_ocall(unsigned char *enclave_ephemeral_public,
     return EXIT_FAILURE;
   }
 
-  *remote_ephemeral_public = OPENSSL_zalloc(*remote_ephemeral_public_len);
+  *remote_ephemeral_public = calloc(*remote_ephemeral_public_len,
+                                    sizeof(unsigned char));
   if (*remote_ephemeral_public == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the remote ephemeral public key.");
@@ -146,7 +147,8 @@ int ecdh_exchange_ocall(unsigned char *enclave_ephemeral_public,
     return EXIT_FAILURE;
   }
 
-  *remote_eph_pub_signature = OPENSSL_zalloc(*remote_eph_pub_signature_len);
+  *remote_eph_pub_signature = calloc(*remote_eph_pub_signature_len,
+                                     sizeof(unsigned char));
   if (*remote_eph_pub_signature == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the remote ephemeral public key.");

--- a/sgx/untrusted/src/ocall/log_ocall.c
+++ b/sgx/untrusted/src/ocall/log_ocall.c
@@ -10,11 +10,11 @@
 /*****************************************************************************
  * log_event_ocall
  ****************************************************************************/
-void log_event_ocall(const char **src_file_ptr,
-                     const char **src_func_ptr,
-                     const int *src_line_ptr, int *severity_ptr,
-                     const char **message_ptr)
+void log_event_ocall(const char *src_file,
+                     const char *src_func,
+                     const int *src_line_ptr,
+                     int *severity_ptr,
+                     const char *msg)
 {
-  log_event(*src_file_ptr, *src_func_ptr, *src_line_ptr, *severity_ptr,
-            *message_ptr);
+  log_event(src_file, src_func, *src_line_ptr, *severity_ptr, msg);
 }

--- a/sgx/untrusted/src/ocall/log_ocall.c
+++ b/sgx/untrusted/src/ocall/log_ocall.c
@@ -12,9 +12,9 @@
  ****************************************************************************/
 void log_event_ocall(const char *src_file,
                      const char *src_func,
-                     const int *src_line_ptr,
-                     int *severity_ptr,
+                     int src_line,
+                     int severity,
                      const char *msg)
 {
-  log_event(src_file, src_func, *src_line_ptr, *severity_ptr, msg);
+  log_event(src_file, src_func, src_line, severity, msg);
 }

--- a/sgx/untrusted/src/ocall/memory_ocall.c
+++ b/sgx/untrusted/src/ocall/memory_ocall.c
@@ -11,7 +11,7 @@
 /*****************************************************************************
  * free_ocall
  ****************************************************************************/
-void OPENSSL_free_ocall(void **mem_block_ptr)
+void free_ocall(void **mem_block_ptr)
 {
-  OPENSSL_free(*mem_block_ptr);
+  free(*mem_block_ptr);
 }


### PR DESCRIPTION
The log_event_ocall() function is used to support logging within the trusted enclave. In the current function, the string-valued parameters to this function are passed as char** values. As it seems that this will place a pointer to trusted memory on the stack for the untrusted application, this pull request proposes changing the log_event_ocall() parameter list to pass the strings directly and specify the values as null terminated C string values by using the 'string' keyword in the .edl file.