### PR TITLE
Refactor TLS Remote (Peer) Certification Verification for ECDH Demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DOC_DIR ?= doc
 LIB_DIR ?= lib
 LOGGER_DIR ?= logger
 UTILS_DIR ?= utils
+KMIP_LIB_DIR ?= /usr/local/lib
 
 # Specify kmyth applications (main) directories/files
 MAIN_SRC_DIR = $(SRC_DIR)/main
@@ -277,8 +278,10 @@ SOFLAGS = -shared#                       compile/link shared library
 SOFLAGS += -fPIC#
 
 # Specify linker flags
-LDFLAGS = -Llib#                         link path for libkmyth-*.so
-LDFLAGS += -Wl,-rpath=lib#               runtime path for libkmyth-*.so
+LDFLAGS = -Llib#                         link path for libkmyth-*.so*
+LDFLAGS += -L$(KMIP_LIB_DIR)#            link path for libkmip*.so*
+LDFLAGS += -Wl,-rpath=lib#               runtime path for libkmyth-*.so*
+LDFLAGS += -Wl,-rpath=$(KMIP_LIB_DIR)#   runtime path for libkmip*.so*
 
 #====================== END: TOOL CONFIGURATION ==============================
 
@@ -301,9 +304,9 @@ libs: clean-backups \
       $(LIB_DIR)/libkmyth-tpm.so
 
 .PHONY: nsl
-nsl:	clean-backups \
-	$(BIN_DIR)/nsl-client \
-	$(BIN_DIR)/nsl-server
+nsl: clean-backups \
+     $(BIN_DIR)/nsl-client \
+     $(BIN_DIR)/nsl-server
 
 .PHONY: utils-lib
 utils-lib: clean-backups $(LIB_DIR)/libkmyth-utils.so

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -400,7 +400,7 @@ ifneq ($(Build_Mode), HW_RELEASE)
 	@$(CURDIR)/$(Server_Name) -k demo/data/server_priv.pem \
 	                          -c demo/data/server_cert.pem \
 	                          -C demo/data/ca_cert.pem \
-							  -N localhost.proxy \
+	                          -N localhost.proxy \
 	                          -p 7001 &
 	@sleep 1
 	@$(CURDIR)/$(Proxy_Name) -k demo/data/proxy_priv.pem \

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -413,7 +413,7 @@ ifneq ($(Build_Mode), HW_RELEASE)
 	                         -p 7000 \
 	                         -K demo/data/proxy_priv.pem \
 	                         -L demo/data/proxy_cert.pem \
-				             -R localhost \
+	                         -R 127.0.0.1 \
 	                         -c demo/data/ca_cert.pem \
 	                         -P 7001 \
 	                         -m 1 &

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -34,9 +34,12 @@
 SGX_SDK ?= /opt/intel/sgxsdk
 SGX_MODE ?= SIM
 SGX_ARCH ?= x64
+
 SGX_SSL_UNTRUSTED_LIB_PATH ?= /opt/intel/sgxssl/lib64/
 SGX_SSL_TRUSTED_LIB_PATH ?= /opt/intel/sgxssl/lib64/
 SGX_SSL_INCLUDE_PATH ?= /opt/intel/sgxssl/include/
+
+KMIP_LIB_PATH ?= /usr/local/lib
 
 TEST_ENCLAVE_HEADER_TRUSTED ?= '"kmyth_sgx_test_enclave_t.h"'
 TEST_ENCLAVE_HEADER_UNTRUSTED ?= '"kmyth_sgx_test_enclave_u.h"'
@@ -108,7 +111,7 @@ ifeq ($(SGX_DEBUG), 1)
 else ifeq ($(SGX_PRERELEASE), 1)
 	SGX_COMMON_CFLAGS += -DNDEBUG -DEDEBUG -UDEBUG
 else
-	GX_COMMON_CFLAGS += -DNDEBUG -UEDEBUG -UDEBUG
+	SGX_COMMON_CFLAGS += -DNDEBUG -UEDEBUG -UDEBUG
 endif
 
 SGX_COMMON_CXXFLAGS := $(SGX_COMMON_FLAGS)
@@ -172,6 +175,7 @@ Demo_App_Cpp_Flags += $(SGX_COMMON_CXXFLAGS)
 Common_App_Link_Flags := $(SGX_COMMON_CFLAGS)
 Common_App_Link_Flags += -L$(SGX_LIBRARY_PATH)
 Common_App_Link_Flags += -L$(SGX_SSL_UNTRUSTED_LIB_PATH)
+Common_App_link_Flags += -L$(KMIP_LIB_PATH)
 Common_App_Link_Flags += -l$(Urts_Library_Name)
 Common_App_Link_Flags += -lsgx_usgxssl
 Common_App_Link_Flags += -lpthread
@@ -179,6 +183,7 @@ Common_App_Link_Flags += -lkmyth-utils
 Common_App_Link_Flags += -lkmyth-logger
 Common_App_Link_Flags += -lkmyth-tpm
 Common_App_Link_Flags += -lkmip
+Common_App_Link_Flags += -Wl,-rpath=$(KMIP_LIB_PATH)
 
 ifneq ($(SGX_MODE), HW)
 	Common_App_Link_Flags += -lsgx_uae_service_sim

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -539,7 +539,7 @@ demo/enclave/protocol_ocall.o: untrusted/src/ocall/protocol_ocall.c
 	@echo "CC   <=  $<"
 
 demo/enclave/$(Demo_Enclave_Name)_u.c: \
