### PR TITLE
Fixed empty file creation when -g option is passed to kmyth-seal (#172)

### DIFF
--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -388,13 +388,17 @@ int main(int argc, char **argv)
   kmyth_clear(authString, auth_string_len);
   kmyth_clear(ownerAuthPasswd, oa_passwd_len);
 
-  if (write_bytes_to_file(outPath, output, output_length))
+  // only create output file if -g option is NOT passed
+  if (bool_trial_only == 0)
   {
-    kmyth_log(LOG_ERR, "error writing data to .ski file ... exiting");
-    free(outPath);
-    free(output);
-    free(pcrs);
-    return 1;
+    if (write_bytes_to_file(outPath, output, output_length))
+    {
+      kmyth_log(LOG_ERR, "error writing data to .ski file ... exiting");
+      free(outPath);
+      free(output);
+      free(pcrs);
+      return 1;
+    }
   }
 
   free(pcrs);


### PR DESCRIPTION
The change is pretty simple and self-explanatory. Issue #172 seems to happen because of `write_bytes_to_file` being called regardless of `bool_trial_only`. So I've added a simple guard before it.

Tested it and it seems like the code addition indeed fixes the empty file creation.