### PR TITLE
Fixes for compile flag warning from pelz

### DIFF
--- a/sgx/common/include/ec_key_cert_unmarshal.h
+++ b/sgx/common/include/ec_key_cert_unmarshal.h
@@ -75,7 +75,7 @@ extern "C"
  *
  * @return 0 on success, 1 on error
  */
-  int unmarshal_der_to_x509_name(uint8_t *der_bytes_in,
+  int unmarshal_der_to_x509_name(const uint8_t *der_bytes_in,
                                  size_t der_bytes_in_len,
                                  X509_NAME **x509_name_out);
 

--- a/sgx/common/src/ec_key_cert_unmarshal.c
+++ b/sgx/common/src/ec_key_cert_unmarshal.c
@@ -64,7 +64,7 @@ int unmarshal_ec_der_to_x509(uint8_t *ec_der_bytes_in,
 /*****************************************************************************
  * unmarshal_der_to_x509_name()
  ****************************************************************************/
-int unmarshal_der_to_x509_name(uint8_t *der_bytes_in,
+int unmarshal_der_to_x509_name(const uint8_t *der_bytes_in,
                                size_t der_bytes_in_len,
                                X509_NAME **x509_name_out)
 {

--- a/sgx/common/src/retrieve_key_protocol.c
+++ b/sgx/common/src/retrieve_key_protocol.c
@@ -41,7 +41,7 @@ int append_msg_signature(EVP_PKEY * sign_key,
 {
   // compute message signature
   unsigned char *signature_bytes = NULL;
-  int signature_len = 0;
+  unsigned int signature_len = 0;
 
   if (EXIT_SUCCESS != ec_sign_buffer(sign_key,
                                      msg->body,

--- a/sgx/common/src/retrieve_key_protocol.c
+++ b/sgx/common/src/retrieve_key_protocol.c
@@ -266,7 +266,7 @@ int parse_client_hello_msg(ECDHMessage * msg_in,
   // convert client identity bytes in message to X509_NAME struct
   X509_NAME *client_id = NULL;
 
-  if (EXIT_SUCCESS != unmarshal_der_to_x509_name(client_id_bytes,
+  if (EXIT_SUCCESS != unmarshal_der_to_x509_name((const uint8_t *) client_id_bytes,
                                                  (size_t) client_id_len,
                                                  &(client_id)))
   {
@@ -628,7 +628,7 @@ int parse_server_hello_msg(ECDHMessage * msg_in,
 
   // convert server identity bytes in message to X509_NAME struct
   X509_NAME *rcvd_server_id = NULL;
-  if (EXIT_SUCCESS != unmarshal_der_to_x509_name(server_id_bytes,
+  if (EXIT_SUCCESS != unmarshal_der_to_x509_name((const uint8_t *) server_id_bytes,
                                                  (size_t) server_id_len,
                                                  &rcvd_server_id))
   {

--- a/sgx/untrusted/include/ocall/memory_ocall.h
+++ b/sgx/untrusted/include/ocall/memory_ocall.h
@@ -26,16 +26,6 @@ extern "C"
  */
   void free_ocall(void **mem_block_ptr);
 
-/**
- * @brief Supports freeing an OpenSSL memory block that was allocated in
- *        untrusted memory from within enclave.
- *
- * @param[in] mem_block_ptr    Pointer to memory buffer to be freed
- *
- * @return                     None
- */
-  void free_ocall(void ** mem_block_ptr);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sgx/untrusted/src/ocall/protocol_ocall.c
+++ b/sgx/untrusted/src/ocall/protocol_ocall.c
@@ -21,7 +21,7 @@ int setup_socket_ocall(const char *server_host,
 {
   *socket_fd = UNSET_FD;
 
-  if ((server_host_len = 0) || (server_port_len < 5))
+  if ((server_host_len = 0) || (server_port_len = 0))
   {
     kmyth_log(LOG_ERR, "Invalid server host or server port length.");
     return EXIT_FAILURE;

--- a/sgx/untrusted/src/ocall/protocol_ocall.c
+++ b/sgx/untrusted/src/ocall/protocol_ocall.c
@@ -21,7 +21,7 @@ int setup_socket_ocall(const char *server_host,
 {
   *socket_fd = UNSET_FD;
 
-  if ((server_host_len = 0) || (server_port_len != 4))
+  if ((server_host_len = 0) || (server_port_len < 5))
   {
     kmyth_log(LOG_ERR, "Invalid server host or server port length.");
     return EXIT_FAILURE;

--- a/sgx/untrusted/src/ocall/protocol_ocall.c
+++ b/sgx/untrusted/src/ocall/protocol_ocall.c
@@ -21,6 +21,12 @@ int setup_socket_ocall(const char *server_host,
 {
   *socket_fd = UNSET_FD;
 
+  if ((server_host_len = 0) || (server_port_len != 4))
+  {
+    kmyth_log(LOG_ERR, "Invalid server host or server port length.");
+    return EXIT_FAILURE;
+  }
+
   // connect to server
   kmyth_log(LOG_DEBUG, "Setting up client socket, remote host: %s, port: %s",
             server_host, server_port);
@@ -62,7 +68,6 @@ int ecdh_exchange_ocall(unsigned char *client_hello,
                         size_t *server_hello_len,
                         int socket_fd)
 {
-  int num_bytes = -1;
   int ret = -1;
 
   kmyth_log(LOG_DEBUG, "Sending enclave's 'Client Hello' message to remote");

--- a/sgx/untrusted/src/util/msg_util.c
+++ b/sgx/untrusted/src/util/msg_util.c
@@ -16,7 +16,7 @@ int recv_ecdh_msg(int socket_fd, unsigned char **buf, size_t *len)
   struct ECDHMessageHeader header;
 
   secure_memset(&header, 0, sizeof(header));
-  ssize_t bytes_read = read(socket_fd, &header, sizeof(header));
+  size_t bytes_read = read(socket_fd, &header, sizeof(header));
   if (bytes_read == 0)
   {
     kmyth_log(LOG_ERR, "ECDH connection is closed");
@@ -74,7 +74,7 @@ int send_ecdh_msg(int socket_fd, unsigned char *buf, size_t len)
   secure_memset(&header, 0, sizeof(header));
   header.msg_size = htons(len);
 
-  ssize_t bytes_sent = write(socket_fd, &header, sizeof(header));
+  size_t bytes_sent = write(socket_fd, &header, sizeof(header));
 
   if (bytes_sent != sizeof(header))
   {


### PR DESCRIPTION
These are minor changes to remove compile flag warnings when building pelz.