### PR TITLE
updated parse_exp_policy_string_pairs() and its tests

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -92,8 +92,12 @@
  * specified (limited to eight by the TPML_DIGEST struct).
  */
 #define MAX_POLICY_OR_CNT 8
-
-#define MAX_EXP_POLICY_PAIR_STR_LEN 1152
+#define MAX_POLICY_DIGEST_STR_LEN 128  // 2 chars/byte, 512-bit (64-byte) hash
+#define MAX_POLICY_PCR_SEL_STR_LEN 120
+#define MAX_EXP_POLICY_DELIM_STR_LEN 8
+#define MAX_EXP_POLICY_PAIR_STR_LEN MAX_POLICY_DIGEST_STR_LEN + \
+                                    MAX_EXP_POLICY_DELIM_STR_LEN + \
+                                    MAX_POLICY_PCR_SEL_STR_LEN
 
 /**
  * In TPM 2.0, the size value for a key or data value (unique parameter)

--- a/include/defines.h
+++ b/include/defines.h
@@ -92,12 +92,32 @@
  * specified (limited to eight by the TPML_DIGEST struct).
  */
 #define MAX_POLICY_OR_CNT 8
-#define MAX_POLICY_DIGEST_STR_LEN 128  // 2 chars/byte, 512-bit (64-byte) hash
+
+/**
+ * These constants provide size limits on an "expected policy" string used to
+ * specify a single policy-OR criterion. They support checks on 1) the length
+ * of a single policy-OR criterion entered by the user as part of the raw
+ * input string used to specify the "-e" ("--expected_policy") command line
+ * option and 2) the length of the parsed, trimmed hex string specifing the
+ * digest (hash) value portion of the policy-OR criterion.
+ *   - The 'PCR selection string length limit is not directly enforced, but is
+ *     used as a factor in computing an overall "expected policy" string limit.
+ *   - The 'delimiter' string length is also not directly enforced, but is also
+ *     used as a factor in computing an overall "expected policy" string limit.
+ *   - For the digest string, the user may include a prefix ('0x') and/or
+ *     trailing/leading whitespace when entering a value on the command line.
+ *     While the maximum specified here does not account for these bytes,
+ *     whitespace allowances for the 'PCR selection' and delimiter strings can
+ *     be applied with a corresponding reduction in whitespace allowances
+ *     for the 'PCR Selection' and/or delimiter string elements.
+ */
+#define MAX_POLICY_DIGEST_SIZE TPM2_SHA512_DIGEST_SIZE
+#define MAX_POLICY_DIGEST_STR_LEN (2 * MAX_POLICY_DIGEST_SIZE)
 #define MAX_POLICY_PCR_SEL_STR_LEN 120
 #define MAX_EXP_POLICY_DELIM_STR_LEN 8
