### PR TITLE
Corrected 'retrieve key' demo KMIP request/response exchange between proxy and demo server

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -322,6 +322,6 @@
 /**
  * @brief kmyth-getkey receive buffer size (in bytes)
  */
-#define KMYTH_GETKEY_RX_BUFFER_SIZE 256
+#define KMYTH_GETKEY_RX_BUFFER_SIZE 16384
 
 #endif // DEFINES_H

--- a/include/network/tls_util.h
+++ b/include/network/tls_util.h
@@ -95,21 +95,23 @@ int tls_cleanup(void);
  * @param[in]  bio             OpenSSL BIO structure with the connection
  *                             already instantiated
  *
- * @param[in]  message         optional message to send the server, can be null
+ * @param[in]  req             optional message to send the server, can be null
  *
- * @param[in]  message_length  length of the message (0 if no message is given)
+ * @param[in]  req_size        length of the message (0 if no message is given)
  *
- * @param[out] key             return message from server, expected to be a key
+ * @param[out] resp            return message from server, expected to be a key
  *
- * @param[out] key_size        size of the returned message
+ * @param[out] resp_size       size of the returned message
  *
  * @param[in]  verbose         if true, extra debug messages displayed
  * 
  * @return 0 if success, 1 if error
  */
-int get_key_from_tls_server(BIO * bio,
-                            char *message, size_t message_length,
-                            unsigned char **key, size_t * key_size);
+int get_resp_from_tls_server(BIO * bio,
+                             char *req,
+                             size_t req_size,
+                             unsigned char **resp,
+                             size_t * resp_size);
 
 /**
  * <pre>

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -192,6 +192,7 @@ Common_Enclave_Include_Paths += -I/usr/local/include
 Common_Enclave_Include_Paths += -I../include
 Common_Enclave_Include_Paths += -I../include/cipher
 Common_Enclave_Include_Paths += -I../include/protocol
+Common_Enclave_include_paths += -I../include/network
 Common_Enclave_Include_Paths += -I../utils/include/kmyth
 
 Test_Enclave_Include_Paths := $(Common_Enclave_Include_Paths)

--- a/sgx/demo/include/node/tls_proxy.h
+++ b/sgx/demo/include/node/tls_proxy.h
@@ -14,6 +14,7 @@
 
 #include "demo_ecdh_util.h"
 #include "demo_tls_util.h"
+#include "tls_util.h"
 
 /**
  * @brief This struct consolidates complete (overall) state information

--- a/src/main/getkey.c
+++ b/src/main/getkey.c
@@ -310,9 +310,9 @@ int main(int argc, char **argv)
   else
   {
     // The "simple" key server is the default.
-    server_result = get_key_from_tls_server(bio,
-                                            message, message_length,
-                                            &key, &key_size);
+    server_result = get_resp_from_tls_server(bio,
+                                             message, message_length,
+                                             &key, &key_size);
   }
 
   if (server_result)

--- a/src/network/tls_util.c
+++ b/src/network/tls_util.c
@@ -434,7 +434,7 @@ int get_resp_from_tls_server(BIO * bio,
   {
     kmyth_log(LOG_ERR, "receive buffer full (%d bytes) ... exiting", recv);
     free(buf);
-    return 1;t s
+    return 1;
   }
 
   *resp_size = recv;

--- a/src/network/tls_util.c
+++ b/src/network/tls_util.c
@@ -434,7 +434,7 @@ int get_resp_from_tls_server(BIO * bio,
   {
     kmyth_log(LOG_ERR, "receive buffer full (%d bytes) ... exiting", recv);
     free(buf);
-    return 1;
+    return 1;t s
   }
 
   *resp_size = recv;

--- a/test/include/network/tls_util_test.h
+++ b/test/include/network/tls_util_test.h
@@ -37,7 +37,7 @@ void test_tls_set_context(void);
 /**
  * Tests for getting a key from a TLS server in get_key_from_tls_server()
  */
-void test_get_key_from_tls_server(void);
+void test_get_resp_from_tls_server(void);
 
 /**
  * Tests for getting a key from a KMIP server in get_key_from_kmip_server()

--- a/test/src/network/tls_util_test.c
+++ b/test/src/network/tls_util_test.c
@@ -29,8 +29,8 @@ int tls_util_add_tests(CU_pSuite suite)
     return 1;
   }
 
-  if (NULL == CU_add_test(suite, "get_key_from_tls_server() Tests",
-                          test_get_key_from_tls_server))
+  if (NULL == CU_add_test(suite, "get_resp_from_tls_server() Tests",
+                          test_get_resp_from_tls_server))
   {
     return 1;
   }
@@ -132,9 +132,9 @@ void test_tls_set_context(void)
 }
 
 //----------------------------------------------------------------------------
-// test_get_key_from_tls_server()
+// test_get_resp_from_tls_server()
 //----------------------------------------------------------------------------
-void test_get_key_from_tls_server(void)
+void test_get_resp_from_tls_server(void)
 {
   BIO *bio = BIO_new(BIO_s_mem());
   char *message = "1";
@@ -143,8 +143,8 @@ void test_get_key_from_tls_server(void)
   size_t key_size = 0;
 
   // A null BIO should produce an error
-  CU_ASSERT(get_key_from_tls_server((BIO *) NULL,
-                                    message, message_length, &key, &key_size));
+  CU_ASSERT(get_resp_from_tls_server((BIO *) NULL,
+                                     message, message_length, &key, &key_size));
 
   // Cleanup
   BIO_free_all(bio);


### PR DESCRIPTION
In the 'retrieve key' demo proxy and demo-server code, prior to sending KMIP requests (from the proxy to the demo-server) and KMIP responses (returned from the demo-server to the proxy). a two-byte length value was sent to facilitate allocating a properly sized receive buffer. This approach, however, is not consistent with a true KMIP server, however. This pull request modifies the code to exchange the KMIP requests and responses only and unmodified, in an attempt to be compliant with an actual KMIP server.

This pull request renames the `get_key_from_tls_server()` function to a more generic `get_resp_from_tls_server()` and re-uses that code in the proxy's `proxy_get_kmip_response()` function. The KMYTH_GETKEY_RX_BUFFER_SIZE  constant was increased to 16384 and a check to error if this buffer is ever completely filled was added.