-        $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
+		$(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
 	@cd demo/enclave && $(SGX_EDGER8R) --untrusted $(Demo_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -552,7 +552,7 @@ demo/enclave/$(Demo_Enclave_Name)_u.o: demo/enclave/$(Demo_Enclave_Name)_u.c
 	@echo "CC   <=  $<"
 
 demo/enclave/$(DEMO_ENCLAVE_HEADER_UNTRUSTED): \
-        demo/enclave/$(Demo_Enclave_Name)_u.c
+		demo/enclave/$(Demo_Enclave_Name)_u.c
 
 demo/obj/%.o: demo/src/app/%.c demo/enclave/$(DEMO_ENCLAVE_HEADER_UNTRUSTED)
 	@$(CC) $(Demo_App_C_Flags) -c $< -o $@
@@ -610,7 +610,7 @@ $(Proxy_Name): demo/obj/tls_proxy.o \
 ######## Test Enclave Objects ########
 
 test/enclave/$(Test_Enclave_Name)_t.c: \
-        $(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
+		$(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
 	@cd test/enclave && $(SGX_EDGER8R) --trusted $(Test_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -704,7 +704,7 @@ test-clean:
 ######## Demo Enclave Objects ########
 
 demo/enclave/$(Demo_Enclave_Name)_t.c: \
-        $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
+		$(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
 	@cd demo/enclave && $(SGX_EDGER8R) --trusted $(Demo_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -717,12 +717,12 @@ demo/enclave/$(Demo_Enclave_Name)_t.o: demo/enclave/$(Demo_Enclave_Name)_t.c
 	@echo "CC   <=  $<"
 
 demo/enclave/kmyth_enclave_memory_util.o: \
-        trusted/src/util/kmyth_enclave_memory_util.c 
+		trusted/src/util/kmyth_enclave_memory_util.c 
 	@$(CC) $(Demo_Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
 demo/enclave/sgx_retrieve_key_impl.o: \
-        trusted/src/wrapper/sgx_retrieve_key_impl.c 
+		trusted/src/wrapper/sgx_retrieve_key_impl.c 
 	@$(CC) $(Demo_Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
@@ -735,7 +735,7 @@ demo/enclave/kmyth_enclave_unseal.o: trusted/src/ecall/kmyth_enclave_unseal.cpp
 	@echo "CC   <=  $<"
 
 demo/enclave/kmyth_enclave_retrieve_key.o: \
-        trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+		trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
 	@$(CXX) $(Demo_Enclave_Cpp_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
@@ -768,7 +768,7 @@ demo/enclave/$(Demo_Enclave_Lib): demo/enclave/$(Demo_Enclave_Name)_t.o \
 	@echo "LINK =>  $@"
 
 demo/enclave/$(Demo_Signed_Enclave_Name): \
-        demo/enclave/$(Demo_Enclave_Lib) $(Enclave_Signing_Key)
+		demo/enclave/$(Demo_Enclave_Lib) $(Enclave_Signing_Key)
 	@$(SGX_ENCLAVE_SIGNER) sign -key $(Enclave_Signing_Key) \
 	                            -enclave demo/enclave/$(Demo_Enclave_Lib) \
 	                            -out $@ \

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -403,20 +403,18 @@ ifneq ($(Build_Mode), HW_RELEASE)
 	@echo "==================================================================================================="
 	@echo ""
 	@$(CURDIR)/$(Server_Name) -k demo/data/server_priv.pem \
-	                          -c demo/data/server_cert.pem \
-	                          -C demo/data/ca_cert.pem \
-	                          -N localhost.proxy \
+	                          -l demo/data/server_cert.pem \
+	                          -c demo/data/ca_cert.pem \
 	                          -p 7001 &
 	@sleep 1
 	@$(CURDIR)/$(Proxy_Name) -k demo/data/proxy_priv.pem \
-	                         -c demo/data/proxy_cert.pem \
-	                         -u demo/data/client_cert.pem \
+	                         -l demo/data/proxy_cert.pem \
+	                         -r demo/data/client_cert.pem \
 	                         -p 7000 \
-	                         -R demo/data/proxy_priv.pem \
-	                         -U demo/data/proxy_cert.pem \
-	                         -C demo/data/ca_cert.pem \
-	                         -I localhost \
-	                         -N localhost.server \
+	                         -K demo/data/proxy_priv.pem \
+	                         -L demo/data/proxy_cert.pem \
+				             -R localhost \
+	                         -c demo/data/ca_cert.pem \
 	                         -P 7001 \
 	                         -m 1 &
 	@sleep 1
@@ -496,7 +494,8 @@ test/enclave/msg_util.o: untrusted/src/util/msg_util.c
 	@$(CC) $(Test_App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-test/enclave/$(Test_Enclave_Name)_u.c: $(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
+test/enclave/$(Test_Enclave_Name)_u.c: \
+        $(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
 	@cd test/enclave && $(SGX_EDGER8R) --untrusted $(Test_Enclave_Name).edl \
                                        --search-path $(SGX_SDK)/include \
                                        --search-path . \
@@ -508,19 +507,18 @@ test/enclave/$(Test_Enclave_Name)_u.o: test/enclave/$(Test_Enclave_Name)_u.c
 	@$(CC) $(Test_App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-$(Test_App_Name): $(Test_App_Source_Files) test/enclave/$(Test_Enclave_Name)_u.o \
-                                           test/enclave/ec_key_cert_marshal.o \
-                                           test/enclave/ec_key_cert_unmarshal.o \
-                                           test/enclave/ecdh_util.o \
-                                           test/enclave/retrieve_key_protocol.o \
-                                           test/enclave/msg_util.o \
-                                           test/enclave/protocol_ocall.o \
-                                           test/enclave/memory_ocall.o \
-                                           test/enclave/log_ocall.o
+$(Test_App_Name): $(Test_App_Source_Files) \
+                  test/enclave/$(Test_Enclave_Name)_u.o \
+                  test/enclave/ec_key_cert_marshal.o \
+                  test/enclave/ec_key_cert_unmarshal.o \
+                  test/enclave/ecdh_util.o \
+                  test/enclave/retrieve_key_protocol.o \
+                  test/enclave/msg_util.o \
+                  test/enclave/protocol_ocall.o \
+                  test/enclave/memory_ocall.o \
+                  test/enclave/log_ocall.o
 	@$(CC) $^ -o $@ $(Test_App_C_Flags) $(Test_App_Link_Flags)
 	@echo "LINK =>  $@"
-
-
 
 ######## Demo App Objects ########
 
@@ -540,7 +538,8 @@ demo/enclave/protocol_ocall.o: untrusted/src/ocall/protocol_ocall.c
 	@$(CC) $(Demo_App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-demo/enclave/$(Demo_Enclave_Name)_u.c: $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
+demo/enclave/$(Demo_Enclave_Name)_u.c: \
+        $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
 	@cd demo/enclave && $(SGX_EDGER8R) --untrusted $(Demo_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -552,7 +551,8 @@ demo/enclave/$(Demo_Enclave_Name)_u.o: demo/enclave/$(Demo_Enclave_Name)_u.c
 	@$(CC) $(Demo_App_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-demo/enclave/$(DEMO_ENCLAVE_HEADER_UNTRUSTED): demo/enclave/$(Demo_Enclave_Name)_u.c
+demo/enclave/$(DEMO_ENCLAVE_HEADER_UNTRUSTED): \
+        demo/enclave/$(Demo_Enclave_Name)_u.c
 
 demo/obj/%.o: demo/src/app/%.c demo/enclave/$(DEMO_ENCLAVE_HEADER_UNTRUSTED)
 	@$(CC) $(Demo_App_C_Flags) -c $< -o $@
@@ -609,7 +609,8 @@ $(Proxy_Name): demo/obj/tls_proxy.o \
 
 ######## Test Enclave Objects ########
 
-test/enclave/$(Test_Enclave_Name)_t.c: $(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
+test/enclave/$(Test_Enclave_Name)_t.c: \
+        $(SGX_EDGER8R) test/enclave/$(Test_Enclave_Name).edl
 	@cd test/enclave && $(SGX_EDGER8R) --trusted $(Test_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -693,7 +694,8 @@ test: test-all
 .PHONY: test-clean
 
 test-clean:
-	@rm -f test/enclave/*_t.h test/enclave/*_u.h test/enclave/*_t.c test/enclave/*_u.c
+	@rm -f test/enclave/*_t.h test/enclave/*_u.h
+	@rm -f test/enclave/*_t.c test/enclave/*_u.c
 	@rm -f test/enclave/*.o test/enclave/*.so
 	@rm -rf test/bin
 	@rm -f $(Enclave_Signing_Key)
@@ -701,7 +703,8 @@ test-clean:
 
 ######## Demo Enclave Objects ########
 
-demo/enclave/$(Demo_Enclave_Name)_t.c: $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
+demo/enclave/$(Demo_Enclave_Name)_t.c: \
+        $(SGX_EDGER8R) demo/enclave/$(Demo_Enclave_Name).edl
 	@cd demo/enclave && $(SGX_EDGER8R) --trusted $(Demo_Enclave_Name).edl \
 	                                   --search-path $(SGX_SDK)/include \
 	                                   --search-path . \
@@ -713,11 +716,13 @@ demo/enclave/$(Demo_Enclave_Name)_t.o: demo/enclave/$(Demo_Enclave_Name)_t.c
 	@$(CC) $(Demo_Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-demo/enclave/kmyth_enclave_memory_util.o: trusted/src/util/kmyth_enclave_memory_util.c 
+demo/enclave/kmyth_enclave_memory_util.o: \
+        trusted/src/util/kmyth_enclave_memory_util.c 
 	@$(CC) $(Demo_Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-demo/enclave/sgx_retrieve_key_impl.o: trusted/src/wrapper/sgx_retrieve_key_impl.c 
+demo/enclave/sgx_retrieve_key_impl.o: \
+        trusted/src/wrapper/sgx_retrieve_key_impl.c 
 	@$(CC) $(Demo_Enclave_C_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
@@ -729,7 +734,8 @@ demo/enclave/kmyth_enclave_unseal.o: trusted/src/ecall/kmyth_enclave_unseal.cpp
 	@$(CXX) $(Demo_Enclave_Cpp_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
-demo/enclave/kmyth_enclave_retrieve_key.o: trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
+demo/enclave/kmyth_enclave_retrieve_key.o: \
+        trusted/src/ecall/kmyth_enclave_retrieve_key.cpp
 	@$(CXX) $(Demo_Enclave_Cpp_Flags) -c $< -o $@
 	@echo "CC   <=  $<"
 
@@ -761,7 +767,8 @@ demo/enclave/$(Demo_Enclave_Lib): demo/enclave/$(Demo_Enclave_Name)_t.o \
 	@$(CXX) $^ -o $@ $(Demo_Enclave_Link_Flags)
 	@echo "LINK =>  $@"
 
-demo/enclave/$(Demo_Signed_Enclave_Name): demo/enclave/$(Demo_Enclave_Lib) $(Enclave_Signing_Key)
+demo/enclave/$(Demo_Signed_Enclave_Name): \
+        demo/enclave/$(Demo_Enclave_Lib) $(Enclave_Signing_Key)
 	@$(SGX_ENCLAVE_SIGNER) sign -key $(Enclave_Signing_Key) \
 	                            -enclave demo/enclave/$(Demo_Enclave_Lib) \
 	                            -out $@ \
@@ -782,7 +789,8 @@ demo/data/server_cert.pem: demo/data/gen_test_keys_certs.bash
 .PHONY: demo-clean
 
 demo-clean:
-	@rm -f demo/enclave/*_u.h demo/enclave/*_t.h demo/enclave/*_u.c demo/enclave/*_t.c
+	@rm -f demo/enclave/*_u.h demo/enclave/*_t.h
+	@rm -f demo/enclave/*_u.c demo/enclave/*_t.c
 	@rm -f demo/enclave/*.o demo/enclave/*.so
 	@rm -f demo/data/*.pem
 	@rm -rf demo/obj

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -400,9 +400,10 @@ ifneq ($(Build_Mode), HW_RELEASE)
 	@$(CURDIR)/$(Server_Name) -k demo/data/server_priv.pem \
 	                          -c demo/data/server_cert.pem \
 	                          -C demo/data/ca_cert.pem \
+							  -N localhost.proxy \
 	                          -p 7001 &
 	@sleep 1
-	@$(CURDIR)/$(Proxy_Name) -r demo/data/proxy_priv.pem \
+	@$(CURDIR)/$(Proxy_Name) -k demo/data/proxy_priv.pem \
 	                         -c demo/data/proxy_cert.pem \
 	                         -u demo/data/client_cert.pem \
 	                         -p 7000 \
@@ -410,7 +411,7 @@ ifneq ($(Build_Mode), HW_RELEASE)
 	                         -U demo/data/proxy_cert.pem \
 	                         -C demo/data/ca_cert.pem \
 	                         -I localhost \
-	                         -N demoServer \
+	                         -N localhost.server \
 	                         -P 7001 \
 	                         -m 1 &
 	@sleep 1

--- a/sgx/common/src/retrieve_key_protocol.c
+++ b/sgx/common/src/retrieve_key_protocol.c
@@ -271,6 +271,7 @@ int parse_client_hello_msg(ECDHMessage * msg_in,
   {
     kmyth_sgx_log(LOG_ERR, "error unmarshaling client identity bytes");
     free(client_id_bytes);
+    X509_NAME_free(client_id);
     free(client_eph_pub_bytes);
     free(msg_sig_bytes);
     return EXIT_FAILURE;

--- a/sgx/common/src/retrieve_key_protocol.c
+++ b/sgx/common/src/retrieve_key_protocol.c
@@ -292,6 +292,24 @@ int parse_client_hello_msg(ECDHMessage * msg_in,
 
   // verify that identity in 'Client Hello' message matches the client
   // certificate pre-loaded into it's peer (TLS proxy for server)
+  char msg[128] = { 0 };
+  char temp_name[64] = { 0 };
+  strncat(msg, "client ID from Client Hello message: ", 63);
+  X509_NAME_get_text_by_NID(client_id,
+                            NID_commonName,
+                            (char *) temp_name,
+                            63);
+  strncat(msg, temp_name, 64);
+  kmyth_sgx_log(LOG_DEBUG, msg);
+  memset(msg, 0, 128);
+  memset(temp_name, 0, 64);
+  strncat(msg, "client ID from pre-loaded certificate: ", 63);
+  X509_NAME_get_text_by_NID(expected_client_id,
+                            NID_commonName,
+                            (char *) temp_name,
+                            63);
+  strncat(msg, temp_name, 64);
+  kmyth_sgx_log(LOG_DEBUG, msg);
   if (0 != X509_NAME_cmp(client_id, expected_client_id))
   {
     kmyth_sgx_log(LOG_ERR, "'Client Hello' - unexpected client identity");
@@ -630,6 +648,24 @@ int parse_server_hello_msg(ECDHMessage * msg_in,
 
   // verify that identity in 'Server Hello' message matches the server
   // certificate pre-loaded into it's peer (enclave client)
+  char msg[128] = { 0 };
+  char temp_name[64] = { 0 };
+  strncat(msg, "server ID from Server Hello message: ", 63);
+  X509_NAME_get_text_by_NID(rcvd_server_id,
+                            NID_commonName,
+                            (char *) temp_name,
+                            63);
+  strncat(msg, temp_name, 64);
+  kmyth_sgx_log(LOG_DEBUG, msg);
+  memset(msg, 0, 128);
+  memset(temp_name, 0, 64);
+  strncat(msg, "server ID from pre-loaded certificate: ", 63);
+  X509_NAME_get_text_by_NID(rcvd_server_id,
+                            NID_commonName,
+                            (char *) temp_name,
+                            63);
+  strncat(msg, temp_name, 64);
+  kmyth_sgx_log(LOG_DEBUG, msg);
   if (0 != X509_NAME_cmp(rcvd_server_id, expected_server_id))
   {
     kmyth_sgx_log(LOG_ERR, "'Server Hello' - unexpected server identity");

--- a/sgx/demo/data/openssl.cnf
+++ b/sgx/demo/data/openssl.cnf
@@ -44,7 +44,7 @@ CN                      = "TestProxy"
 [ dn_server ]
 C                       = "US"
 O                       = "kmyth"
-CN                      = "TestServer"
+CN                      = "DemoServer"
 
 [ v3_ext_ca ]
 subjectKeyIdentifier    = hash
@@ -68,7 +68,7 @@ basicConstraints        = CA:false
 
 [ alt_names_client ]
 IP.0                    = 127.0.0.1
-DNS.0                   = localhost.enclaveAppClient
+DNS.0                   = localhost.enclave
 
 [ alt_names_proxy ]
 IP.0                    = 127.0.0.1
@@ -76,4 +76,4 @@ DNS.0                   = localhost.proxy
 
 [ alt_names_server ]
 IP.0                    = 127.0.0.1
-DNS.0                   = localhost.demoServer 
+DNS.0                   = localhost.server 

--- a/sgx/demo/data/openssl.cnf
+++ b/sgx/demo/data/openssl.cnf
@@ -68,12 +68,12 @@ basicConstraints        = CA:false
 
 [ alt_names_client ]
 IP.0                    = 127.0.0.1
-DNS.0                   = localhost.enclave
+DNS.0                   = localhost
 
 [ alt_names_proxy ]
 IP.0                    = 127.0.0.1
-DNS.0                   = localhost.proxy
+DNS.0                   = localhost
 
 [ alt_names_server ]
 IP.0                    = 127.0.0.1
-DNS.0                   = localhost.server 
+DNS.0                   = localhost 

--- a/sgx/demo/include/node/demo_kmip_server.h
+++ b/sgx/demo/include/node/demo_kmip_server.h
@@ -54,6 +54,7 @@ static const struct option demo_kmip_server_longopts[] = {
   // TLS connection info
   {"server-key", required_argument, 0, 'k'},
   {"server-cert", required_argument, 0, 'c'},
+  {"client-san", required_argument, 0, 'N'},
   {"ca-cert", required_argument, 0, 'C'},
   // network options
   {"port", required_argument, 0, 'p'},

--- a/sgx/demo/include/node/demo_kmip_server.h
+++ b/sgx/demo/include/node/demo_kmip_server.h
@@ -51,15 +51,11 @@ typedef struct DemoServer
  * @brief Command-line options for the 'demo server' application
  */
 static const struct option demo_kmip_server_longopts[] = {
-  // TLS connection info
-  {"server-key", required_argument, 0, 'k'},
-  {"server-cert", required_argument, 0, 'c'},
-  {"client-san", required_argument, 0, 'N'},
-  {"ca-cert", required_argument, 0, 'C'},
-  // network options
-  {"port", required_argument, 0, 'p'},
-  // Misc
+  {"ca-cert", required_argument, 0, 'c'},
   {"help", no_argument, 0, 'h'},
+  {"local-key", required_argument, 0, 'k'},
+  {"local-cert", required_argument, 0, 'l'},
+  {"port", required_argument, 0, 'p'},
   {0, 0, 0, 0}
 };
 

--- a/sgx/demo/include/node/tls_proxy.h
+++ b/sgx/demo/include/node/tls_proxy.h
@@ -34,16 +34,15 @@ typedef struct TLSProxy
  */
 static const struct option proxy_longopts[] = {
   // ECDH connection info
-  {"ecdh-server-port", required_argument, 0, 'p'},
-  {"ecdh-server-key", required_argument, 0, 'k'},
-  {"ecdh-server-cert", required_argument, 0, 'c'},
-  {"ecdh-client-cert", required_argument, 0, 'u'},
+  {"ecdh-port", required_argument, 0, 'p'},
+  {"ecdh-local-key", required_argument, 0, 'k'},
+  {"ecdh-local-cert", required_argument, 0, 'l'},
+  {"ecdh-remote-cert", required_argument, 0, 'r'},
   // TLS connection info
-  {"tls-server-host", required_argument, 0, 'I'},
-  {"tls-server-port", required_argument, 0, 'P'},
-  {"tls-server-san", required_argument, 0, 'N'},
-  {"tls-client-key", required_argument, 0, 'R'},
-  {"tls-client-cert", required_argument, 0, 'U'},
+  {"tls-port", required_argument, 0, 'P'},
+  {"tls-local-key", required_argument, 0, 'K'},
+  {"tls-local-cert", required_argument, 0, 'L'},
+  {"tls-remote-host", required_argument, 0, 'R'},
   // Certificate Authority (CA) info
   {"ca-cert", required_argument, 0, 'C'},
   // Test options

--- a/sgx/demo/include/node/tls_proxy.h
+++ b/sgx/demo/include/node/tls_proxy.h
@@ -33,22 +33,17 @@ typedef struct TLSProxy
  * @brief Command-line options for the 'TLS proxy' application
  */
 static const struct option proxy_longopts[] = {
-  // ECDH connection info
+  {"ca-cert", required_argument, 0, 'c'},
   {"ecdh-port", required_argument, 0, 'p'},
   {"ecdh-local-key", required_argument, 0, 'k'},
   {"ecdh-local-cert", required_argument, 0, 'l'},
   {"ecdh-remote-cert", required_argument, 0, 'r'},
-  // TLS connection info
+  {"help", no_argument, 0, 'h'},
+  {"maxconn", required_argument, 0, 'm'},
   {"tls-port", required_argument, 0, 'P'},
   {"tls-local-key", required_argument, 0, 'K'},
   {"tls-local-cert", required_argument, 0, 'L'},
-  {"tls-remote-host", required_argument, 0, 'R'},
-  // Certificate Authority (CA) info
-  {"ca-cert", required_argument, 0, 'C'},
-  // Test options
-  {"maxconn", required_argument, 0, 'm'},
-  // Misc
-  {"help", no_argument, 0, 'h'},
+  {"tls-remote-addr", required_argument, 0, 'R'},
   {0, 0, 0, 0}
 };
 

--- a/sgx/demo/include/node/tls_proxy.h
+++ b/sgx/demo/include/node/tls_proxy.h
@@ -34,15 +34,18 @@ typedef struct TLSProxy
  */
 static const struct option proxy_longopts[] = {
   // ECDH connection info
-  {"local-port", required_argument, 0, 'p'},
-  {"private", required_argument, 0, 'r'},
-  {"public", required_argument, 0, 'u'},
+  {"ecdh-server-port", required_argument, 0, 'p'},
+  {"ecdh-server-key", required_argument, 0, 'k'},
+  {"ecdh-server-cert", required_argument, 0, 'c'},
+  {"ecdh-client-cert", required_argument, 0, 'u'},
   // TLS connection info
-  {"remote-ip", required_argument, 0, 'I'},
-  {"remote-port", required_argument, 0, 'P'},
-  {"ca-path", required_argument, 0, 'C'},
-  {"client-key", required_argument, 0, 'R'},
-  {"client-cert", required_argument, 0, 'U'},
+  {"tls-server-host", required_argument, 0, 'I'},
+  {"tls-server-port", required_argument, 0, 'P'},
+  {"tls-server-san", required_argument, 0, 'N'},
+  {"tls-client-key", required_argument, 0, 'R'},
+  {"tls-client-cert", required_argument, 0, 'U'},
+  // Certificate Authority (CA) info
+  {"ca-cert", required_argument, 0, 'C'},
   // Test options
   {"maxconn", required_argument, 0, 'm'},
   // Misc

--- a/sgx/demo/include/util/demo_ecdh_util.h
+++ b/sgx/demo/include/util/demo_ecdh_util.h
@@ -45,12 +45,12 @@
 typedef struct ECDHConfig
 {
   bool isClient;
-  char *local_sign_key_path;
-  EVP_PKEY *local_sign_key;
-  char *local_sign_cert_path;
-  X509 *local_sign_cert;
-  char *remote_sign_cert_path;
-  X509 *remote_sign_cert;
+  char *local_private_key_path;
+  EVP_PKEY *local_private_key;
+  char *local_cert_path;
+  X509 *local_cert;
+  char *remote_cert_path;
+  X509 *remote_cert;
   char *port;
   char *ip;
   int session_limit;
@@ -150,44 +150,46 @@ int demo_ecdh_check_options(ECDHConfig * ecdhopts);
 /**
  * @brief Load the signing key for the local ECDH peer.
  *
- * @param[out] ecdhconn             Pointer to ECDHPeer struct into which a
- *                                  pointer to the EVP_PKEY local signature
- *                                  key will be "loaded"
- * 
- * @param[in]  local_sign_key_path  String containing the path for the file
- *                                  containing the key to be "loaded"
+ * @param[in/out] ecdhconn          Pointer to ECDHPeer struct into which a
+ *                                  pointer to the EVP_PKEY local private
+ *                                  key will be "loaded". This struct must
+ *                                  have been pre-configured to set its
+ *                                  'local_private_key_path' element to specify
+ *                                  the path for the file containing the key
+ *                                  to be "loaded"
+ *
  * @return none
  */
-int demo_ecdh_load_local_sign_key(ECDHPeer * ecdhconn,
-                                  char * local_sign_key_path);
+int demo_ecdh_load_local_private_key(ECDHPeer * ecdhconn);
 
 /**
  * @brief Load the certificate for the local ECDH peer.
  *
- * @param[out] ecdhconn             Pointer to ECDHPeer struct into which a
+ * @param[in/out] ecdhconn          Pointer to ECDHPeer struct into which a
  *                                  pointer to the X509 local signature
- *                                  certificate will be "loaded"
- * 
- * @param[in]  local_sign_key_path  String containing the path for the file
- *                                  containing the certificate to be "loaded"
+ *                                  certificate will be "loaded". This struct
+ *                                  must have been pre-configured to set its
+ *                                  'local_cert_path' element to specify
+ *                                  the path for the file containing the
+ *                                  certificate to be "loaded"
+ *
  * @return none
  */
-int demo_ecdh_load_local_sign_cert(ECDHPeer * ecdhconn,
-                                   char * local_sign_cert_path);
+int demo_ecdh_load_local_cert(ECDHPeer * ecdhconn);
 
 /**
  * @brief Load the certificate for the remote ECDH peer.
  *
  * @param[out] ecdhconn             Pointer to ECDHPeer struct into which a
  *                                  pointer to the X509 remote signature
- *                                  certificate will be "loaded"
- * 
- * @param[in]  local_sign_key_path  String containing the path for the file
- *                                  containing the certificate to be "loaded"
+ *                                  certificate will be "loaded". This struct
+ *                                  must have been pre-configured to set its
+ *                                  'remote_cert_path' element to specify
+ *                                  the path for the file containing the
+ *                                  certificate to be "loaded"
  * @return none
  */
-int demo_ecdh_load_remote_sign_cert(ECDHPeer * ecdhconn,
-                                    char * remote_sign_cert_path);
+int demo_ecdh_load_remote_cert(ECDHPeer * ecdhconn);
 
 /**
  * @brief Receive a 'retrieve key' protocol message from an ECDH peer.

--- a/sgx/demo/include/util/demo_tls_util.h
+++ b/sgx/demo/include/util/demo_tls_util.h
@@ -30,6 +30,7 @@
 #include <kmyth/memory_util.h>
 
 #include "socket_util.h"
+#include "tls_util.h"
 
 #include "demo_misc_util.h"
 #include "ecdh_util.h"
@@ -63,11 +64,10 @@ typedef struct TLSMessage {
 typedef struct TLSPeer
 {
   bool isClient;
-  char *remote_host;
-  char *remote_san; 
   char *conn_port;
+  char *remote_host;
   char *ca_cert_path;
-  char *local_key_path;
+  char *local_private_key_path;
   char *local_cert_path;
   SSL_CTX *ctx;
   BIO *bio;

--- a/sgx/demo/include/util/demo_tls_util.h
+++ b/sgx/demo/include/util/demo_tls_util.h
@@ -63,8 +63,8 @@ typedef struct TLSMessage {
 typedef struct TLSPeer
 {
   bool isClient;
-  char *remote_server;
-  char *remote_server_func; 
+  char *remote_host;
+  char *remote_san; 
   char *conn_port;
   char *ca_cert_path;
   char *local_key_path;

--- a/sgx/demo/include/util/demo_tls_util.h
+++ b/sgx/demo/include/util/demo_tls_util.h
@@ -65,7 +65,7 @@ typedef struct TLSPeer
 {
   bool isClient;
   char *conn_port;
-  char *remote_host;
+  char *remote_addr;
   char *ca_cert_path;
   char *local_private_key_path;
   char *local_cert_path;

--- a/sgx/demo/src/app/kmyth_sgx_retrieve_key_demo.c
+++ b/sgx/demo/src/app/kmyth_sgx_retrieve_key_demo.c
@@ -50,7 +50,7 @@
 #define SERVER_PUBLIC_CERT_FILE "demo/data/proxy_cert.pem"
 
 /* These parameters are hard-coded for now. */
-#define SERVER_HOST "localhost"
+#define SERVER_ADDR "127.0.0.1"
 #define SERVER_PORT "7000"
 #define KEY_ID "7"
 #define KEY_ID_LEN 1
@@ -127,20 +127,20 @@ int main(void)
   if (client_ec_cert_bio == NULL)
   {
     demo_log(LOG_ERR, "BIO association with file (%s) failed",
-             CLIENT_PUBLIC_CERT_FILE);
+                      CLIENT_PUBLIC_CERT_FILE);
     return EXIT_FAILURE;
   }
   client_ec_cert = PEM_read_bio_X509(client_ec_cert_bio, NULL, 0, NULL);
   if (client_ec_cert == NULL)
   {
     demo_log(LOG_ERR, "EC Certificate PEM file (%s) read failed",
-             CLIENT_PUBLIC_CERT_FILE);
+                      CLIENT_PUBLIC_CERT_FILE);
     BIO_free(client_ec_cert_bio);
     return EXIT_FAILURE;
   }
   BIO_free(client_ec_cert_bio);
   demo_log(LOG_DEBUG, "loaded client public certificate from file: %s",
-           CLIENT_PUBLIC_CERT_FILE);
+                      CLIENT_PUBLIC_CERT_FILE);
 
   // marshal (DER format) the server's certificate
   //   - facilitates passing this certificate into the enclave
@@ -165,20 +165,20 @@ int main(void)
   if (server_ec_cert_bio == NULL)
   {
     demo_log(LOG_ERR, "BIO association with file (%s) failed",
-             SERVER_PUBLIC_CERT_FILE);
+                      SERVER_PUBLIC_CERT_FILE);
     return EXIT_FAILURE;
   }
   server_ec_cert = PEM_read_bio_X509(server_ec_cert_bio, NULL, 0, NULL);
   if (server_ec_cert == NULL)
   {
     demo_log(LOG_ERR, "EC Certificate PEM file (%s) read failed",
-             SERVER_PUBLIC_CERT_FILE);
+                      SERVER_PUBLIC_CERT_FILE);
     BIO_free(server_ec_cert_bio);
     return EXIT_FAILURE;
   }
   BIO_free(server_ec_cert_bio);
   demo_log(LOG_DEBUG, "loaded server public certificate from file: %s",
-           SERVER_PUBLIC_CERT_FILE);
+                      SERVER_PUBLIC_CERT_FILE);
 
   // marshal (DER format) the server's certificate
   //   - facilitates passing this certificate into the enclave
@@ -205,7 +205,7 @@ int main(void)
   if (sgx_ret != SGX_SUCCESS)
   {
     demo_log(LOG_ERR, "SGX enclave init failed - error code: %d\n",
-             (int) sgx_ret);
+                      (int) sgx_ret);
     return EXIT_FAILURE;
   }
   demo_log(LOG_DEBUG, "initialized SGX enclave - EID = 0x%016lx", eid);
@@ -214,8 +214,8 @@ int main(void)
   demo_log(LOG_DEBUG, "invoking 'retrieve key' ECALL ...");
   int retval = -1;
 
-  const char *server_host = SERVER_HOST;
-  size_t server_host_len = strlen(server_host) + 1;
+  const char *server_addr = SERVER_ADDR;
+  size_t server_addr_len = strlen(server_addr) + 1;
   const char *server_port = SERVER_PORT;
   size_t server_port_len = strlen(server_port) + 1;
 
@@ -227,8 +227,8 @@ int main(void)
                                                    (size_t) client_ec_cert_bytes_len,
                                                    server_ec_cert_bytes,
                                                    (size_t) server_ec_cert_bytes_len,
-                                                   server_host,
-                                                   server_host_len,
+                                                   server_addr,
+                                                   server_addr_len,
                                                    server_port,
                                                    server_port_len,
                                                    (unsigned char *) KEY_ID,

--- a/sgx/demo/src/node/demo_kmip_server.c
+++ b/sgx/demo/src/node/demo_kmip_server.c
@@ -26,7 +26,7 @@ static void demo_kmip_server_init(DemoServer * demo_server)
   demo_server->tlsconn.isClient = false;
   
   // initialize all demo server's TLSPeer struct parameters as NULL
-  demo_server->tlsconn.remote_host = NULL;
+  demo_server->tlsconn.remote_addr = NULL;
   demo_server->tlsconn.conn_port = NULL;
   demo_server->tlsconn.ca_cert_path = NULL;
   demo_server->tlsconn.local_private_key_path = NULL;

--- a/sgx/demo/src/node/demo_kmip_server.c
+++ b/sgx/demo/src/node/demo_kmip_server.c
@@ -158,7 +158,7 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   if (server_key_path == NULL)
   {
-    kmyth_log(LOG_ERR, "path for server's private key required");
+    fprintf(stderr, "path for server's private key (-k) option required");
     invalid_options = true;
   }
   else
@@ -168,7 +168,7 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   if (server_cert_path == NULL)
   {
-    kmyth_log(LOG_ERR, "path for server's public certificate required");
+    fprintf(stderr, "path for server's public cert (-c) option required");
     invalid_options = true;
   }
   else
@@ -178,7 +178,7 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   if (port_string == NULL)
   {
-    kmyth_log(LOG_ERR, "network port (server listen) argument required");
+    fprintf(stderr, "network port (server listen) argument required");
     invalid_options = true;
   }
   else

--- a/sgx/demo/src/node/demo_kmip_server.c
+++ b/sgx/demo/src/node/demo_kmip_server.c
@@ -178,7 +178,7 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   if (port_string == NULL)
   {
-    fprintf(stderr, "network port (server listen) argument required");
+    fprintf(stderr, "server port (-p) argument required");
     invalid_options = true;
   }
   else

--- a/sgx/demo/src/node/demo_kmip_server.c
+++ b/sgx/demo/src/node/demo_kmip_server.c
@@ -25,9 +25,14 @@ static void demo_kmip_server_init(DemoServer * demo_server)
   // configure 'server' mode
   demo_server->tlsconn.isClient = false;
   
-  // initialize remote client information as NULL (must later re-configure)
+  // initialize all demo server's TLSPeer struct parameters as NULL
   demo_server->tlsconn.remote_host = NULL;
-  demo_server->tlsconn.remote_san = NULL;
+  demo_server->tlsconn.conn_port = NULL;
+  demo_server->tlsconn.ca_cert_path = NULL;
+  demo_server->tlsconn.local_private_key_path = NULL;
+  demo_server->tlsconn.local_cert_path = NULL;
+  demo_server->tlsconn.ctx = NULL;
+  demo_server->tlsconn.bio = NULL; 
 }
 
 /*****************************************************************************
@@ -60,20 +65,17 @@ static void demo_kmip_server_usage(const char *prog)
   fprintf(stdout,
     "\nusage: %s [options]\n\n"
     "options are:\n\n"
-    "TLS Connection Information --\n"
-    "  -k or --server-key    server (local) private key PEM file name\n"
-    "  -c or --server-cert   server (local) certificate PEM file name\n"
-    "  -N or --client-san    Subject Alternative Name (SAN) expected in\n"
-    "                        received remote client's certificate. If this\n"
-    "                        option is not specified, the host (network)\n" 
-    "                        name will be used for certificate verification\n"
-    "                        as the default behavior.\n"
-    "  -C or --ca-cert       path (file name) for the Certificate\n"
+    "Keys / Certificates (all options must be specified) --\n"
+    "  -k or --local-key     server (local) private key PEM file name\n"
+    "  -l or --local-cert    server (local) certificate PEM file name\n"
+    "  -r or --remote_cert   client (remote) certificate PEM file name\n"
+    "  -c or --ca-cert       path (file name) for the Certificate\n"
     "                        Authority's (CA's) public certificate\n"
-    "Network Information --\n"
+    "Network Information  (all options must be specified) --\n"
     "  -p or --port          port number the server will listen on\n"
     "Misc --\n"
-    "  -h or --help          help (displays this usage info)\n\n", prog);
+    "  -h or --help          help (displays this usage info and exits)\n\n",
+    prog);
 }
 
 /*****************************************************************************
@@ -89,14 +91,6 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
     exit(EXIT_SUCCESS);
   }
 
-  // validate input 'DemoServer' context struct initialization
-  if ((demo_server->tlsconn.remote_host != NULL) ||
-      (demo_server->tlsconn.remote_san != NULL))
-  {
-    kmyth_log(LOG_ERR, "'client-specific' server settings detected");
-    demo_kmip_server_error(demo_server);
-  }
-
   int options;
   int option_index = 0;
 
@@ -104,36 +98,36 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   char * server_key_path = NULL;
   char * server_cert_path = NULL;
-  char * client_san = NULL;
   char * ca_cert_path = NULL;
   char * port_string = NULL;
   bool help_flag = false;
 
   // parse command-line options, but do not yet process them
-  while ((options =
-          getopt_long(argc, argv, "c:hk:p:C:N:",
-                      demo_kmip_server_longopts, &option_index)) != -1)
+  while ((options = getopt_long(argc,
+                                argv,
+                                "c:hk:l:p:",
+                                demo_kmip_server_longopts,
+                                &option_index)) != -1)
   {
     switch (options)
     {
-    // key and certificate files
+    //specify path to file containing CA public certificate
+    case 'c':
+      ca_cert_path = optarg;
+      break;
+    // specify path to file containing server (local) private key
     case 'k':
       server_key_path = optarg;
       break;
-    case 'c':
+    // specify path to file containing server (local) public certificate
+    case 'l':
       server_cert_path = optarg;
       break;
-    case 'C':
-      ca_cert_path = optarg;
-      break;
-    case 'N':
-      client_san = optarg;
-      break;
-    // network Connection
+    // specify network (IP) port for server to listen on
     case 'p':
       port_string = optarg;
       break;
-    // Misc
+    // display help (application usage information)
     case 'h':
       help_flag = true;
       break;
@@ -158,17 +152,17 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   if (server_key_path == NULL)
   {
-    fprintf(stderr, "path for server's private key (-k) option required");
+    fprintf(stderr, "server's private key path (-k) option required");
     invalid_options = true;
   }
   else
   {
-    demo_server->tlsconn.local_key_path = strdup(server_key_path);
+    demo_server->tlsconn.local_private_key_path = strdup(server_key_path);
   }
 
   if (server_cert_path == NULL)
   {
-    fprintf(stderr, "path for server's public cert (-c) option required");
+    fprintf(stderr, "server's public cert path (-l) option required");
     invalid_options = true;
   }
   else
@@ -184,11 +178,6 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
   else
   {
     demo_server->tlsconn.conn_port = strdup(port_string);
-  }
-
-  if (client_san != NULL)
-  {
-    demo_server->tlsconn.remote_san = strdup(client_san);
   }
 
   // consolidated error exit point => all detected invalid options first logged

--- a/sgx/demo/src/node/demo_kmip_server.c
+++ b/sgx/demo/src/node/demo_kmip_server.c
@@ -22,15 +22,12 @@ static void demo_kmip_server_init(DemoServer * demo_server)
 {
   secure_memset(demo_server, 0, sizeof(DemoServer));
 
-  // specify 'server' mode TLS parameters
-  //   - isClient boolean is initialized to false to indicate 'server' mode
-  //   - a hostname or IP address and functional name are not needed by the
-  //     server to construct a DNS name for validating the certificate
-  //     supplied by a connecting client - initialized to NULL pointers
-  //     (server-side checks validate only the CA-chain of the client cert)
+  // configure 'server' mode
   demo_server->tlsconn.isClient = false;
-  demo_server->tlsconn.remote_server = NULL;
-  demo_server->tlsconn.remote_server_func = NULL;
+  
+  // initialize remote client information as NULL (must later re-configure)
+  demo_server->tlsconn.remote_host = NULL;
+  demo_server->tlsconn.remote_san = NULL;
 }
 
 /*****************************************************************************
@@ -64,13 +61,19 @@ static void demo_kmip_server_usage(const char *prog)
     "\nusage: %s [options]\n\n"
     "options are:\n\n"
     "TLS Connection Information --\n"
-    "  -k or --key      Local server private key PEM file name\n"
-    "  -c or --cert     Local server certificate PEM file name\n"
-    "  -C or --ca       Certification Authority (CA) certificate file name"
+    "  -k or --server-key    server (local) private key PEM file name\n"
+    "  -c or --server-cert   server (local) certificate PEM file name\n"
+    "  -N or --client-san    Subject Alternative Name (SAN) expected in\n"
+    "                        received remote client's certificate. If this\n"
+    "                        option is not specified, the host (network)\n" 
+    "                        name will be used for certificate verification\n"
+    "                        as the default behavior.\n"
+    "  -C or --ca-cert       path (file name) for the Certificate\n"
+    "                        Authority's (CA's) public certificate\n"
     "Network Information --\n"
-    "  -p or --port     The port number the server will listen on\n"
+    "  -p or --port          port number the server will listen on\n"
     "Misc --\n"
-    "  -h or --help     Help (displays this usage)\n\n", prog);
+    "  -h or --help          help (displays this usage info)\n\n", prog);
 }
 
 /*****************************************************************************
@@ -86,9 +89,9 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
     exit(EXIT_SUCCESS);
   }
 
-  // validate input 'DemoServer' context struct configuration
-  if ((demo_server->tlsconn.remote_server != NULL) ||
-      (demo_server->tlsconn.remote_server_func != NULL))
+  // validate input 'DemoServer' context struct initialization
+  if ((demo_server->tlsconn.remote_host != NULL) ||
+      (demo_server->tlsconn.remote_san != NULL))
   {
     kmyth_log(LOG_ERR, "'client-specific' server settings detected");
     demo_kmip_server_error(demo_server);
@@ -101,13 +104,14 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
 
   char * server_key_path = NULL;
   char * server_cert_path = NULL;
+  char * client_san = NULL;
   char * ca_cert_path = NULL;
   char * port_string = NULL;
   bool help_flag = false;
 
   // parse command-line options, but do not yet process them
   while ((options =
-          getopt_long(argc, argv, "k:c:C:p:h",
+          getopt_long(argc, argv, "c:hk:p:C:N:",
                       demo_kmip_server_longopts, &option_index)) != -1)
   {
     switch (options)
@@ -121,6 +125,9 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
       break;
     case 'C':
       ca_cert_path = optarg;
+      break;
+    case 'N':
+      client_san = optarg;
       break;
     // network Connection
     case 'p':
@@ -177,6 +184,11 @@ static void demo_kmip_server_get_options(DemoServer * demo_server,
   else
   {
     demo_server->tlsconn.conn_port = strdup(port_string);
+  }
+
+  if (client_san != NULL)
+  {
+    demo_server->tlsconn.remote_san = strdup(client_san);
   }
 
   // consolidated error exit point => all detected invalid options first logged

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -59,33 +59,33 @@ static void proxy_usage(const char *prog)
     "\nusage: %s [options]\n\n"
     "options are:\n\n"
     "ECDH Connection Information --\n"
-    "  -p or --ecdh-server-port  port number proxy will listen on for\n"
+    "  -p or --ecdh-port         port number proxy will listen on for\n"
     "                            ECDH client connections\n"
-    "  -k or --ecdh-server-key   private key PEM file name for proxy's\n"
-    "                            ECDH server role\n"
-    "  -c or --ecdh-server-cert  X509 certificate PEM file name for\n"
-    "                            proxy's ECDH server role"
-    "  -u or --ecdh-client-cert  X509 public cert PEM file name for\n"
-    "                            ECDH client connecting to proxy\n"
+    "  -k or --ecdh-local-key    private key PEM file name (path)\n"
+    "                            for proxy's local ECDH server role\n"
+    "  -l or --ecdh-local-cert   X509 certificate PEM file name (path)\n"
+    "                            for proxy's local ECDH server role"
+    "  -r or --ecdh-remote-cert  X509 public cert PEM file name (path)\n"
+    "                            for remote ECDH client connecting to proxy\n"
     "TLS Connection Information --\n"
-    "  -I or --tls-server-host   network name (IP address or hostname) of\n"
-    "                            the remote server for the TLS connection\n"
-    "  -N or --tls-server-san    Subject Alternative Name (SAN) expected in\n"
-    "                            received remote server's certificate. If\n"
-    "                            this option is not specified, the host\n"
-    "                            (network) name will be used for certificate\n"
-    "                            verification as the default behavior.\n"
-    "  -P or --tls-server-port   port number to use when connecting to the remote TLS server\n"
-    "  -R or --tls_client-key    private key PEM file name for proxy's TLS client role\n"
-    "  -U or --tls-client-cert   X509 certificate PEM file name for proxy's TLS client role\n"
+    "  -P or --tls-port          port number for proxy to use\n"
+    "                            when connecting to the remote TLS server\n"
+    "  -K or --tls-local-key     private key PEM file name (path)\n"
+    "                            for proxy's local TLS client role\n"
+    "  -L or --tls-local-cert    X509 certificate PEM file name (path)\n"
+    "                            for proxy's local TLS client role\n"
+    "  -R or --tls-remote-host   network name for remote TLS server\n"
     "Certificate Authority (CA) Information --\n"
-    "  -C or --ca-path           CA certificate file used to verify the remote TLS server\n"
-    "                            (if not specified, the default system CA chain will be used instead)\n"
+    "  -c or --ca-path           X509 public certificate PEM file name (path)\n"
+    "                            for CA, if not specified, default system\n"
+    "                            CA chain will be used\n"
     "Test Options --\n"
-    "  -m or --maxconn           number of connections the server will accept before exiting\n"
-    "                            (unlimited by default, or if the value is not a positive integer)\n"
+    "  -m or --maxconn           number of ECDH connections the proxy will\n"
+    "                            accept before exiting (unlimited by default,\n"
+    "                            or if supplied value not positive integer)\n"
     "Misc --\n"
-    "  -h or --help     Help (displays this usage).\n\n", prog);
+    "  -h or --help              Help (displays this proxy usage info)\n\n",
+                                 prog);
 }
 
 /*****************************************************************************
@@ -93,8 +93,6 @@ static void proxy_usage(const char *prog)
  ****************************************************************************/
 static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
 {
-  int ret = -1;
-
   // Exit early if there are no arguments.
   if (1 == argc)
   {
@@ -106,74 +104,67 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
   int option_index = 0;
 
   while ((options =
-          getopt_long(argc, argv, "c:hk:m:p:u:C:I:N:P:R:U:",
+          getopt_long(argc, argv, "c:hk:l:m:p:r:K:L:P:R:",
                       proxy_longopts, &option_index)) != -1)
   {
     switch (options)
-   {
-    //  load public certificate for proxy's ECDH server role (remote verify key)
+  {
+    // configure file name for Certificate Authority (CA) certificate
     case 'c':
-      ret = demo_ecdh_load_local_sign_cert(&(proxy->ecdhconn), optarg);
-      if (ret != EXIT_SUCCESS)
-      {
-        fprintf(stderr, "invalid ECDH server certificate path: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
+      proxy->tlsconn.ca_cert_path = strdup(optarg);
       break;
+
     // display command-line option "help" information for the user
     case 'h':
       proxy_usage(argv[0]);
       exit(EXIT_SUCCESS);
       break;
-    // load private key for proxy's ECDH server role (local sign key)
+
+    // configure file name for proxy's ECDH server role local private key
     case 'k':
-      // load proxy's ECDH server private key needed to sign messages of server-side origin
-      ret = demo_ecdh_load_local_sign_key(&(proxy->ecdhconn), optarg);
-      if (ret != EXIT_SUCCESS)
-      {
-        fprintf(stderr, "invalid ECDH server signature key path: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
+      proxy->ecdhconn.config.local_private_key_path = strdup(optarg);
       break;
+
+    // configure file name for proxy's ECDH server role public certificate
+    case 'l':
+      proxy->ecdhconn.config.local_cert_path = strdup(optarg);
+      break;
+
     // set session count limit for proxy (default is unlimited)
     case 'm':
       proxy->ecdhconn.config.session_limit = atoi(optarg);
       break;
+
     // configure port string for proxy's ECDH interface
     case 'p':
       proxy->ecdhconn.config.port = strdup(optarg);
       break;
-    // load public certificate for remote ECDH client (local verify key)
-    case 'u':
-      ret = demo_ecdh_load_remote_sign_cert(&(proxy->ecdhconn), optarg);
-      if (ret != EXIT_SUCCESS)
-      {
-        fprintf(stderr, "invalid ECDH remote client cert path: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
+
+    //  configure file name for remote ECDH client public certificate
+    case 'r':
+      proxy->ecdhconn.config.remote_cert_path = strdup(optarg);
       break;
-     // configure file name for Certificate Authority (CA) certificate
-     case 'C':
-      proxy->tlsconn.ca_cert_path = strdup(optarg);
+
+    // configure file name for proxy's TLS client role private key 
+    case 'K':
+      proxy->tlsconn.local_private_key_path = strdup(optarg);
       break;
-    // configure TLS remote server host name/IP string
-    case 'I':
-      proxy->tlsconn.remote_host = strdup(optarg);
+
+    // configure file name for proxy's TLS client role public certificate 
+    case 'L':
+      proxy->tlsconn.local_cert_path = strdup(optarg);
       break;
-    // configure SAN for remote server certificate validation
-    case 'N':
-      proxy->tlsconn.remote_san = strdup(optarg);
-      break;
-    // configure port string for proxy's TLS interface
+
+    // configure TLS port string for proxy (remote server listen port)
     case 'P':
       proxy->tlsconn.conn_port = strdup(optarg);
       break;
+
+    // configure file name for remote TLS server public certificate 
     case 'R':
-      proxy->tlsconn.local_key_path = strdup(optarg);
+      proxy->tlsconn.remote_host = strdup(optarg);
       break;
-    case 'U':
-      proxy->tlsconn.local_cert_path = strdup(optarg);
-      break;
+
     default:
       proxy_error(proxy);
     }
@@ -185,19 +176,33 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
  ****************************************************************************/
 static void proxy_check_options(TLSProxy * proxy)
 {
+  // check that required ECDH interface options were specified
   demo_ecdh_check_options(&(proxy->ecdhconn.config));
 
+  // check that required TLS interface options were specified 
   bool err = false;
 
-  if (proxy->tlsconn.remote_host == NULL)
+  if (proxy->tlsconn.local_private_key_path == NULL)
   {
-    fprintf(stderr, "missing remote server host name/IP string (-I) option");
+    fprintf(stderr, "missing TLS local private key file path (-K) option");
+    err = true;
+  }
+
+  if (proxy->tlsconn.local_cert_path == NULL)
+  {
+    fprintf(stderr, "missing TLS local public cert file path (-L) option");
     err = true;
   }
 
   if (proxy->tlsconn.conn_port == NULL)
   {
-    fprintf(stderr, "missing TLS connection port number (-P) argument");
+    fprintf(stderr, "missing TLS connection port number (-P) option");
+    err = true;
+  }
+
+  if (proxy->tlsconn.remote_host == NULL)
+  {
+    fprintf(stderr, "missing TLS remote server host name (-R) option");
     err = true;
   }
 
@@ -235,6 +240,32 @@ static int proxy_create_tls_client(TLSProxy * proxy)
 static int proxy_create_ecdh_server(TLSProxy * proxy)
 {
   ECDHPeer *ecdh_svr = &(proxy->ecdhconn);
+  int ret = -1;
+
+  // load proxy's ECDH server private key
+  // (needed to sign messages of server-side origin)
+  ret = demo_ecdh_load_local_private_key(ecdh_svr);
+  if (ret != EXIT_SUCCESS)
+  {
+    kmyth_log(LOG_ERR, "error loading proxy's ECDH server signature key");
+    exit(EXIT_FAILURE);
+  }
+
+  // load proxy's ECDH server public certificate
+  ret = demo_ecdh_load_local_cert(ecdh_svr);
+  if (ret != EXIT_SUCCESS)
+  {
+    kmyth_log(LOG_ERR, "error loading proxy's ECDH server certificate");
+    exit(EXIT_FAILURE);
+  }
+
+  // load remote ECDH client's public certificate
+  ret = demo_ecdh_load_remote_cert(ecdh_svr);
+  if (ret != EXIT_SUCCESS)
+  {
+    kmyth_log(LOG_ERR, "error loading ECDH remote client certificate");
+    exit(EXIT_FAILURE);
+  }
 
   ecdh_svr->config.listen_socket_fd = UNSET_FD;
 
@@ -380,7 +411,7 @@ static int proxy_send_key_response_message(TLSProxy * proxy)
   ByteBuffer *kmip_resp = &(ecdh_svr->session.proto.kmip_response);
   ECDHMessage *key_resp = &(ecdh_svr->session.proto.key_response);
 
-  ret = compose_key_response_msg(ecdh_svr->config.local_sign_key,
+  ret = compose_key_response_msg(ecdh_svr->config.local_private_key,
                                  &(ecdh_svr->session.response_symkey),
                                  kmip_resp,
                                  key_resp);

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -284,19 +284,19 @@ static int proxy_create_ecdh_server(TLSProxy * proxy)
     return EXIT_FAILURE;
   }
 
-  kmyth_log(LOG_DEBUG, "setting up server socket on port %s",
+  kmyth_log(LOG_DEBUG, "setting up ECDH server socket on port %s",
                        ecdh_svr->config.port);
   if (setup_server_socket(ecdh_svr->config.port,
                          &(ecdh_svr->config.listen_socket_fd)))
   {
-    kmyth_log(LOG_ERR, "failed to setup server socket on port %s",
+    kmyth_log(LOG_ERR, "failed to ECDH setup server socket on port %s",
                        ecdh_svr->config.port);
     return EXIT_FAILURE;
   }
 
   if (listen(ecdh_svr->config.listen_socket_fd, 1))
   {
-    kmyth_log(LOG_ERR, "server socket listen (for client connection) failed");
+    kmyth_log(LOG_ERR, "ECDH server socket listen failed");
     close(ecdh_svr->config.listen_socket_fd);
     return EXIT_FAILURE;
   }

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -60,7 +60,7 @@ static void proxy_usage(const char *prog)
     "options are:\n\n"
     "ECDH Connection Information --\n"
     "  -p or --ecdh-server-port  port number proxy will listen on for\n"
-    "                            ECDH connections.\n"
+    "                            ECDH client connections\n"
     "  -k or --ecdh-server-key   private key PEM file name for proxy's\n"
     "                            ECDH server role\n"
     "  -c or --ecdh-server-cert  X509 certificate PEM file name for\n"

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -116,7 +116,7 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
       ret = demo_ecdh_load_local_sign_cert(&(proxy->ecdhconn), optarg);
       if (ret != EXIT_SUCCESS)
       {
-        fprintf(stdout, "invalid ECDH server certificate path: %s\n", optarg);
+        fprintf(stderr, "invalid ECDH server certificate path: %s\n", optarg);
         exit(EXIT_FAILURE);
       }
       break;
@@ -131,74 +131,48 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
       ret = demo_ecdh_load_local_sign_key(&(proxy->ecdhconn), optarg);
       if (ret != EXIT_SUCCESS)
       {
-        fprintf(stdout, "invalid ECDH server signature key path: %s\n", optarg);
+        fprintf(stderr, "invalid ECDH server signature key path: %s\n", optarg);
         exit(EXIT_FAILURE);
       }
       break;
     // set session count limit for proxy (default is unlimited)
     case 'm':
       proxy->ecdhconn.config.session_limit = atoi(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: proxy session limit = %d",
-                proxy->ecdhconn.config.session_limit);
       break;
     // configure port string for proxy's ECDH interface
     case 'p':
       proxy->ecdhconn.config.port = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: ECDH interface port = %s",
-                proxy->ecdhconn.config.port);
       break;
     // load public certificate for remote ECDH client (local verify key)
     case 'u':
       ret = demo_ecdh_load_remote_sign_cert(&(proxy->ecdhconn), optarg);
       if (ret != EXIT_SUCCESS)
       {
-        fprintf(stdout,
-                "invalid remote (ECDH client) certificate path: %s\n",
-                optarg);
+        fprintf(stderr, "invalid ECDH remote client cert path: %s\n", optarg);
         exit(EXIT_FAILURE);
       }
       break;
      // configure file name for Certificate Authority (CA) certificate
      case 'C':
       proxy->tlsconn.ca_cert_path = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: CA certificate path = %s",
-                proxy->tlsconn.ca_cert_path);
       break;
-    // configure TLS server host string
+    // configure TLS remote server host name/IP string
     case 'I':
       proxy->tlsconn.remote_host = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: TLS (remote server) host = %s",
-                proxy->tlsconn.remote_host);
       break;
     // configure SAN for remote server certificate validation
     case 'N':
       proxy->tlsconn.remote_san = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: TLS (remote server) SAN = %s",
-                proxy->tlsconn.remote_san);
       break;
     // configure port string for proxy's TLS interface
     case 'P':
       proxy->tlsconn.conn_port = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: ECDH interface port = %s",
-                proxy->tlsconn.conn_port);
       break;
     case 'R':
       proxy->tlsconn.local_key_path = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: TLS (local client) private key path = %s",
-                proxy->tlsconn.local_key_path);
       break;
     case 'U':
       proxy->tlsconn.local_cert_path = strdup(optarg);
-      kmyth_log(LOG_DEBUG,
-                "option: TLS (local client) public cert path = %s",
-                proxy->tlsconn.local_cert_path);
       break;
     default:
       proxy_error(proxy);
@@ -217,26 +191,19 @@ static void proxy_check_options(TLSProxy * proxy)
 
   if (proxy->tlsconn.remote_host == NULL)
   {
-    kmyth_log(LOG_ERR, "remote server host string (-I) is required");
+    fprintf(stderr, "missing remote server host name/IP string (-I) option");
     err = true;
   }
 
   if (proxy->tlsconn.conn_port == NULL)
   {
-    kmyth_log(LOG_ERR, "TLS connection port number argument (-P) is required");
+    fprintf(stderr, "missing TLS connection port number (-P) argument");
     err = true;
   }
 
   if (err)
   {
     proxy_error(proxy);
-  }
-
-  // default remote certificate "name" criteria (if not specified by user)
-  if (proxy->tlsconn.remote_san == NULL)
-  {
-    proxy->tlsconn.remote_san = proxy->tlsconn.remote_host;
-    kmyth_log(LOG_DEBUG, "no SAN specified for remote host");
   }
 }
 
@@ -635,11 +602,9 @@ int main(int argc, char **argv)
   set_applog_severity_threshold(DEMO_LOG_LEVEL);
   set_applog_output_mode(0);
 
-  kmyth_log(LOG_DEBUG, "starting proxy ...");
-
   proxy_init(&proxy);
 
-  // apply and validate command-line options
+  // parse and validate command-line options
   proxy_get_options(&proxy, argc, argv);
   proxy_check_options(&proxy);
 
@@ -649,7 +614,6 @@ int main(int argc, char **argv)
     kmyth_log(LOG_ERR, "failed to setup proxy's TLS client interface");
     proxy_error(&proxy);
   }
-  kmyth_log(LOG_DEBUG, "finished setting up proxy's TLS client interface");
 
   // setup proxy's ECDH server interface
   if (EXIT_SUCCESS != proxy_create_ecdh_server(&proxy))

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -59,33 +59,31 @@ static void proxy_usage(const char *prog)
     "\nusage: %s [options]\n\n"
     "options are:\n\n"
     "ECDH Connection Information --\n"
-    "  -p or --local-port      The port number to listen on for ECDH connections.\n"
-    "  -r or --private         Local private key PEM file used for ECDH connections.\n"
-    "  -u or --public          Remote public cert PEM file used to validate ECDH connections.\n"
+    "  -p or --ecdh-server-port  port number proxy will listen on for\n"
+    "                            ECDH connections.\n"
+    "  -k or --ecdh-server-key   private key PEM file name for proxy's\n"
+    "                            ECDH server role\n"
+    "  -c or --ecdh-server-cert  X509 certificate PEM file name for\n"
+    "                            proxy's ECDH server role"
+    "  -u or --ecdh-client-cert  X509 public cert PEM file name for\n"
+    "                            ECDH client connecting to proxy\n"
     "TLS Connection Information --\n"
-    "  -I or --remote-ip       The IP address or hostname of the remote server\n"
-    "                          (i.e., address/name used for network connection)\n"
-    "  -N or --remote-name     In some cases, the server that the proxy connects to may\n"
-    "                          reside on the same network node. In order to better\n"
-    "                          differentiate endpoints, an additional 'functional name'\n"
-    "                          can be specified for the remote server. This proxy\n"
-    "                          implements the convention of concatenating the network\n"
-    "                          address/name with this 'functional name' using a 'dot'\n"
-    "                          delimiter (<IP address or hostname>.<functional name>)\n"
-    "                          and using that extended name for certificate validation.\n"
-    "                          If no 'functional name' is specified, the address/name\n"
-    "                          value specified with the '-I' (--remote-ip) option is used\n"
-    "                          directly for server certificate verification.\n"
-    "                            Note: the remote server's certificate must use, or\n"
-    "                                  define as a Subject Alternate Name (SAN), the\n"
-    "                                  configured certificate verification name\n"
-    "  -P or --remote-port     The port number to use when connecting to the remote server\n"
-    "  -C or --ca-path         Optional CA certificate file used to verify the remote server\n"
-    "                          (if not specified, the default system CA chain will be used instead)\n"
-    "  -R or --client-key      Local (client) private key (for TLS connection) PEM file name\n"
-    "  -U or --client-cert     Local (client) certificate (for TLS connection) PEM file name\n"
+    "  -I or --tls-server-host   network name (IP address or hostname) of\n"
+    "                            the remote server for the TLS connection\n"
+    "  -N or --tls-server-san    Subject Alternative Name (SAN) expected in\n"
+    "                            received remote server's certificate. If\n"
+    "                            this option is not specified, the host\n"
+    "                            (network) name will be used for certificate\n"
+    "                            verification as the default behavior.\n"
+    "  -P or --tls-server-port   port number to use when connecting to the remote TLS server\n"
+    "  -R or --tls_client-key    private key PEM file name for proxy's TLS client role\n"
+    "  -U or --tls-client-cert   X509 certificate PEM file name for proxy's TLS client role\n"
+    "Certificate Authority (CA) Information --\n"
+    "  -C or --ca-path           CA certificate file used to verify the remote TLS server\n"
+    "                            (if not specified, the default system CA chain will be used instead)\n"
     "Test Options --\n"
-    "  -m or --maxconn  The number of connections the server will accept before exiting (unlimited by default, or if the value is not a positive integer).\n"
+    "  -m or --maxconn           number of connections the server will accept before exiting\n"
+    "                            (unlimited by default, or if the value is not a positive integer)\n"
     "Misc --\n"
     "  -h or --help     Help (displays this usage).\n\n", prog);
 }
@@ -108,72 +106,100 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
   int option_index = 0;
 
   while ((options =
-          getopt_long(argc, argv, "r:c:u:p:I:N:P:C:R:U:m:h",
+          getopt_long(argc, argv, "c:h:k:m:p:u:C:I:N:P:R:U:",
                       proxy_longopts, &option_index)) != -1)
   {
     switch (options)
-    {
-    // Key files
-    case 'r':
-      // load proxy (server) key needed to sign messages of server-side origin
-      ret = demo_ecdh_load_local_sign_key(&(proxy->ecdhconn), optarg);
-      if (ret != EXIT_SUCCESS)
-      {
-        fprintf(stdout, "invalid local signature key path: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
-      break;
+   {
+    //  load public certificate for proxy's ECDH server role (remote verify key)
     case 'c':
-      // load proxy (server) certificate containing proxy identity information
       ret = demo_ecdh_load_local_sign_cert(&(proxy->ecdhconn), optarg);
       if (ret != EXIT_SUCCESS)
       {
-        fprintf(stdout, "invalid local certificate path: %s\n", optarg);
+        fprintf(stdout, "invalid ECDH server certificate path: %s\n", optarg);
         exit(EXIT_FAILURE);
       }
       break;
-    case 'u':
-      // load client certificate containing:
-      //     - client's identity information (X509 subject name)
-      //     - public key needed to verfiy messages received from client
-      ret = demo_ecdh_load_remote_sign_cert(&(proxy->ecdhconn), optarg);
-      if (ret != EXIT_SUCCESS)
-      {
-        fprintf(stdout, "invalid remote (peer) certificate path: %s\n", optarg);
-        exit(EXIT_FAILURE);
-      }
-      break;
-    // ECDH Connection
-    case 'p':
-      proxy->ecdhconn.config.port = strdup(optarg);
-      break;
-    // TLS Connection
-    case 'I':
-      proxy->tlsconn.remote_server = strdup(optarg);
-      break;
-    case 'N':
-      proxy->tlsconn.remote_server_func = strdup(optarg);
-      break;
-    case 'P':
-      proxy->tlsconn.conn_port = strdup(optarg);
-      break;
-    case 'C':
-      proxy->tlsconn.ca_cert_path = strdup(optarg);
-      break;
-    case 'R':
-      proxy->tlsconn.local_key_path = strdup(optarg);
-      break;
-    case 'U':
-      proxy->tlsconn.local_cert_path = strdup(optarg);
-      break;
-    // Test
-    case 'm':
-      proxy->ecdhconn.config.session_limit = atoi(optarg);
-      break;
-    // Misc
+    // display command-line option "help" information for the user
     case 'h':
       proxy_usage(argv[0]);
       exit(EXIT_SUCCESS);
+      break;
+    // load private key for proxy's ECDH server role (local sign key)
+    case 'k':
+      // load proxy's ECDH server private key needed to sign messages of server-side origin
+      ret = demo_ecdh_load_local_sign_key(&(proxy->ecdhconn), optarg);
+      if (ret != EXIT_SUCCESS)
+      {
+        fprintf(stdout, "invalid ECDH server signature key path: %s\n", optarg);
+        exit(EXIT_FAILURE);
+      }
+      break;
+    // set session count limit for proxy (default is unlimited)
+    case 'm':
+      proxy->ecdhconn.config.session_limit = atoi(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: proxy session limit = %d",
+                proxy->ecdhconn.config.session_limit);
+      break;
+    // configure port string for proxy's ECDH interface
+    case 'p':
+      proxy->ecdhconn.config.port = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: ECDH interface port = %s",
+                proxy->ecdhconn.config.port);
+      break;
+    // load public certificate for remote ECDH client (local verify key)
+    case 'u':
+      ret = demo_ecdh_load_remote_sign_cert(&(proxy->ecdhconn), optarg);
+      if (ret != EXIT_SUCCESS)
+      {
+        fprintf(stdout,
+                "invalid remote (ECDH client) certificate path: %s\n",
+                optarg);
+        exit(EXIT_FAILURE);
+      }
+      break;
+     // configure file name for Certificate Authority (CA) certificate
+     case 'C':
+      proxy->tlsconn.ca_cert_path = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: CA certificate path = %s",
+                proxy->tlsconn.ca_cert_path);
+      break;
+    // configure TLS server host string
+    case 'I':
+      proxy->tlsconn.remote_host = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: TLS (remote server) host = %s",
+                proxy->tlsconn.remote_host);
+      break;
+    // configure SAN for remote server certificate validation
+    case 'N':
+      proxy->tlsconn.remote_san = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: TLS (remote server) SAN = %s",
+                proxy->tlsconn.remote_san);
+      break;
+    // configure port string for proxy's TLS interface
+    case 'P':
+      proxy->tlsconn.conn_port = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: ECDH interface port = %s",
+                proxy->tlsconn.conn_port);
+      break;
+    case 'R':
+      proxy->tlsconn.local_key_path = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: TLS (local client) private key path = %s",
+                proxy->tlsconn.local_key_path);
+      break;
+    case 'U':
+      proxy->tlsconn.local_cert_path = strdup(optarg);
+      kmyth_log(LOG_DEBUG,
+                "option: TLS (local client) public cert path = %s",
+                proxy->tlsconn.local_cert_path);
+      break;
     default:
       proxy_error(proxy);
     }
@@ -189,20 +215,28 @@ static void proxy_check_options(TLSProxy * proxy)
 
   bool err = false;
 
-  if (proxy->tlsconn.remote_server == NULL)
+  if (proxy->tlsconn.remote_host == NULL)
   {
-    fprintf(stderr, "remote server IP or hostname arg (-I) is required.\n");
+    kmyth_log(LOG_ERR, "remote server host string (-I) is required");
     err = true;
   }
+
   if (proxy->tlsconn.conn_port == NULL)
   {
-    fprintf(stderr, "TLS connection port number argument (-P) is required.\n");
+    kmyth_log(LOG_ERR, "TLS connection port number argument (-P) is required");
     err = true;
   }
+
   if (err)
   {
-    kmyth_log(LOG_ERR, "Invalid command-line arguments.");
     proxy_error(proxy);
+  }
+
+  // default remote certificate "name" criteria (if not specified by user)
+  if (proxy->tlsconn.remote_san == NULL)
+  {
+    proxy->tlsconn.remote_san = proxy->tlsconn.remote_host;
+    kmyth_log(LOG_DEBUG, "no SAN specified for remote host");
   }
 }
 
@@ -615,6 +649,7 @@ int main(int argc, char **argv)
     kmyth_log(LOG_ERR, "failed to setup proxy's TLS client interface");
     proxy_error(&proxy);
   }
+  kmyth_log(LOG_DEBUG, "finished setting up proxy's TLS client interface");
 
   // setup proxy's ECDH server interface
   if (EXIT_SUCCESS != proxy_create_ecdh_server(&proxy))

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -106,7 +106,7 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
   int option_index = 0;
 
   while ((options =
-          getopt_long(argc, argv, "c:h:k:m:p:u:C:I:N:P:R:U:",
+          getopt_long(argc, argv, "c:hk:m:p:u:C:I:N:P:R:U:",
                       proxy_longopts, &option_index)) != -1)
   {
     switch (options)

--- a/sgx/demo/src/node/tls_proxy.c
+++ b/sgx/demo/src/node/tls_proxy.c
@@ -160,9 +160,9 @@ static void proxy_get_options(TLSProxy * proxy, int argc, char **argv)
       proxy->tlsconn.conn_port = strdup(optarg);
       break;
 
-    // configure file name for remote TLS server public certificate 
+    // configure IP address string for remote TLS server
     case 'R':
-      proxy->tlsconn.remote_host = strdup(optarg);
+      proxy->tlsconn.remote_addr = strdup(optarg);
       break;
 
     default:
@@ -200,9 +200,9 @@ static void proxy_check_options(TLSProxy * proxy)
     err = true;
   }
 
-  if (proxy->tlsconn.remote_host == NULL)
+  if (proxy->tlsconn.remote_addr == NULL)
   {
-    fprintf(stderr, "missing TLS remote server host name (-R) option");
+    fprintf(stderr, "missing TLS remote server IP address (-R) option");
     err = true;
   }
 

--- a/sgx/demo/src/util/demo_ecdh_util.c
+++ b/sgx/demo/src/util/demo_ecdh_util.c
@@ -35,17 +35,17 @@ void demo_ecdh_cleanup(ECDHPeer * ecdhconn)
   }
 
   // clear and/or free memory for loaded keys and certs
-  if (ecdhconn->config.local_sign_key != NULL)
+  if (ecdhconn->config.local_private_key != NULL)
   {
-    EVP_PKEY_free(ecdhconn->config.local_sign_key);
+    EVP_PKEY_free(ecdhconn->config.local_private_key);
   }
-  if (ecdhconn->config.local_sign_cert != NULL)
+  if (ecdhconn->config.local_cert != NULL)
   {
-    X509_free(ecdhconn->config.local_sign_cert);
+    X509_free(ecdhconn->config.local_cert);
   }
-  if (ecdhconn->config.remote_sign_cert != NULL)
+  if (ecdhconn->config.remote_cert != NULL)
   {
-    X509_free(ecdhconn->config.remote_sign_cert);
+    X509_free(ecdhconn->config.remote_cert);
   }
 
   // clear/free memory for 'ephemeral' session key agreement contributions
@@ -131,32 +131,30 @@ int demo_ecdh_check_options(ECDHConfig * ecdhopts)
 {
   bool err = false;
 
-  if (ecdhopts->local_sign_key == NULL)
+  if (ecdhopts->local_private_key_path == NULL)
   {
-    fprintf(stderr, "local signature key path argument (-r) is required\n");
+    fprintf(stderr, "ECDH local private key file path (-k) option required\n");
     err = true;
   }
-  if (ecdhopts->local_sign_cert == NULL)
+  
+  if (ecdhopts->local_cert_path == NULL)
   {
-    fprintf(stderr, "local cert path argument (-c) is required\n");
+    fprintf(stderr, "ECDH local cert file path (-l) option required\n");
     err = true;
   }
-  if (ecdhopts->remote_sign_cert == NULL)
-  {
-    fprintf(stderr, "remote cert path argument (-u) is required\n");
-    err = true;
-  }
+  
   if (ecdhopts->port == NULL)
   {
-    fprintf(stderr, "port number argument (-p) is required\n");
+    fprintf(stderr, "proxy's ECDH server port number (-p) option required\n");
     err = true;
   }
-  if (ecdhopts->isClient && ecdhopts->ip == NULL)
+  
+  if (ecdhopts->remote_cert_path == NULL)
   {
-    fprintf(stderr, "IP address argument (-i) is required in client mode\n");
+    fprintf(stderr, "ECDH remote cert file path (-r) option required\n");
     err = true;
   }
-
+  
   if (err)
   {
     kmyth_log(LOG_ERR, "invalid command-line arguments");
@@ -167,98 +165,102 @@ int demo_ecdh_check_options(ECDHConfig * ecdhopts)
 }
 
 /*****************************************************************************
- * demo_ecdh_load_local_sign_key()
+ * demo_ecdh_load_local_private_key()
  ****************************************************************************/
-int demo_ecdh_load_local_sign_key(ECDHPeer * ecdhconn,
-                                  char * local_sign_key_path)
+int demo_ecdh_load_local_private_key(ECDHPeer * ecdhconn)
 {
-  // read  elliptic curve private signing key from file (.pem formatted)
-  BIO *priv_key_bio = BIO_new_file(local_sign_key_path, "r");
+  // read  elliptic curve private key from file (.pem formatted)
+  BIO *priv_bio = BIO_new_file(ecdhconn->config.local_private_key_path, "r");
 
-  if (priv_key_bio == NULL)
+  if (priv_bio == NULL)
   {
     kmyth_log(LOG_ERR, "BIO association with file (%s) failed",
-                       local_sign_key_path);
+                       ecdhconn->config.local_private_key_path);
     return EXIT_FAILURE;
   }
 
-  ecdhconn->config.local_sign_key = PEM_read_bio_PrivateKey(priv_key_bio,
-                                                            NULL, 0, NULL);
+  ecdhconn->config.local_private_key = PEM_read_bio_PrivateKey(priv_bio,
+                                                               NULL,
+                                                               0,
+                                                               NULL);
 
-  BIO_free(priv_key_bio);
-  priv_key_bio = NULL;
+  BIO_free(priv_bio);
+  priv_bio = NULL;
 
-  if (!ecdhconn->config.local_sign_key)
+  if (!ecdhconn->config.local_private_key)
   {
     kmyth_log(LOG_ERR, "elliptic curve key PEM file (%s) read failed",
-                       local_sign_key_path);
+                       ecdhconn->config.local_private_key_path);
     return EXIT_FAILURE;
   }
 
   kmyth_log(LOG_DEBUG, "loaded local private signing key from file (%s)",
-                       local_sign_key_path);
+                       ecdhconn->config.local_private_key_path);
 
   return EXIT_SUCCESS;
 }
 
 /*****************************************************************************
- * demo_ecdh_load_local_sign_cert()
+ * demo_ecdh_load_local_cert()
  ****************************************************************************/
-int demo_ecdh_load_local_sign_cert(ECDHPeer * ecdhconn,
-                                   char * local_sign_cert_path)
+int demo_ecdh_load_local_cert(ECDHPeer * ecdhconn)
 {
   // read  elliptic curve private signing key from file (.pem formatted)
-  BIO *cert_bio = BIO_new_file(local_sign_cert_path, "r");
+  BIO *cert_bio = BIO_new_file(ecdhconn->config.local_cert_path, "r");
 
   if (cert_bio == NULL)
   {
     kmyth_log(LOG_ERR, "BIO association with file (%s) failed",
-                       local_sign_cert_path);
+                       ecdhconn->config.local_cert_path);
     return EXIT_FAILURE;
   }
 
-  ecdhconn->config.local_sign_cert = PEM_read_bio_X509(cert_bio,
-                                                       NULL, 0, NULL);
+  ecdhconn->config.local_cert = PEM_read_bio_X509(cert_bio,
+                                                  NULL,
+                                                  0,
+                                                  NULL);
   BIO_free(cert_bio);
   cert_bio = NULL;
-  if (!ecdhconn->config.local_sign_cert)
+  if (!ecdhconn->config.local_cert)
   {
     kmyth_log(LOG_ERR, "elliptic curve X509 PEM file (%s) read failed",
-                       local_sign_cert_path);
+                       ecdhconn->config.local_cert_path);
     return EXIT_FAILURE;
   }
 
   kmyth_log(LOG_DEBUG, "loaded local certificate from file (%s)",
-                       local_sign_cert_path);
+                       ecdhconn->config.local_cert_path);
+
   return EXIT_SUCCESS;
 }
 
 /*****************************************************************************
- * demo_ecdh_load_remote_sign_cert()
+ * demo_ecdh_load_remote_cert()
  ****************************************************************************/
-int demo_ecdh_load_remote_sign_cert(ECDHPeer * ecdhconn,
-                                    char * remote_sign_cert_path)
+int demo_ecdh_load_remote_cert(ECDHPeer * ecdhconn)
 {
   // read remote certificate (X509) from file (.pem formatted)
-  BIO *pub_cert_bio = BIO_new_file(remote_sign_cert_path, "r");
-  if (pub_cert_bio == NULL)
+  BIO *cert_bio = BIO_new_file(ecdhconn->config.remote_cert_path, "r");
+  if (cert_bio == NULL)
   {
     kmyth_log(LOG_ERR, "BIO association with file (%s) failed",
-                       remote_sign_cert_path);
+                       ecdhconn->config.remote_cert_path);
     return EXIT_FAILURE;
   }
-  ecdhconn->config.remote_sign_cert = PEM_read_bio_X509(pub_cert_bio,
-                                                        NULL, 0, NULL);
-  BIO_free(pub_cert_bio);
-  pub_cert_bio = NULL;
-  if (ecdhconn->config.remote_sign_cert == NULL)
+  ecdhconn->config.remote_cert = PEM_read_bio_X509(cert_bio,
+                                                   NULL,
+                                                   0,
+                                                   NULL);
+  BIO_free(cert_bio);
+  cert_bio = NULL;
+  if (ecdhconn->config.remote_cert == NULL)
   {
     kmyth_log(LOG_ERR, "EC Certificate PEM file (%s) read failed",
-                       remote_sign_cert_path);
+                       ecdhconn->config.remote_cert_path);
     return EXIT_FAILURE;
   }
   kmyth_log(LOG_DEBUG, "loaded remote certificate from file (%s)",
-                       remote_sign_cert_path);
+                       ecdhconn->config.remote_cert_path);
 
   return EXIT_SUCCESS;
 }
@@ -371,7 +373,7 @@ int demo_ecdh_recv_client_hello_msg(ECDHPeer * ecdh_svr)
 
   // validate 'Client Hello' message and parse out message fields
   ret = parse_client_hello_msg(msg,
-                               ecdh_svr->config.remote_sign_cert,
+                               ecdh_svr->config.remote_cert,
                                &(ecdh_svr->session.remote_eph_pubkey));
   if (ret != EXIT_SUCCESS)
   {
@@ -394,8 +396,8 @@ int demo_ecdh_send_server_hello_msg(ECDHPeer * ecdh_svr)
   ECDHMessage *msg = &(ecdh_svr->session.proto.server_hello);
 
   // compose 'Server Hello' message
-  ret = compose_server_hello_msg(ecdh_svr->config.local_sign_key,
-                                 ecdh_svr->config.local_sign_cert,
+  ret = compose_server_hello_msg(ecdh_svr->config.local_private_key,
+                                 ecdh_svr->config.local_cert,
                                  ecdh_svr->session.remote_eph_pubkey,
                                  ecdh_svr->session.local_eph_keypair,
                                  msg);
@@ -514,7 +516,7 @@ int demo_ecdh_recv_key_request_msg(ECDHPeer * ecdh_svr)
   // decrypt, validate message, and parse out 'Key Request' fields
   ByteBuffer *kmip_req = &(ecdh_svr->session.proto.kmip_request);
 
-  ret = parse_key_request_msg(ecdh_svr->config.remote_sign_cert,
+  ret = parse_key_request_msg(ecdh_svr->config.remote_cert,
                               &(ecdh_svr->session.request_symkey),
                               msg,
                               ecdh_svr->session.local_eph_keypair,

--- a/sgx/demo/src/util/demo_tls_util.c
+++ b/sgx/demo/src/util/demo_tls_util.c
@@ -34,16 +34,16 @@ void demo_tls_cleanup(TLSPeer * tlsconn)
     SSL_CTX_free(tlsconn->ctx);
   }
 
-  // clean up 'host' / 'IP' string for TLS interface
-  if (tlsconn->remote_server != NULL)
+  // clean up 'host' (hostname or IP) string for TLS interface
+  if (tlsconn->remote_host != NULL)
   {
-    free(tlsconn->remote_server);
+    free(tlsconn->remote_host);
   }
   
-  // clean up 'name' string for TLS interface
-  if (tlsconn->remote_server_func != NULL)
+  // clean up Subject Alternative Name (SAN) string for remote TLS host
+  if (tlsconn->remote_san != NULL)
   {
-    free(tlsconn->remote_server_func);
+    free(tlsconn->remote_san);
   }
 
   // clean up 'port' string for TLS interface
@@ -222,8 +222,6 @@ int demo_tls_config_ctx(TLSPeer * tlsconn)
  ****************************************************************************/
 int demo_tls_config_client_connect(TLSPeer * tls_clnt)
 {
-  kmyth_log(LOG_DEBUG, "tls_config_client_connect()");
-
   // verify that this configuration is correctly for a client connection
   if (!tls_clnt->isClient)
   {
@@ -247,71 +245,35 @@ int demo_tls_config_client_connect(TLSPeer * tls_clnt)
   }
 
   // configure server hostname settings
-  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_server))
+  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_host))
   {
     log_openssl_error("BIO_set_conn_hostname()");
     return -1;
   }
 
-  // obtain SSL BIO pointer for the TLS client BIO chain
-  SSL *ssl = NULL;
+ 
+  // if the user supplies a Subject Alternative Name (SAN) for the
+  // remote server, configure its use for certificate verification
+  if (tls_clnt->remote_san != NULL)
+  {
+    // obtain SSL BIO pointer for the TLS client BIO chain
+    SSL *ssl = NULL;
 
-  BIO_get_ssl(tls_clnt->bio, &ssl);  // internal pointer, not a new allocation
-  if (ssl == NULL)
-  {
-    log_openssl_error("BIO_get_ssl()");
-    return -1;
+    BIO_get_ssl(tls_clnt->bio, &ssl);  // internal pointer, not a new allocation
+    if (ssl == NULL)
+    {
+      log_openssl_error("BIO_get_ssl()");
+      return -1;
+    }
+ 
+    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
+    if (1 != SSL_set1_host(ssl, tls_clnt->remote_san))
+    {
+      log_openssl_error("SSL_set1_host()");
+      return -1;
+    }
+    kmyth_log(LOG_DEBUG, "set remote server SAN = %s", tls_clnt->remote_san);
   }
-
-  // compute expected server name (as specified in server's cert)
-  //   - expected to be <IP address or hostname string>.<name string>
-  //     (e.g., localhost.demoServer, 127.0.0.1.server, ...)
-  char * server_name = NULL;
-  size_t server_name_size = strlen(tls_clnt->remote_server) + 1;
-  if (tls_clnt->remote_server_func != NULL)
-  {
-    server_name_size += (strlen(tls_clnt->remote_server_func) + 1);
-  }
-  server_name = calloc(server_name_size, sizeof(char));
-  int bytes_needed = 0;
-  if (tls_clnt->remote_server_func == NULL)
-  {
-    bytes_needed = snprintf(server_name,
-                            server_name_size,
-                            "%s",
-                            tls_clnt->remote_server);
-  }
-  else
-  {
-    bytes_needed = snprintf(server_name,
-                            server_name_size,
-                            "%s.%s",
-                            tls_clnt->remote_server,
-                            tls_clnt->remote_server_func);
-  }
-  if (bytes_needed < 0)
-  {
-    kmyth_log(LOG_ERR, "error creating server certificate verification name");
-    free(server_name);
-    return -1;
-  }
-  if ((size_t) bytes_needed > server_name_size)
-  {
-    kmyth_log(LOG_ERR, "truncated server certificate verification name");
-    free(server_name);
-    return -1;
-  }
-
-  // set host name for server certificate verification
-  if (1 != SSL_set1_host(ssl, server_name))
-  {
-    log_openssl_error("SSL_set1_host()");
-    free(server_name);
-    return -1;
-  }
-  kmyth_log(LOG_DEBUG, "name for server cert verification: %s", server_name);
-
-  free(server_name);
 
   return 0;
 }
@@ -342,7 +304,20 @@ int demo_tls_config_server_accept(TLSPeer * tls_svr)
   // set read/write operations to only return after successful handshake
   SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
 
-  // creates new accept BIO to accept client connection to the server
+  // if the user supplies a Subject Alternative Name (SAN) for the
+  // remote client, configure its use it for certificate verification
+  if (tls_svr->remote_san != NULL)
+  {
+    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
+    if (1 != SSL_set1_host(ssl, tls_svr->remote_san))
+    {
+      log_openssl_error("SSL_set1_host()");
+      return -1;
+    }
+    kmyth_log(LOG_DEBUG, "set remote client SAN = %s", tls_svr->remote_san);
+  }
+
+  // create new accept BIO to accept client connection to the server
   BIO *abio = BIO_new_accept(tls_svr->conn_port);
   if (abio == NULL)
   {

--- a/sgx/demo/src/util/demo_tls_util.c
+++ b/sgx/demo/src/util/demo_tls_util.c
@@ -265,13 +265,18 @@ int demo_tls_config_client_connect(TLSPeer * tls_clnt)
       log_openssl_error("BIO_get_ssl()");
       return -1;
     }
- 
+
+    // check only against certificate SAN values (not CN/DN) 
     SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
+
+    // replace any existing critera with user supplied SAN
+    //   Note: SSL_add1_host() would have appended as additional criteria
     if (1 != SSL_set1_host(ssl, tls_clnt->remote_san))
     {
       log_openssl_error("SSL_set1_host()");
       return -1;
     }
+
     kmyth_log(LOG_DEBUG, "set remote server SAN = %s", tls_clnt->remote_san);
   }
 
@@ -308,12 +313,17 @@ int demo_tls_config_server_accept(TLSPeer * tls_svr)
   // remote client, configure its use it for certificate verification
   if (tls_svr->remote_san != NULL)
   {
+    // check only against certificate SAN values (not CN/DN) 
     SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
+
+    // replace any existing critera with user supplied SAN
+    //   Note: SSL_add1_host() would have appended as additional criteria
     if (1 != SSL_set1_host(ssl, tls_svr->remote_san))
     {
       log_openssl_error("SSL_set1_host()");
       return -1;
     }
+
     kmyth_log(LOG_DEBUG, "set remote client SAN = %s", tls_svr->remote_san);
   }
 

--- a/sgx/demo/src/util/demo_tls_util.c
+++ b/sgx/demo/src/util/demo_tls_util.c
@@ -34,10 +34,10 @@ void demo_tls_cleanup(TLSPeer * tlsconn)
     SSL_CTX_free(tlsconn->ctx);
   }
 
-  // clean up name string for remote TLS host
-  if (tlsconn->remote_host != NULL)
+  // clean up IP address string for remote TLS host
+  if (tlsconn->remote_addr != NULL)
   {
-    free(tlsconn->remote_host);
+    free(tlsconn->remote_addr);
   }
   
   // clean up 'port' string for TLS interface
@@ -231,16 +231,16 @@ int demo_tls_config_client_connect(TLSPeer * tls_clnt)
     return -1;
   }
 
-  // configure remote server hostname settings:
-  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_host))
+  // set BIO's remote server hostname to configured IP address
+  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_addr))
   {
     log_openssl_error("BIO_set_conn_hostname()");
     return -1;
   }
-  kmyth_log(LOG_DEBUG, "configured BIO remote server hostname: %s",
-                       tls_clnt->remote_host);
+  kmyth_log(LOG_DEBUG, "configured BIO remote server IP address: %s",
+                       tls_clnt->remote_addr);
  
-  // set the port number for the connection
+  // set BIO's port number for the connection
   if (1 != BIO_set_conn_port(tls_clnt->bio, tls_clnt->conn_port))
   {
     log_openssl_error("BIO_set_conn_port()");

--- a/sgx/demo/src/util/demo_tls_util.c
+++ b/sgx/demo/src/util/demo_tls_util.c
@@ -34,18 +34,12 @@ void demo_tls_cleanup(TLSPeer * tlsconn)
     SSL_CTX_free(tlsconn->ctx);
   }
 
-  // clean up 'host' (hostname or IP) string for TLS interface
+  // clean up name string for remote TLS host
   if (tlsconn->remote_host != NULL)
   {
     free(tlsconn->remote_host);
   }
   
-  // clean up Subject Alternative Name (SAN) string for remote TLS host
-  if (tlsconn->remote_san != NULL)
-  {
-    free(tlsconn->remote_san);
-  }
-
   // clean up 'port' string for TLS interface
   if (tlsconn->conn_port != NULL)
   {
@@ -59,9 +53,9 @@ void demo_tls_cleanup(TLSPeer * tlsconn)
   }
 
   // clean up local key file path string for TLS interface
-  if (tlsconn->local_key_path != NULL)
+  if (tlsconn->local_private_key_path != NULL)
   {
-    free(tlsconn->local_key_path);
+    free(tlsconn->local_private_key_path);
   }
 
   // clean up local certificate file path string for TLS interface
@@ -184,19 +178,19 @@ int demo_tls_config_ctx(TLSPeer * tlsconn)
   }
 
   // set local private key
