### PR TITLE
Remove kmyth.h from Makefile 'install' and 'uninstall' targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,8 +595,6 @@ endif
 ifeq ($(wildcard $(TPM_LIB_LOCAL_DEST)), $(TPM_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 755 $(TPM_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth
-	install -m 644 $(INC_DIR)/kmyth.h $(DESTDIR)$(PREFIX)/include/kmyth/
 	ldconfig
 endif
 ifeq ($(wildcard $(BIN_DIR)/kmyth-seal), $(BIN_DIR)/kmyth-seal)
@@ -617,7 +615,6 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(UTILS_LIB_SONAME)
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(TPM_LIB_SONAME)
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(LOGGER_LIB_SONAME)
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/file_io.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/formatting_tools.h


### PR DESCRIPTION
In pull request #187 (Refactor PCR-based policy-OR functionality) - commit 339d7f3, the header file kmyth.h was removed, but the Makefile was not updated to completely reflect this change. This broke the `make install` build target.

This pull request simply removes the installation of the kmyth.h header file so that the `make install` target no longer errors because it can't find the file it is trying to install and deletes the step deleting this file as part of the `make uninstall` target.