### PR TITLE
Fix Compiler Warnings for use of Deprecated OpenSSL HMAC API

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -171,7 +171,7 @@
 /**
  * OpenSSL EVP hashing algorithm / message digest
  * 
- * including options from:
+ * includes options from:
  * <UL>
  *   <LI> SHA1 </LI>
  *   <LI> SHA2 </LI>
@@ -188,7 +188,9 @@
 #define KMYTH_OPENSSL_EVP_MAC_DIGEST "SHA-256"
 
 /**
- * OpenSSL EVP Message Authentication Code (MAC) algorithm options:
+ * OpenSSL EVP Message Authentication Code (MAC) algorithm
+ * 
+ * options such as:
  * <UL>
  *   <LI> BLAKE2 </LI>
  *   <LI> CMAC </LI>

--- a/include/defines.h
+++ b/include/defines.h
@@ -185,7 +185,7 @@
  *
  * @brief OpenSSL EVP_MAC "digest" specification
  */
-#define KMYTH_OPENSSL_EVP_MAC_DIGEST "SHA3-256"
+#define KMYTH_OPENSSL_EVP_MAC_DIGEST "SHA-256"
 
 /**
  * OpenSSL EVP Message Authentication Code (MAC) algorithm options:

--- a/include/defines.h
+++ b/include/defines.h
@@ -169,6 +169,41 @@
 #define KMYTH_OPENSSL_HASH EVP_sha256()
 
 /**
+ * OpenSSL EVP hashing algorithm / message digest
+ * 
+ * including options from:
+ * <UL>
+ *   <LI> SHA1 </LI>
+ *   <LI> SHA2 </LI>
+ *   <LI> SHA3 </LI>
+ *   <LI> KECCAK </LI>
+ *   <LI> KECCAK-KMAC </LI>
+ *   <LI> SHAKE </LI>
+ *   <LI> BLAKE2 </LI>
+ *   <LI> ... </LI>
+ * </UL>
+ *
+ * @brief OpenSSL EVP_MAC "digest" specification
+ */
+#define KMYTH_OPENSSL_EVP_MAC_DIGEST "SHA3-256"
+
+/**
+ * OpenSSL EVP Message Authentication Code (MAC) algorithm options:
+ * <UL>
+ *   <LI> BLAKE2 </LI>
+ *   <LI> CMAC </LI>
+ *   <LI> GMAC </LI>
+ *   <LI> HMAC </LI>
+ *   <LI> KMAC </LI>
+ *   <LI> SIPHASH </LI>
+ *   <LI> POLY1305 </LI>
+ * </UL>
+ *
+ * @brief OpenSSL EVP_MAC "type" specification
+ */
+#define KMYTH_OPENSSL_EVP_MAC_ALG "HMAC"
+
+/**
  * TPM 2.0 hash algorithm digest size options:
  * <UL>
  *   <LI> TPM2_SHA1_DIGEST_SIZE </LI>

--- a/src/cipher/cipher.c
+++ b/src/cipher/cipher.c
@@ -17,11 +17,13 @@
 
 // Check for supported OpenSSL version
 //   - OpenSSL v1.1.x required for AES KeyWrap RFC5649 w/ padding
+//   - OpenSSL v3.x required for 'EVP_MAC' API
+//   - OpenSSL v3.0.0 is a LTS version supported until 2026-09-07
 //   - OpenSSL v1.1.1 is a LTS version supported until 2023-09-11
 //   - OpenSSL v1.1.0 is not a supported version after 2019-09-11
 //   - OpenSSL v1.0.2 is not a supported version after 2019-12-31
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-#error OpenSSL version 1.1.1 or newer is required
+#if !(OPENSSL_VERSION_PREREQ(3, 0))
+#error OpenSSL version 3.0.x or newer is required
 #endif
 
 // cipher_list[] - array of structs that is used to specify all valid

--- a/test/src/tpm/tpm2_interface_test.c
+++ b/test/src/tpm/tpm2_interface_test.c
@@ -525,7 +525,6 @@ void test_init_password_cmd_auth(void)
   TSS2L_SYS_AUTH_COMMAND cmd_out;
   TSS2L_SYS_AUTH_RESPONSE res_out;
 
-
   //Valid test for NULL auth
   TPM2B_AUTH auth = {.size = 0, };
   CU_ASSERT(init_password_cmd_auth(&auth, &cmd_out, &res_out) == 0);

--- a/test/src/tpm/tpm2_interface_test.c
+++ b/test/src/tpm/tpm2_interface_test.c
@@ -525,6 +525,7 @@ void test_init_password_cmd_auth(void)
   TSS2L_SYS_AUTH_COMMAND cmd_out;
   TSS2L_SYS_AUTH_RESPONSE res_out;
 
+
   //Valid test for NULL auth
   TPM2B_AUTH auth = {.size = 0, };
   CU_ASSERT(init_password_cmd_auth(&auth, &cmd_out, &res_out) == 0);


### PR DESCRIPTION
In OpenSSL 3.0, the 'HMAC' API calls were deprecated (all HMAC/CMAC API functionality was migrated to the new 'EVP_MAC' API). Therefore, in the kmyth `compute_authHMAC()` function, calls to the 'HMAC' API are generating a lot of compiler warnings.

This pull request, therefore, proposes migrating kmyth's "HMAC" implementation that is based on the OpenSSL library to use of the newer 'EVP_MAC' API.

This pull request also proposes updating the OpenSSL version check to use the more readable `OPENSSL_VERSION_PREREQ()` macro and updates the specified minimum version to OpenSSL 3.0.0, which is an LTS version supported until September, 2026 (its predecessor, OpenSSL 1.1.1 became unsupported in September, 2023).

***NOTE: As the 'EVP_MAC' functions were introduced in OpenSSL 3, this pull request will make OpenSSL 3.x.x a kmyth hard dependency (the code will no longer build with earlier OpenSSL versions and the check will error if the detected runtime OpenSSL library is older than 3.0.0). If compatibility with earlier OpenSSL versions remains a goal/requirement, the approach proposed in this pull request will require modification.***