-  if (tlsconn->local_key_path)
+  if (tlsconn->local_private_key_path)
   {
     if (1 != SSL_CTX_use_PrivateKey_file(tlsconn->ctx,
-                                         tlsconn->local_key_path,
+                                         tlsconn->local_private_key_path,
                                          SSL_FILETYPE_PEM))
     {
       kmyth_log(LOG_ERR, "failed to set local private key (%s)",
-                         tlsconn->local_key_path);
+                         tlsconn->local_private_key_path);
       log_openssl_error("SSL_CTX_use_PrivateKey_file()");
       return -1;
     }
     kmyth_log(LOG_DEBUG, "set local private key (%s)",
-                         tlsconn->local_key_path);
+                         tlsconn->local_private_key_path);
   }
 
   // set local certificate
@@ -237,48 +231,23 @@ int demo_tls_config_client_connect(TLSPeer * tls_clnt)
     return -1;
   }
 
+  // configure remote server hostname settings:
+  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_host))
+  {
+    log_openssl_error("BIO_set_conn_hostname()");
+    return -1;
+  }
+  kmyth_log(LOG_DEBUG, "configured BIO remote server hostname: %s",
+                       tls_clnt->remote_host);
+ 
   // set the port number for the connection
   if (1 != BIO_set_conn_port(tls_clnt->bio, tls_clnt->conn_port))
   {
     log_openssl_error("BIO_set_conn_port()");
     return -1;
   }