-#define MAX_EXP_POLICY_PAIR_STR_LEN MAX_POLICY_DIGEST_STR_LEN + \
-                                    MAX_EXP_POLICY_DELIM_STR_LEN + \
-                                    MAX_POLICY_PCR_SEL_STR_LEN
+#define MAX_EXP_POLICY_PAIR_STR_LEN (MAX_POLICY_DIGEST_STR_LEN + \
+                                     MAX_EXP_POLICY_DELIM_STR_LEN + \
+                                     MAX_POLICY_PCR_SEL_STR_LEN)
 
 /**
  * In TPM 2.0, the size value for a key or data value (unique parameter)

--- a/test/include/utils/formatting_tools_test.h
+++ b/test/include/utils/formatting_tools_test.h
@@ -13,6 +13,9 @@
 
 #include <tss2/tss2_sys.h>
 
+#define MAX_TEST_POLICY_PAIR_STRLEN (MAX_EXP_POLICY_PAIR_STR_LEN + 8)
+#define MAX_TEST_POLICY_STRLEN MAX_POLICY_OR_CNT * MAX_TEST_POLICY_PAIR_STRLEN
+
 /**
  * This function adds all of the tests contained in formatting_tools_test.c to a
  * test suite parameter passed in by the caller. This allows a top-level

--- a/test/include/utils/formatting_tools_test.h
+++ b/test/include/utils/formatting_tools_test.h
@@ -14,11 +14,12 @@
 #include <tss2/tss2_sys.h>
 
 #define MAX_TEST_POLICY_PAIR_STRLEN (MAX_EXP_POLICY_PAIR_STR_LEN + 8)
-#define MAX_TEST_POLICY_STRLEN MAX_POLICY_OR_CNT * MAX_TEST_POLICY_PAIR_STRLEN
+#define MAX_TEST_POLICY_STRLEN (MAX_POLICY_OR_CNT * \
+                                MAX_TEST_POLICY_PAIR_STRLEN)
 
 /**
- * This function adds all of the tests contained in formatting_tools_test.c to a
- * test suite parameter passed in by the caller. This allows a top-level
+ * This function adds all of the tests contained in formatting_tools_test.c to
+ * a test suite parameter passed in by the caller. This allows a top-level
  * 'test-runner' application to include them in the set of tests that it runs.
  *
  * @param[out] suite  CUnit test suite function that will add all the tests

--- a/utils/src/formatting_tools.c
+++ b/utils/src/formatting_tools.c
@@ -571,7 +571,7 @@ int parse_exp_policy_string_pairs(char * exp_policy_string,
   token = strtok(exp_policy_string, "/");
   while ((*pair_count < (MAX_POLICY_OR_CNT - 1)) && (token != NULL))
   {
-    if (strlen(token) >= MAX_EXP_POLICY_PAIR_STR_LEN)
+    if (strlen(token) > MAX_EXP_POLICY_PAIR_STR_LEN)
     {
       kmyth_log(LOG_ERR, "token (pair) size is %d chars (max is %u)",
                          strlen(token), MAX_EXP_POLICY_PAIR_STR_LEN);
@@ -604,7 +604,7 @@ int parse_exp_policy_string_pairs(char * exp_policy_string,
     {
       kmyth_log(LOG_ERR, "pcrs string parse error (%s)",
                          pair_vals[i]);
-      for(size_t j = 0; j < i; j++)
+      for (size_t j = 0; j < i; j++)
       {
         free(pcrs_strings[j]);
         pcrs_strings[j] = NULL;
@@ -619,7 +619,7 @@ int parse_exp_policy_string_pairs(char * exp_policy_string,
     if (pcrs_strings[i] == NULL)
     {
       kmyth_log(LOG_ERR, "malloc() of pcrs string error");
-      for(size_t j = 0; j < i; j++)
+      for (size_t j = 0; j < i; j++)
       {
         free(pcrs_strings[j]);
         pcrs_strings[j] = NULL;
@@ -696,6 +696,20 @@ int parse_exp_policy_string_pairs(char * exp_policy_string,
       idx1 += 2;
     }
     memcpy(digest_strings[i], token + idx1, idx2 - idx1);
+
+    // verify that the parsed digest string is within limits
+    if (strlen(digest_strings[i]) > MAX_POLICY_DIGEST_STR_LEN)
+    {
+      kmyth_log(LOG_ERR, "parsed expected policy digest string is too long");
+      for (size_t j = 0; j <= i; j++)
+      {
+        free(pcrs_strings[j]);
+        pcrs_strings[j] = NULL;
+        free(digest_strings[j]);
+        digest_strings[j] = NULL;
+      }
+      return 1;
+    }
 
     // check for additional (invalid) tokens
     token = strtok(NULL, ":");


### PR DESCRIPTION
Code in `test_parse_exp_policy_string_pairs()` found in test/src/utils/formatting_tools_test.c was generating potential overflow condition compiler warnings:

```
test/src/utils/formatting_tools_test.c:513:31: warning: ‘/16,23:’ directive writing 7 bytes into a region of size between 1 and 9280 [-Wformat-overflow=]
  513 |   sprintf(expPolicyString, "%s/16,23:", expPolicyString);
      |                               ^~~~~~~
test/src/utils/formatting_tools_test.c:513:3: note: ‘sprintf’ output between 8 and 9287 bytes into a destination of size 9280
  513 |   sprintf(expPolicyString, "%s/16,23:", expPolicyString);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/src/utils/formatting_tools_test.c:513:3: warning: ‘sprintf’ argument 3 overlaps destination object ‘expPolicyString’ [-Wrestrict]
test/src/utils/formatting_tools_test.c:478:8: note: destination object referenced by ‘restrict’-qualified argument 1 was declared here
  478 |   char expPolicyString[MAX_POLICY_OR_CNT * (MAX_EXP_POLICY_PAIR_STR_LEN + 8)] = { 0 }; 
```

As the issue seemed to be with an awkward sprintf() call that uses the `expPolicyString` character array as both a string input parameter and the destination buffer for the resultant string, this was modified to instead generate every test policy string independently (instead of modifying the string used in a previous test). Although probably not necessary, the test code in this function was also modified to use snprintf() to ensure truncation rather than overflow. Related to this, two string length value macros: MAX_TEST_POLICY_PAIR_STRLEN (maximum length of a test PCR selections / policy digest value pair string) and MAX_TEST_POLICY_STRLEN (maximum length of a test 'expected policy' string that may contain up to seven of the PCR selection / policy digest value pair strings) were added to support the need to repeatedly specify these lengths.

After reviewing this code and the function it tests, some additional updates are proposed:

- added the initial generation of a simple, valid expected policy string as a test case

- hopefully made the length restrictions more useful and meaningful:

> - shortened the maximum length for a PCR selection / digest value pair string from 1152 bytes to 256 bytes and attempted to specify it in in a more clearly defined manner (up to 120 characters for the PCR selection string, up to 8 characters for the delimiter string, and up to 128 characters (based on 512-bit or 64-byte maximum digest length)
>
> - changed the PCR selections / digest value pair string length comparison from '>=' to '>' to permit strings equal to the maximum length
>
> - added checks on the parsed/trimmed digest hex string length and a test case to test this new check

Note: The length checks are on the unparsed PCR selection / digest value pair input string (must be less than 256 characters)  and the parsed digest hex string with any whitespace/prefix removed. The other elements of the string (PCR selections and delimiter) are not length checked. Although macros are defined to specify these lengths, those are primarily to provide insight into how the size limit for the unparsed PCR selection / digest value pair input string.

Finally, a few whitespace/comment updates attempt to make the tests more readable.
