### PR TITLE
Bugfix/string handling warnings

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -66,7 +66,7 @@
  *        if too long). This maximum does not apply to user-specified
  *        filename values.
  */
-#define KMYTH_MAX_DEFAULT_FILENAME_LEN 25
+#define KMYTH_MAX_DEFAULT_FILENAME_LEN 64
 
 /**
  * @brief Default extension value/length for an output kmyth file produced

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -383,9 +383,10 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
   kmyth_clear(ownerAuthPasswd, oa_passwd_len);
 
   // rename input file to <input filename>.orig to preserve it
-  char * renamePath = malloc(strlen(inPath) + strlen(".orig") + 1);
+  size_t renamePath_len = strlen(inPath) + strlen(".orig") + 1;
+  char * renamePath = malloc(renamePath_len);
   strncpy(renamePath, inPath, strlen(inPath));
-  strncat(renamePath, ".orig", 5);
+  strncat(renamePath, ".orig", renamePath_len);
   if (!stat(renamePath, &st) && !forceOverwrite)
   {
     kmyth_log(LOG_ERR,

--- a/src/main/reseal.c
+++ b/src/main/reseal.c
@@ -383,10 +383,9 @@ if (tpm2_kmyth_seal(unseal_output, unseal_output_len, &seal_output, &seal_output
   kmyth_clear(ownerAuthPasswd, oa_passwd_len);
 
   // rename input file to <input filename>.orig to preserve it
-  size_t renamePath_len = strlen(inPath) + strlen(".orig") + 1;
-  char * renamePath = malloc(renamePath_len);
-  strncpy(renamePath, inPath, strlen(inPath));
-  strncat(renamePath, ".orig", renamePath_len);
+  char * renamePath = malloc(strlen(inPath) + strlen(".orig") + 1);
+  strncpy(renamePath, inPath, strlen(inPath) + 1);
+  strncat(renamePath, ".orig", strlen(".orig") + 1);
   if (!stat(renamePath, &st) && !forceOverwrite)
   {
     kmyth_log(LOG_ERR,

--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -303,20 +303,15 @@ int main(int argc, char **argv)
   if (outPath == NULL && !boolTrialOnly)
   {
     // create buffer to hold default filename derived from input filename
-    //    size = string length of basename +
-    //           string length of delimiter ('.') +
-    //           string length of file extension +
-    //           extra byte for null terminator
-    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN +
-                    KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2];
+    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN];
     memset(default_fn, '\0', sizeof(default_fn));
 
     // Initialize default filename to basename() of input path, truncating if
     // necessary. The maximum size of this "root" value is the must allow space
     // to add a '.' delimiter (1 byte) and the default extension
-    // (KMYTH_DEFAULT_SEAL_OUT_EXT_LEN bytes).
+    // (KMYTH_DEFAULT_SEAL_OUT_EXT_LEN bytes), leaving a null termination.
     size_t max_root_len = KMYTH_MAX_DEFAULT_FILENAME_LEN;
-    max_root_len -= KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 1;
+    max_root_len -= KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2;
     strncpy(default_fn, basename(inPath), max_root_len);
 
     // remove any leading '.'s
@@ -339,7 +334,7 @@ int main(int argc, char **argv)
     if (ext_ptr == NULL)
     {
       // no filename extension found - just add trailing '.'
-      strncat(default_fn, ".", strlen(default_fn)+2);
+      strncat(default_fn, ".", 2);
     }
     else
     {
@@ -354,7 +349,7 @@ int main(int argc, char **argv)
     // concatenate default filename root and extension
     strncat(default_fn,
             KMYTH_DEFAULT_SEAL_OUT_EXT,
-            strlen(default_fn) + KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2);
+            KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 1);
 
     // Make sure default filename we constructed doesn't already exist
     struct stat st = { 0 };
@@ -369,7 +364,7 @@ int main(int argc, char **argv)
     }
 
     // Go ahead and make the default value the output path
-    outPath_size = strlen(default_fn);
+    outPath_size = strlen(default_fn) + 1;
     outPath = malloc(outPath_size * sizeof(char));
     memcpy(outPath, default_fn, outPath_size);
     kmyth_log(LOG_WARNING, "output file not specified, default = %s", outPath);

--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -269,7 +269,13 @@ int main(int argc, char **argv)
   // Some options don't do anything with -g, so warn about that now.
   if(boolTrialOnly)
   {
-    if(authString != NULL || ownerAuthPasswd != "" || outPath != NULL || inPath != NULL || cipherString != NULL || forceOverwrite || expected_policy != NULL)
+    if(authString != NULL ||
+       (strcmp(ownerAuthPasswd, "") != 0) ||
+       outPath != NULL ||
+       inPath != NULL ||
+       cipherString != NULL ||
+       forceOverwrite ||
+       expected_policy != NULL)
     {
       kmyth_log(LOG_WARNING, "-a, -c, -e, -f, -i, -o, and -w have no effect when combined with -g");
     }
@@ -297,7 +303,12 @@ int main(int argc, char **argv)
   if (outPath == NULL && !boolTrialOnly)
   {
     // create buffer to hold default filename derived from input filename
-    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN + 1];
+    //    size = string length of basename +
+    //           string length of delimiter ('.') +
+    //           string length of file extension +
+    //           extra byte for null terminator
+    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN +
+                    KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2];
     memset(default_fn, '\0', sizeof(default_fn));
 
     // Initialize default filename to basename() of input path, truncating if
@@ -328,7 +339,7 @@ int main(int argc, char **argv)
     if (ext_ptr == NULL)
     {
       // no filename extension found - just add trailing '.'
-      strncat(default_fn, ".", 1);
+      strncat(default_fn, ".", strlen(default_fn)+2);
     }
     else
     {
@@ -341,8 +352,9 @@ int main(int argc, char **argv)
     }
 
     // concatenate default filename root and extension
-    strncat(default_fn, KMYTH_DEFAULT_SEAL_OUT_EXT,
-                        KMYTH_DEFAULT_SEAL_OUT_EXT_LEN);
+    strncat(default_fn,
+            KMYTH_DEFAULT_SEAL_OUT_EXT,
+            strlen(default_fn) + KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2);
 
     // Make sure default filename we constructed doesn't already exist
     struct stat st = { 0 };

--- a/src/main/seal.c
+++ b/src/main/seal.c
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
   if (outPath == NULL && !boolTrialOnly)
   {
     // create buffer to hold default filename derived from input filename
-    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN];
+    char default_fn[KMYTH_MAX_DEFAULT_FILENAME_LEN + 1];
     memset(default_fn, '\0', sizeof(default_fn));
 
     // Initialize default filename to basename() of input path, truncating if
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
     // to add a '.' delimiter (1 byte) and the default extension
     // (KMYTH_DEFAULT_SEAL_OUT_EXT_LEN bytes), leaving a null termination.
     size_t max_root_len = KMYTH_MAX_DEFAULT_FILENAME_LEN;
-    max_root_len -= KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 2;
+    max_root_len -= KMYTH_DEFAULT_SEAL_OUT_EXT_LEN + 1;
     strncpy(default_fn, basename(inPath), max_root_len);
 
     // remove any leading '.'s


### PR DESCRIPTION
This pull request addresses compiler warnings that highlighted incorrect string handling:

- In a couple cases, the strncat() function was passed a bound that was the length of the source string being appended to the destination string. As this is essentially the behavior of strcat(), the strncat() calls could have been changed to strcat() calls to address the compiler warnings. In this pull request, however, the choice was made to instead increase the bound to to make the copied source string null terminated.

- The maximum default filename length was only 25 characters. This pull request increases the maximum length to 64.
- An incorrect string comparison was fixed.
- An extra byte was allocated for `outPath_size` to include space for null termination