-
-  // configure server hostname settings
-  if (1 != BIO_set_conn_hostname(tls_clnt->bio, tls_clnt->remote_host))
-  {
-    log_openssl_error("BIO_set_conn_hostname()");
-    return -1;
-  }
-
- 
-  // if the user supplies a Subject Alternative Name (SAN) for the
-  // remote server, configure its use for certificate verification
-  if (tls_clnt->remote_san != NULL)
-  {
-    // obtain SSL BIO pointer for the TLS client BIO chain
-    SSL *ssl = NULL;
-
-    BIO_get_ssl(tls_clnt->bio, &ssl);  // internal pointer, not a new allocation
-    if (ssl == NULL)
-    {
-      log_openssl_error("BIO_get_ssl()");
-      return -1;
-    }
-
-    // check only against certificate SAN values (not CN/DN) 
-    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
-
-    // replace any existing critera with user supplied SAN
-    //   Note: SSL_add1_host() would have appended as additional criteria
-    if (1 != SSL_set1_host(ssl, tls_clnt->remote_san))
-    {
-      log_openssl_error("SSL_set1_host()");
-      return -1;
-    }
-
-    kmyth_log(LOG_DEBUG, "set remote server SAN = %s", tls_clnt->remote_san);
-  }
+  kmyth_log(LOG_DEBUG, "configured BIO remote server IP port: %s",
+                       tls_clnt->conn_port);
 
   return 0;
 }
