### PR TITLE
Addressed Compiler Warnings for deprecated OpenSSL calls in SGX code

### DIFF
--- a/sgx/common/src/ecdh_util.c
+++ b/sgx/common/src/ecdh_util.c
@@ -208,7 +208,9 @@ int compute_ecdh_session_key(unsigned char * secret_in_bytes,
   }
 
   // set 'salt' value for HKDF
-  if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, "kmyth", 5) != 1)
+  const unsigned char *salt_val = (const unsigned char *) "kmyth";
+  size_t salt_len = strlen((const char *) salt_val);
+  if (EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt_val, (int) salt_len) != 1)
   {
     kmyth_sgx_log(LOG_ERR, "failed to set HKDF 'salt' value");
     EVP_PKEY_CTX_free(pctx);
@@ -216,7 +218,9 @@ int compute_ecdh_session_key(unsigned char * secret_in_bytes,
   }
 
   // set input key value for HKDF
-  if (EVP_PKEY_CTX_set1_hkdf_key(pctx, secret_in_bytes, (int)secret_in_len) != 1)
+  if (EVP_PKEY_CTX_set1_hkdf_key(pctx,
+                                 secret_in_bytes,
+                                 (int) secret_in_len) != 1)
   {
     kmyth_sgx_log(LOG_ERR, "failed to set HKDF input key bytes");
     EVP_PKEY_CTX_free(pctx);

--- a/sgx/untrusted/src/util/msg_util.c
+++ b/sgx/untrusted/src/util/msg_util.c
@@ -65,14 +65,16 @@ int send_ecdh_msg(int socket_fd, unsigned char *buf, size_t len)
 {
   struct ECDHMessageHeader header;
 
-  if (len > KMYTH_ECDH_MAX_MSG_SIZE)
+  if ((len > KMYTH_ECDH_MAX_MSG_SIZE) || (len > UINT16_MAX))
   {
     kmyth_log(LOG_ERR, "ECDH message exceeds size limit");
     return EXIT_FAILURE;
   }
+  uint16_t temp_len = (uint16_t) len;
 
   secure_memset(&header, 0, sizeof(header));
-  header.msg_size = htons(len);
+
+  header.msg_size = htons(temp_len);
 
   ssize_t bytes_sent = write(socket_fd, &header, sizeof(header));
   if ((bytes_sent <= 0) || ((size_t)bytes_sent != sizeof(header)))


### PR DESCRIPTION
In OpenSSL 3, the low-level EC_KEY API was deprecated. The 'EVP_PKEY_cmp' macro was also deprecated.

As kmyth utilizes this functionality in the ECDH/TLS Proxy demonstration code, building the targets in the kmyth 'sgx' directory (e.g., 'make test' and 'make demo') produces a number of compiler warnings.  This pull request proposes a refactor to no longer use these deprecated calls and clean up the build messaging.

Note: I chose to use the 'i2d_PUBKEY()' and 'd2i_PUBKEY()' functionality to serialize/deserialize the EVP_PKEY struct containing an elliptic curve key directly. This actually simplifies the code somewhat. I also experimented with using the new 'EVP_PKEY_fromdata()', 'EVP_PKEY_todata()' and 'OSSL_PARAM' functionality but encountered some difficulties with that approach.