### PR TITLE
Updated kmyth-reseal

### DIFF
--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -133,8 +133,8 @@ static void usage(const char *prog)
           " -i or --input           Path to file containing the data to be sealed.\n"
           " -o or --output          Destination path for the sealed file. Defaults to <filename>.ski in the CWD.\n"
           " -f or --force           Force the overwrite of an existing .ski file when using default output.\n"
-          " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
-          "                         Defaults to no PCRs specified. Encapsulate in quotes (e.g. \"0, 1, 2\").\n"
+//          " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
+//          "                         Defaults to no PCRs specified. Encapsulate in quotes (e.g. \"0, 1, 2\").\n"
           " -c or --cipher          Specifies the cipher type to use. Defaults to \'%s\'\n"
           " -e or --expected_policy Specifies an alternative digest value that can satisfy the authorization policy. \n"
           " -l or --list_ciphers    Lists all valid ciphers and exits.\n"
@@ -167,7 +167,7 @@ const struct option longopts[] = {
   {"input", required_argument, 0, 'i'},
   {"output", required_argument, 0, 'o'},
   {"force", no_argument, 0, 'f'},
-  {"pcrs_list", required_argument, 0, 'p'},
+ // {"pcrs_list", required_argument, 0, 'p'},
   {"owner_auth", required_argument, 0, 'w'},
   {"cipher", required_argument, 0, 'c'},
   {"expected_policy", required_argument, 0, 'e'},
@@ -242,8 +242,8 @@ int main(int argc, char **argv)
     case 'e':
       expected_policy = optarg;
       break;
-    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
-      pcrsString = optarg;
+//    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
+//      pcrsString = optarg;
       break;
     case 'w':
       ownerAuthPasswd = optarg;
@@ -382,15 +382,14 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  // Call top-level "kmyth-reseal" function
-  // disable the -g option that is run by default
+  // Call top-level "kmyth-seal" function
   if (tpm2_kmyth_seal_file(inPath, &output, &output_length,
                            (uint8_t *) authString, auth_string_len,
                            (uint8_t *) ownerAuthPasswd, oa_passwd_len,
                            pcrs, (size_t)pcrs_len, cipherString, expected_policy,
                            bool_trial_only))
   {
-    kmyth_log(LOG_ERR, "kmyth-reseal error ... exiting");
+    kmyth_log(LOG_ERR, "kmyth-seal error ... exiting");
     kmyth_clear(authString, auth_string_len);
     kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     free(pcrs);

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -196,7 +196,6 @@ int main(int argc, char **argv)
   // Initialize parameters that might be modified by command line options
   char *inPath = NULL;
   char *outPath = NULL;
-  size_t outPath_size = 0;
   char *authString = NULL;
   char *ownerAuthPasswd = "";
   char *pcrsString = NULL;
@@ -226,15 +225,7 @@ int main(int argc, char **argv)
       inPath = optarg;
       break;
     case 'o':
-      // make outPath a copy of the argument for consistency with case
-      // where we assign a default outPath value - always allocate memory
-      // so we can always free it
-      outPath_size = strlen(optarg) + 1;
-      if (outPath_size > 1)
-      {
-        outPath = malloc(outPath_size * sizeof(char));
-        memcpy(outPath, optarg, outPath_size);
-      }
+      outPath = optarg;
       break;
     case 'f':
       forceOverwrite = true;
@@ -349,7 +340,7 @@ int main(int argc, char **argv)
   uint8_t *unseal_output = NULL;
   size_t unseal_output_len = 0;
 
- // Call top-level "kmyth-unseal" function
+// Call top-level "kmyth-unseal" function
   if (tpm2_kmyth_unseal_file(inPath, &unseal_output, &unseal_output_len,
                              (uint8_t *) authString, auth_string_len,
                              (uint8_t *) ownerAuthPasswd, oa_passwd_len,
@@ -366,7 +357,7 @@ int main(int argc, char **argv)
   uint8_t *seal_output = NULL;
   size_t seal_output_len = 0;
 
-  // Call top-level "kmyth-seal" function
+// Call top-level "kmyth-seal" function
 if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output_len,
                       (uint8_t *) authString,
                       auth_string_len,
@@ -391,7 +382,7 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
   kmyth_clear(authString, auth_string_len);
   kmyth_clear(ownerAuthPasswd, oa_passwd_len);
 
-   // rename input file to <input filename>.orig to preserve it
+  // rename input file to <input filename>.orig to preserve it
   char * renamePath = malloc(strlen(inPath) + strlen(".orig") + 1);
   strncpy(renamePath, inPath, strlen(inPath));
   strncat(renamePath, ".orig", 5);

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -388,11 +388,11 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
   strncat(renamePath, ".orig", 5);
   if (!stat(renamePath, &st) && !forceOverwrite)
   {
+    kmyth_log(LOG_ERR,
+          "output filename (%s) already exists ... exiting",
+          renamePath);
     free(seal_output);
     free(renamePath);
-    kmyth_log(LOG_ERR,
-              "output filename (%s) already exists ... exiting",
-              renamePath);
     return 1;
   }
   

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -283,6 +283,19 @@ int main(int argc, char **argv)
     return 1;
   }
 
+  // Check that the -e 'expected policy' was specified
+  if (expected_policy == NULL)
+  {
+    kmyth_log(LOG_ERR, "no expected policy specified ... exiting");
+    if (authString != NULL)
+    {
+      kmyth_clear(authString, auth_string_len);
+    }
+    kmyth_clear(ownerAuthPasswd, oa_passwd_len);
+    free(outPath);
+    return 1;
+  }
+
   // If output file not specified, set output path to basename(inPath) with
   // a .ski extension in the directory that the application is being run from.
   if (outPath == NULL)

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -131,7 +131,7 @@ static void usage(const char *prog)
           "options are: \n\n"
           " -a or --auth_string     String used to create 'authVal' digest. Defaults to empty string (all-zero digest).\n"
           " -i or --input           Path to file containing the data to be sealed.\n"
-          " -o or --output          Destination path for the sealed file. Defaults to <filename>.ski in the CWD.\n"
+          " -o or --output          Destination path for the temporary unsealed file. Defaults to <filename>.txt in the CWD.\n"
           " -f or --force           Force the overwrite of an existing .ski file when using default output.\n"
           " -s or --stdout          Output unencrypted result to stdout instead of file.\n" // possibly remove later
           " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
@@ -240,13 +240,13 @@ int main(int argc, char **argv)
     case 'f':
       forceOverwrite = true;
       break;
-    //case 'g':       ********** 
+    //case 'g':
     //  bool_trial_only = 1;
     //  break;
     case 'e':
       expected_policy = optarg;
       break;
-    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
+    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file.
       pcrsString = optarg;
       bool_policy_or = 1;
       break;
@@ -433,21 +433,17 @@ int main(int argc, char **argv)
 
 
 
-////////////////////////
+// swaps the inPath and outPath before calling seal
 char *tempIn = outPath;
 char *tempOut = inPath;
 
-// always allocate memory
-// so we can always free it
+// allocates the updated outPath_size memory after the swap
 outPath_size = strlen(tempOut) + 1;
 if (outPath_size > 1)
 {
   tempOut = malloc(outPath_size * sizeof(char));
   memcpy(tempOut, inPath, outPath_size);
 }
- /////////////////// 
-
-
 
   // Call top-level "kmyth-seal" function
   if (tpm2_kmyth_seal_file(tempIn, &output, &output_length,

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -383,13 +383,12 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
     kmyth_clear(ownerAuthPasswd, oa_passwd_len);
     kmyth_clear_and_free(unseal_output, unseal_output_len);
     free(pcrs);
-    free(unseal_output);
     return 1;
   }
 
+  kmyth_clear_and_free(unseal_output, unseal_output_len);
   kmyth_clear(authString, auth_string_len);
   kmyth_clear(ownerAuthPasswd, oa_passwd_len);
-
 
    // rename input file to <input filename>.orig to preserve it
   char * renamePath = malloc(strlen(inPath) + strlen(".orig") + 1);
@@ -417,8 +416,7 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
     free(seal_output);
   }
 
-  kmyth_clear_and_free(unseal_output, unseal_output_len);
-  free(seal_output);
+  kmyth_clear_and_free(seal_output, seal_output_len);
 
   return 0;
 }

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -135,6 +135,7 @@ static void usage(const char *prog)
           " -f or --force           Force the overwrite of an existing .ski file when using default output.\n"
           " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
           "                         Defaults to no PCRs specified. Encapsulate in quotes (e.g. \"0, 1, 2\").\n"
+          " -g                      Used when resealing a file that already contains a policy OR\n" // may change later
           " -c or --cipher          Specifies the cipher type to use. Defaults to \'%s\'\n"
           " -e or --expected_policy Specifies an alternative digest value that can satisfy the authorization policy. \n"
           " -l or --list_ciphers    Lists all valid ciphers and exits.\n"
@@ -167,6 +168,7 @@ const struct option longopts[] = {
   {"input", required_argument, 0, 'i'},
   {"output", required_argument, 0, 'o'},
   {"force", no_argument, 0, 'f'},
+  {"previous_policy_or", no_argument, 0, 'g'},
   {"pcrs_list", required_argument, 0, 'p'},
   {"owner_auth", required_argument, 0, 'w'},
   {"cipher", required_argument, 0, 'c'},
@@ -210,7 +212,7 @@ int main(int argc, char **argv)
   int option_index;
 
   while ((options =
-          getopt_long(argc, argv, "a:e:i:o:c:p:w:fhlv", longopts,
+          getopt_long(argc, argv, "a:e:g:i:o:c:p:w:fhlv", longopts,
                       &option_index)) != -1)
   {
     switch (options)
@@ -238,15 +240,16 @@ int main(int argc, char **argv)
     case 'f':
       forceOverwrite = true;
       break;
-    //case 'g':
-    //  bool_trial_only = 1;
-    //  break;
+    case 'g': // used when resealing a .ski file with policy OR
+      //bool_trial_only = 1;
+      bool_policy_or = 1;
+      break;
     case 'e':
       expected_policy = optarg;
       break;
     case 'p': // cut this option. always use the set of pcrs that are specified in the ski file.
       pcrsString = optarg;
-      bool_policy_or = 1;
+      //bool_policy_or = 1;
       break;
     case 'w':
       ownerAuthPasswd = optarg;
@@ -407,11 +410,11 @@ int main(int argc, char **argv)
 
   // rename the input file **** This is temporary. Needs to be changed slightly
   int worked;
-  char *newFileName = "orginalFile.ski";
+  char *newFileName = "originalFile.ski";
   worked = rename(inPath, newFileName);
   // error checking for the rename
   if (worked == 0){
-    kmyth_log(LOG_ERR, "Input file renamed succesfully");
+    kmyth_log(LOG_DEBUG, "Input file renamed succesfully");
   }
   else{
     kmyth_log(LOG_ERR, "Failed to rename the input file.. exiting..");

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -236,13 +236,13 @@ int main(int argc, char **argv)
     case 'f':
       forceOverwrite = true;
       break;
-    //case 'g':
+    //case 'g':       ********** 
     //  bool_trial_only = 1;
     //  break;
     case 'e':
       expected_policy = optarg;
       break;
-    case 'p':
+    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
       pcrsString = optarg;
       break;
     case 'w':
@@ -383,6 +383,7 @@ int main(int argc, char **argv)
   }
 
   // Call top-level "kmyth-reseal" function
+  // disable the -g option that is run by default
   if (tpm2_kmyth_seal_file(inPath, &output, &output_length,
                            (uint8_t *) authString, auth_string_len,
                            (uint8_t *) ownerAuthPasswd, oa_passwd_len,

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -133,8 +133,8 @@ static void usage(const char *prog)
           " -i or --input           Path to file containing the data to be sealed.\n"
           " -o or --output          Destination path for the sealed file. Defaults to <filename>.ski in the CWD.\n"
           " -f or --force           Force the overwrite of an existing .ski file when using default output.\n"
-//          " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
-//          "                         Defaults to no PCRs specified. Encapsulate in quotes (e.g. \"0, 1, 2\").\n"
+          " -p or --pcrs_list       List of TPM platform configuration registers (PCRs) to apply to authorization policy.\n"
+          "                         Defaults to no PCRs specified. Encapsulate in quotes (e.g. \"0, 1, 2\").\n"
           " -c or --cipher          Specifies the cipher type to use. Defaults to \'%s\'\n"
           " -e or --expected_policy Specifies an alternative digest value that can satisfy the authorization policy. \n"
           " -l or --list_ciphers    Lists all valid ciphers and exits.\n"
@@ -167,7 +167,7 @@ const struct option longopts[] = {
   {"input", required_argument, 0, 'i'},
   {"output", required_argument, 0, 'o'},
   {"force", no_argument, 0, 'f'},
- // {"pcrs_list", required_argument, 0, 'p'},
+  {"pcrs_list", required_argument, 0, 'p'},
   {"owner_auth", required_argument, 0, 'w'},
   {"cipher", required_argument, 0, 'c'},
   {"expected_policy", required_argument, 0, 'e'},
@@ -242,8 +242,8 @@ int main(int argc, char **argv)
     case 'e':
       expected_policy = optarg;
       break;
-//    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
-//      pcrsString = optarg;
+    case 'p': // cut this option. always use the set of pcrs that are specified in the ski file. *****************************************
+    pcrsString = optarg;
       break;
     case 'w':
       ownerAuthPasswd = optarg;


### PR DESCRIPTION
Reseal now unseals a .ski file, seals the unsealed file, and then deletes the unsealed file. '-o' output now defaults to a .txt file