@@ -288,10 +257,10 @@ int demo_tls_config_client_connect(TLSPeer * tls_clnt)
  ****************************************************************************/
 int demo_tls_config_server_accept(TLSPeer * tls_svr)
 {
-  // verify that this configuration is correctly for a client connection
+  // verify that this configuration is correctly configured as a server
   if (tls_svr->isClient)
   {
-    kmyth_log(LOG_ERR, "server config inappropriate for client connection");
+    kmyth_log(LOG_ERR, "node not configured as a server");
     return -1;
   }
 
@@ -309,24 +278,6 @@ int demo_tls_config_server_accept(TLSPeer * tls_svr)
   // set read/write operations to only return after successful handshake
   SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
 
-  // if the user supplies a Subject Alternative Name (SAN) for the
-  // remote client, configure its use it for certificate verification
-  if (tls_svr->remote_san != NULL)
-  {
-    // check only against certificate SAN values (not CN/DN) 
-    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
-
-    // replace any existing critera with user supplied SAN
-    //   Note: SSL_add1_host() would have appended as additional criteria
-    if (1 != SSL_set1_host(ssl, tls_svr->remote_san))
-    {
-      log_openssl_error("SSL_set1_host()");
-      return -1;
-    }
-
-    kmyth_log(LOG_DEBUG, "set remote client SAN = %s", tls_svr->remote_san);
-  }
-
   // create new accept BIO to accept client connection to the server
   BIO *abio = BIO_new_accept(tls_svr->conn_port);
   if (abio == NULL)
@@ -337,7 +288,12 @@ int demo_tls_config_server_accept(TLSPeer * tls_svr)
   }
 
   // prepend SSL BIO to any incoming connection
