### PR TITLE
Bugfix/warning messages with g option

### DIFF
--- a/include/kmyth.h
+++ b/include/kmyth.h
@@ -9,6 +9,7 @@
 #define KMYTH_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -56,6 +57,10 @@ extern "C"
  *                               policy digest to be used for authorizing
  *                               actions
  *
+ * @param[in]  bool_trail_only   Option indicating kmyth should only compute
+ *                               and display the PolicyPCR digest associated
+ *                               with the current value of the PCR registers.
+ *                               No actual sealed data is needed.
  *
  * @return 0 on success, 1 on error
  */
@@ -64,7 +69,7 @@ extern "C"
                       uint8_t * auth_bytes, size_t auth_bytes_len,
                       uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                       int *pcrs, size_t pcrs_len, char *cipher_string,
-                      char *expected_policy, uint8_t bool_trial_only);
+                      char *expected_policy, bool bool_trial_only);
 
 /**
  * @brief High-level function implementing kmyth-unseal using TPM 2.0.
@@ -139,6 +144,11 @@ extern "C"
  *                               policy digest to be used for authorizing
  *                               actions
  *
+ * @param[in]  bool_trail_only   Option indicating kmyth should only compute
+ *                               and display the PolicyPCR digest associated
+ *                               with the current value of the PCR registers.
+ *                               No actual sealed data is needed.
+ *
  * @return 0 on success, 1 on error
  */
   int tpm2_kmyth_seal_file(char *input_path,
@@ -146,7 +156,7 @@ extern "C"
                            uint8_t * auth_bytes, size_t auth_bytes_len,
                            uint8_t * owner_auth_bytes, size_t oa_bytes_len,
                            int *pcrs, size_t pcrs_len, char *cipher_string,
-                           char *expected_policy, uint8_t bool_trial_only);
+                           char *expected_policy, bool bool_trial_only);
 
 /**
  * @brief High-level function implementing kmyth-unseal for files using TPM 2.0.

--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -269,9 +269,9 @@ int main(int argc, char **argv)
   // Some options don't do anything with -g, so warn about that now.
   if(boolTrialOnly)
   {
-    if(outPath != NULL || forceOverwrite || expected_policy != NULL)
+    if(outPath != NULL || inPath != NULL || cipherString != NULL || forceOverwrite || expected_policy != NULL)
     {
-      kmyth_log(LOG_WARNING, "-i, -o, -f, and -e have no effect when combined with -g");
+      kmyth_log(LOG_WARNING, "-i, -o, -c,-f, and -e have no effect when combined with -g");
     }
   }
   //Since these originate in main() we know they are null terminated

--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
     (ownerAuthPasswd == NULL) ? 0 : strlen(ownerAuthPasswd);
 
   // Check that input path (file to be sealed) was specified
-  if (inPath == NULL)
+  if (inPath == NULL && !boolTrialOnly)
   {
     kmyth_log(LOG_ERR, "no input (file to be sealed) specified ... exiting");
     if (authString != NULL)

--- a/src/tpm/kmyth_seal_unseal_impl.c
+++ b/src/tpm/kmyth_seal_unseal_impl.c
@@ -533,31 +533,38 @@ int tpm2_kmyth_seal_file(char *input_path,
                          int *pcrs, size_t pcrs_len, char *cipher_string,
                          char *expected_policy, bool bool_trial_only)
 {
-
-  // Verify input path exists with read permissions
-  if (verifyInputFilePath(input_path))
-  {
-    kmyth_log(LOG_ERR, "input path (%s) is not valid ... exiting", input_path);
-    return 1;
-  }
-
-  uint8_t *data = NULL;
+  uint8_t* data = NULL;
   size_t data_len = 0;
-
-  if (read_bytes_from_file(input_path, &data, &data_len))
+  
+  // Only validate the input if we're not just checking the current
+  // PCR values.
+  if(!bool_trial_only)
   {
-    kmyth_log(LOG_ERR, "seal input data file read error ... exiting");
-    if (data != NULL) free(data);
-    return 1;
-  }
-  kmyth_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_len);
+    // Verify input path exists with read permissions
+    if (verifyInputFilePath(input_path))
+    {
+      kmyth_log(LOG_ERR, "input path (%s) is not valid ... exiting", input_path);
+      return 1;
+    }
 
-  // validate non-empty plaintext buffer specified
-  if (data_len == 0 || data == NULL)
-  {
-    kmyth_log(LOG_ERR, "no input data ... exiting");
-    if (data != NULL) free(data);
-    return 1;
+    if (read_bytes_from_file(input_path, &data, &data_len))
+    {
+      kmyth_log(LOG_ERR, "seal input data file read error ... exiting");
+      if (data != NULL)
+      {
+	free(data);
+      }
+      return 1;
+    }
+    kmyth_log(LOG_DEBUG, "read in %d bytes of data to be wrapped", data_len);
+
+    // validate non-empty plaintext buffer specified
+    if (data_len == 0 || data == NULL)
+    {
+      kmyth_log(LOG_ERR, "no input data ... exiting");
+      if (data != NULL) free(data);
+      return 1;
+    }
   }
 
   if (tpm2_kmyth_seal(data, data_len,
@@ -568,10 +575,16 @@ int tpm2_kmyth_seal_file(char *input_path,
                       bool_trial_only))
   {
     kmyth_log(LOG_ERR, "Failed to kmyth-seal data ... exiting");
-    if (data != NULL) free(data);
+    if (data != NULL)
+    {
+      free(data);
+    }
     return (1);
   }
-  if (data != NULL) free(data);
+  if (data != NULL)
+  {
+    free(data);
+  }
   return 0;
 }
 

--- a/src/tpm/kmyth_seal_unseal_impl.c
+++ b/src/tpm/kmyth_seal_unseal_impl.c
@@ -41,7 +41,7 @@ int tpm2_kmyth_seal(uint8_t * input,
                     uint8_t * owner_auth_bytes,
                     size_t oa_bytes_len, int *pcrs, size_t pcrs_len,
                     char *cipher_string, char *expected_policy,
-                    uint8_t bool_trial_only)
+                    bool bool_trial_only)
 {
   if(oa_bytes_len > UINT16_MAX)
   {
@@ -160,7 +160,7 @@ int tpm2_kmyth_seal(uint8_t * input,
 
   // optional argument allowing user to receive a hex dump of the policy digest,
   // to be used to calculate a second policy for policyOR authorization
-  if (bool_trial_only == 1)
+  if (bool_trial_only == true)
   {
     // size of string is 2x chars for the size of the TPM2B_DIGEST buffer + 4
     // for TPM2B struct which encodes size in memory + 1 byte for null termination.
@@ -531,7 +531,7 @@ int tpm2_kmyth_seal_file(char *input_path,
                          uint8_t * owner_auth_bytes,
                          size_t oa_bytes_len,
                          int *pcrs, size_t pcrs_len, char *cipher_string,
-                         char *expected_policy, uint8_t bool_trial_only)
+                         char *expected_policy, bool bool_trial_only)
 {
 
   // Verify input path exists with read permissions


### PR DESCRIPTION
This removes the warnings that used to appear if you used ```-g``` without an output file. It also makes it possible to use ```-g``` without an input file.