### PR TITLE
Fix Missing Installation of TPM Utility Headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,10 @@ endif
 ifeq ($(wildcard $(TPM_LIB_LOCAL_DEST)), $(TPM_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 755 $(TPM_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
+	install -d $(DESTDIR)$(PREFIX)/include/kmyth
+	install -m 644 $(TPM_HEADERS) \
+	               $(DESTDIR)$(PREFIX)/include/kmyth/
+	ldconfig
 	ldconfig
 endif
 ifeq ($(wildcard $(BIN_DIR)/kmyth-seal), $(BIN_DIR)/kmyth-seal)

--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,6 @@ ifeq ($(wildcard $(TPM_LIB_LOCAL_DEST)), $(TPM_LIB_LOCAL_DEST))
 	install -m 644 $(TPM_HEADERS) \
 	               $(DESTDIR)$(PREFIX)/include/kmyth/
 	ldconfig
-	ldconfig
 endif
 ifeq ($(wildcard $(BIN_DIR)/kmyth-seal), $(BIN_DIR)/kmyth-seal)
 	install -d $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -576,10 +576,12 @@ $(TEST_TPM_OBJ_DIR):
 
 .PHONY: install
 install:
+	install -d $(DESTDIR)$(PREFIX)/include/kmyth
+	install -m 644 $(INC_DIR)/defines.h \
+	               $(DESTDIR)$(PREFIX)/include/kmyth/
 ifeq ($(wildcard $(UTILS_LIB_LOCAL_DEST)), $(UTILS_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 755 $(UTILS_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth
 	install -m 644 $(UTILS_HEADERS) \
 	               $(DESTDIR)$(PREFIX)/include/kmyth/
 	ldconfig
@@ -587,7 +589,6 @@ endif
 ifeq ($(wildcard $(LOGGER_LIB_LOCAL_DEST)), $(LOGGER_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 755 $(LOGGER_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth
 	install -m 644 $(LOGGER_INC_DIR)/kmyth_log.h \
 	               $(DESTDIR)$(PREFIX)/include/kmyth/
 	ldconfig
@@ -595,7 +596,6 @@ endif
 ifeq ($(wildcard $(TPM_LIB_LOCAL_DEST)), $(TPM_LIB_LOCAL_DEST))
 	install -d $(DESTDIR)$(PREFIX)/lib
 	install -m 755 $(TPM_LIB_LOCAL_DEST) $(DESTDIR)$(PREFIX)/lib/
-	install -d $(DESTDIR)$(PREFIX)/include/kmyth
 	install -m 644 $(TPM_HEADERS) \
 	               $(DESTDIR)$(PREFIX)/include/kmyth/
 	ldconfig
@@ -618,10 +618,17 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(UTILS_LIB_SONAME)
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(TPM_LIB_SONAME)
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(LOGGER_LIB_SONAME)
-	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/defines.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/file_io.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/formatting_tools.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_log.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/kmyth_seal_unseal_impl.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/marshalling_tools.h
 	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/memory_util.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/object_tools.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/pcrs.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/storage_key_tools.h
+	rm -f $(DESTDIR)$(PREFIX)/include/kmyth/tpm2_interface.h
 ifeq ($(wildcard $(DESTDIR)$(PREFIX)/include/kmyth/*.h),)
 	rm -rf $(DESTDIR)$(PREFIX)/include/kmyth
 endif


### PR DESCRIPTION
For some reason, the "install" target in the Makefile does not include the header file installation for kmyth TPM utilities.

This pull request simply proposes adding the installation of these header files to the `make install` target.