-  BIO_set_accept_bios(abio, sbio);
+  if (BIO_set_accept_bios(abio, sbio) != 1)
+  {
+    kmyth_log(LOG_ERR, "error chaining BIOs");
+    log_openssl_error("BIO_set_accept_bios()");
+    return -1;
+  }
 
   // setup accept BIO
   if (BIO_do_accept(abio) <= 0)

--- a/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
+++ b/sgx/trusted/src/wrapper/sgx_retrieve_key_impl.c
@@ -57,7 +57,7 @@ int enclave_retrieve_key(EVP_PKEY * client_sign_privkey,
     EVP_PKEY_free(enclave_ephemeral_keypair);
     return EXIT_FAILURE;
   }
-  kmyth_sgx_log(LOG_DEBUG, "created client-side ephemeral key pair");
+  kmyth_sgx_log(LOG_DEBUG, "created client-side ECDH ephemeral key pair");
 
   // compose 'Client Hello' message (client to server key agreement 'request')
   ECDHMessage client_hello_msg = { { 0 }, NULL };

--- a/sgx/untrusted/src/ocall/protocol_ocall.c
+++ b/sgx/untrusted/src/ocall/protocol_ocall.c
@@ -27,8 +27,8 @@ int setup_socket_ocall(const char *server_host,
   }
 
   // connect to server
