### PR TITLE
Minor build/logging cleanup

### DIFF
--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -108,7 +108,7 @@ ifeq ($(SGX_DEBUG), 1)
 else ifeq ($(SGX_PRERELEASE), 1)
 	SGX_COMMON_CFLAGS += -DNDEBUG -DEDEBUG -UDEBUG
 else
-	 GX_COMMON_CFLAGS += -DNDEBUG -UEDEBUG -UDEBUG
+	GX_COMMON_CFLAGS += -DNDEBUG -UEDEBUG -UDEBUG
 endif
 
 SGX_COMMON_CXXFLAGS := $(SGX_COMMON_FLAGS)
@@ -558,7 +558,7 @@ $(Demo_App_Name): demo/obj/kmyth_sgx_retrieve_key_demo.o \
                   demo/enclave/protocol_ocall.o \
                   demo/enclave/memory_ocall.o \
                   demo/enclave/log_ocall.o 
-	$(CXX) $^ -o $@ $(Demo_App_Cpp_Flags) $(Demo_App_Link_Flags)
+	@$(CXX) $^ -o $@ $(Demo_App_Cpp_Flags) $(Demo_App_Link_Flags)
 	@echo "LINK =>  $@"
 
 ######## Test Server ########

--- a/sgx/untrusted/src/wrapper/sgx_seal_unseal_impl.c
+++ b/sgx/untrusted/src/wrapper/sgx_seal_unseal_impl.c
@@ -71,8 +71,6 @@ int kmyth_sgx_unseal_nkl(sgx_enclave_id_t eid,
                          size_t input_len,
                          uint64_t * handle)
 {
-  kmyth_log(LOG_ERR, "inside kmyth_sgx_unseal_nkl");
-
   uint8_t *block = NULL;
   size_t blocksize = 0;
 
@@ -102,8 +100,6 @@ int kmyth_sgx_unseal_nkl(sgx_enclave_id_t eid,
     free(block);
     return 1;
   }
-
-  kmyth_log(LOG_ERR, "before unseal into enclave");
 
   free(block);
   kmyth_unseal_into_enclave(eid, &ret, data, data_size, handle);


### PR DESCRIPTION
This pull request is pretty trivial:

- It removes two unhelpful and incorrectly characterized log messages.
- It suppresses echo of the compile command used to build the SGX ECDH demo application.
- It makes a very small white-space edit 