-  kmyth_log(LOG_DEBUG, "Setting up client socket, remote host: %s, port: %s",
-            server_host, server_port);
+  kmyth_log(LOG_DEBUG, "Setting up socket - remote host: %s, port: %s",
+                       server_host, server_port);
 
   if (setup_client_socket(server_host, server_port, socket_fd))
   {

--- a/src/network/socket_util.c
+++ b/src/network/socket_util.c
@@ -61,7 +61,7 @@ int setup_client_socket(const char *node, const char *service, int *socket_fd)
     close(*socket_fd);
     if (rp->ai_next == NULL)
     {
-      kmyth_log(LOG_DEBUG, "no more addresses to try");
+      kmyth_log(LOG_DEBUG, "socket setup: no more addresses to try");
     }
   }
 

--- a/src/network/socket_util.c
+++ b/src/network/socket_util.c
@@ -47,7 +47,7 @@ int setup_client_socket(const char *node, const char *service, int *socket_fd)
     if (*socket_fd == -1)
     {
       // Socket creation failed, try the next address.
-      kmyth_log(LOG_DEBUG, "socket creation failed (%s)", ipstr);
+      kmyth_log(LOG_DEBUG, "socket creation failed (remote host: %s)", ipstr);
       continue;
     }
     kmyth_log(LOG_DEBUG, "socket creation succeeded (%s)", ipstr);

--- a/src/network/socket_util.c
+++ b/src/network/socket_util.c
@@ -2,6 +2,10 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <errno.h>
 
 #include "defines.h"
 
@@ -27,7 +31,7 @@ int setup_client_socket(const char *node, const char *service, int *socket_fd)
   if (s != 0)
   {
     kmyth_log(LOG_ERR, "Failed to lookup target Internet address: %s",
-              gai_strerror(s));
+                       gai_strerror(s));
     return 1;
   }
 
@@ -35,25 +39,37 @@ int setup_client_socket(const char *node, const char *service, int *socket_fd)
   // right one.
   for (rp = result; rp != NULL; rp = rp->ai_next)
   {
+    char ipstr[INET_ADDRSTRLEN];
+    struct sockaddr_in *sa = (struct sockaddr_in *)rp->ai_addr;
+    void *addr = &(sa->sin_addr);
+    inet_ntop(rp->ai_family, addr, ipstr, sizeof(ipstr));
     *socket_fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
     if (*socket_fd == -1)
     {
       // Socket creation failed, try the next address.
+      kmyth_log(LOG_DEBUG, "socket creation failed (%s)", ipstr);
       continue;
     }
+    kmyth_log(LOG_DEBUG, "socket creation succeeded (%s)", ipstr);
     if (connect(*socket_fd, rp->ai_addr, rp->ai_addrlen) != -1)
     {
       // Socket connection succeeded, use this socket.
+      kmyth_log(LOG_DEBUG, "socket connection succeeded");
       break;
     }
+    kmyth_log(LOG_DEBUG, "socket connect: %s", strerror(errno));
     close(*socket_fd);
+    if (rp->ai_next == NULL)
+    {
+      kmyth_log(LOG_DEBUG, "no more addresses to try");
+    }
   }
 
   // Cleanup address information and handle errors.
   freeaddrinfo(result);
   if (rp == NULL)
   {
-    kmyth_log(LOG_ERR, "Failed to establish socket connection.");
+    kmyth_log(LOG_ERR, "failed to establish socket connection");
     return 1;
   }
 


### PR DESCRIPTION
In pull request #189,  the kmyth ECDH demonstration code was changed to require a specific format for the name used in server certificate verification (i.e., network host name or IP address concatenated, using '.' as the separator, with a unique name to indicate functionality). This was done to address issues with implementing all of the ECDH demo nodes on the same network host (i.e., localhost).

This pull request attempts to propose a better approach. Instead of parsing the network (connection) host name and the certificate verification criteria from a custom format, it provides options for the user to directly specify the network host name/IP and, optionally, a separate Subject Alternative Name (SAN) criteria to be used in name verification for the remote (peer) certificate. This is hopefully simpler, less confusing, and more generic than the current approach.