### PR TITLE
Memory Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 
 *.pem
 
+/bin/
 test/data/*
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,16 @@ nsl:	clean-backups \
 	$(BIN_DIR)/nsl-client \
 	$(BIN_DIR)/nsl-server
 
+.PHONY: nsl-test
+nsl-test: nsl
+	rm -f test/data/nsl*.pem
+	openssl genrsa -out test/data/nslclient_priv.pem 2048
+	openssl genrsa -out test/data/nslserver_priv.pem 2048
+	openssl rsa -in test/data/nslclient_priv.pem -pubout -out test/data/nslclient_pub.pem
+	openssl rsa -in test/data/nslserver_priv.pem -pubout -out test/data/nslserver_pub.pem
+	./bin/nsl-server -r test/data/nslserver_priv.pem -p 12345 -u test/data/nslclient_pub.pem --verbose &
+	./bin/nsl-client -r test/data/nslclient_priv.pem -i localhost -p 12345 -u test/data/nslserver_pub.pem --verbose
+
 .PHONY: utils-lib
 utils-lib: clean-backups $(LIB_DIR)/libkmyth-utils.so
 

--- a/Makefile
+++ b/Makefile
@@ -673,6 +673,7 @@ clean: clean-backups
 	rm -rf $(TEST_OBJ_DIR)
 	rm -rf $(UTILS_OBJ_DIR)
 	rm -rf $(LOGGER_OBJ_DIR)
+	rm -f test/data/nsl*.pem
 
 .PHONY: clean-backups
 clean-backups:

--- a/include/protocol/nsl_util.h
+++ b/include/protocol/nsl_util.h
@@ -298,17 +298,17 @@ int generate_nonce(size_t desired_nonce_len,
  *
  * @param[in]  socket_fd        the open socket file descriptor
  *
- * @param[in]  public_key_ctx   the EVP_PKEY_CTX containing the remote public key
+ * @param[in]  public_key_ctx   the EVP_PKEY_CTX containing the remote (server) public key
  *
- * @param[in]  private_key_ctx  the EVP_PKEY_CTX containing the local private key
+ * @param[in]  private_key_ctx  the EVP_PKEY_CTX containing the local (client) private key
  *
- * @param[in]  id               the local ID
+ * @param[in]  client_id        the local (client) ID
+ * 
+ * @param[in]  client_id_len    length (in bytes) of the local (client) ID
  *
- * @param[in]  id_len           length (in bytes) of the local ID
+ * @param[in]  expected_server_id      the expected remote (server) ID
  *
- * @param[in]  expected_id      the expected ID
- *
- * @param[in]  expected_id_len  length (in bytes) of the expected ID
+ * @param[in]  expected_server_id_len  length (in bytes) of the expected remote (server) ID
  *
  * @param[out] session_key      the session key
  *
@@ -319,10 +319,10 @@ int generate_nonce(size_t desired_nonce_len,
 int negotiate_client_session_key(int socket_fd,
                                  EVP_PKEY_CTX * public_key_ctx,
                                  EVP_PKEY_CTX * private_key_ctx,
-                                 unsigned char *id,
-                                 size_t id_len,
-                                 unsigned char *expected_id,
-                                 size_t expected_id_len,
+                                 unsigned char *client_id,
+                                 size_t client_id_len,
+                                 unsigned char *expected_server_id,
+                                 size_t expected_server_id_len,
                                  unsigned char **session_key,
                                  size_t *session_key_len);
 
@@ -337,9 +337,9 @@ int negotiate_client_session_key(int socket_fd,
  *
  * @param[in]  private_key_ctx  the EVP_PKEY_CTX containing the local private key
  *
- * @param[in]  id               the local ID
+ * @param[in]  server_id        the local (server) ID
  *
- * @param[in]  id_len           length (in bytes) of the local ID
+ * @param[in]  server_id_len    length (in bytes) of the local (server) ID
  * 
  * @param[out] session_key      the session key
  *
@@ -350,8 +350,8 @@ int negotiate_client_session_key(int socket_fd,
 int negotiate_server_session_key(int socket_fd,
                                  EVP_PKEY_CTX * public_key_ctx,
                                  EVP_PKEY_CTX * private_key_ctx,
-                                 unsigned char *id,
-                                 size_t id_len,
+                                 unsigned char *server_id,
+                                 size_t server_id_len,
                                  unsigned char **session_key,
                                  size_t *session_key_len);
 #endif

--- a/include/protocol/nsl_util.h
+++ b/include/protocol/nsl_util.h
@@ -279,7 +279,7 @@ int generate_session_key(unsigned char *nonce_a,
  * This function generates a random nonce value.
  * </pre>
  *
- * @param[in]  desired_min_nonce_len  minimum length (in bytes) of the desired nonce
+ * @param[in]  desired_nonce_len      length (in bytes) of the desired nonce
  *
  * @param[out] nonce                  the nonce
  *
@@ -287,7 +287,7 @@ int generate_session_key(unsigned char *nonce_a,
  *
  * @return 0 on success, 1 on error
  */
-int generate_nonce(size_t desired_min_nonce_len,
+int generate_nonce(size_t desired_nonce_len,
                    unsigned char **nonce,
                    size_t *nonce_len);
 

--- a/src/main/nsl_client.c
+++ b/src/main/nsl_client.c
@@ -27,7 +27,9 @@ static void usage(const char *prog)
           "  -i or --ip    The IP address or hostname of the server.\n"
           "  -p or --port  The port number to connect to.\n"
           "  -u or --pub  Path to the file containing the server's public key.\n"
-          "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
+          "Misc --\n"
+          "  -h or --help  Help (displays this usage).\n"
+          "  -v or --verbose  Verbose mode provides detailed debug/demo info.\n\n", prog);
 }
 
 int check_string_arg(const char *arg,
@@ -51,6 +53,7 @@ const struct option longopts[] = {
   {"pub", required_argument, 0, 'u'},
   // Misc
   {"help", no_argument, 0, 'h'},
+  {"verbose", no_argument, 0, 'v'},
   {0, 0, 0, 0}
 };
 
@@ -202,12 +205,15 @@ int main(int argc, char **argv)
   char *port = NULL;
   char *cert = NULL;
 
+  // Set default (non-verbose) display threshold 
+  set_applog_severity_threshold(LOG_INFO);
+
   int options;
   int option_index;
 
   while ((options = getopt_long(argc,
                                 argv,
-                                "r:i:p:u:h",
+                                "r:i:p:u:h:v",
                                 longopts,
                                 &option_index)) != -1)
   {
@@ -231,12 +237,13 @@ int main(int argc, char **argv)
     case 'h':
       usage(argv[0]);
       return 0;
+    case 'v':
+      set_applog_severity_threshold(LOG_DEBUG);
+      break;
     default:
       return 1;
     }
   }
-
-  set_applog_severity_threshold(LOG_DEBUG);
 
   // Create socket to B
   int socket_fd = -1;
@@ -319,6 +326,7 @@ int main(int argc, char **argv)
   kmyth_log(LOG_INFO, "Received symmetric key: 0x%02X..%02X",
             retrieved_key[0], retrieved_key[retrieved_key_len - 1]);
 
+  kmyth_clear_and_free(session_key, session_key_len);
   kmyth_clear_and_free(retrieved_key, (size_t) retrieved_key_len);
   close(socket_fd);
 

--- a/src/main/nsl_client.c
+++ b/src/main/nsl_client.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
     }
   }
 
-  set_applog_severity_threshold(LOG_INFO);
+  set_applog_severity_threshold(LOG_DEBUG);
 
   // Create socket to B
   int socket_fd = -1;

--- a/src/main/nsl_server.c
+++ b/src/main/nsl_server.c
@@ -23,7 +23,9 @@ static void usage(const char *prog)
           "  -p or --port  The port number to connect to.\n"
           "Client Information --\n"
           "  -u or --pub  Path to the file containing the client's public key.\n"
-          "Misc --\n" "  -h or --help  Help (displays this usage).\n\n", prog);
+          "Misc --\n"
+          "  -h or --help  Help (displays this usage).\n"
+          "  -v or --verbose  Verbose mode provides detailed debug/demo info.\n\n", prog);
 }
 
 int check_string_arg(const char *arg,
@@ -46,6 +48,7 @@ const struct option longopts[] = {
   {"pub", required_argument, 0, 'u'},
   // Misc
   {"help", no_argument, 0, 'h'},
+  {"verbose", no_argument, 0, 'v'},
   {0, 0, 0, 0}
 };
 
@@ -191,12 +194,15 @@ int main(int argc, char **argv)
   char *port = NULL;
   char *cert = NULL;
 
+  // set default (non-verbose) display mode
+  set_applog_severity_threshold(LOG_INFO);
+
   int options;
   int option_index;
 
   while ((options = getopt_long(argc,
                                 argv,
-                                "r:p:u:h",
+                                "r:p:u:h:v",
                                 longopts,
                                 &option_index)) != -1)
   {
@@ -217,13 +223,14 @@ int main(int argc, char **argv)
     case 'h':
       usage(argv[0]);
       return 0;
+    case 'v':
+      set_applog_severity_threshold(LOG_DEBUG);
+      break;
     default:
       return 1;
     }
   }
 
-  set_applog_severity_threshold(LOG_DEBUG);
-  
   // Create server socket
   kmyth_log(LOG_INFO, "Setting up server socket");
 
@@ -316,7 +323,8 @@ int main(int argc, char **argv)
     close(socket_fd);
     return 1;
   }
-
+  
+  kmyth_clear_and_free(session_key, session_key_len);
   close(socket_fd);
 
   return 0;

--- a/src/main/nsl_server.c
+++ b/src/main/nsl_server.c
@@ -222,8 +222,8 @@ int main(int argc, char **argv)
     }
   }
 
-  set_applog_severity_threshold(LOG_INFO);
-
+  set_applog_severity_threshold(LOG_DEBUG);
+  
   // Create server socket
   kmyth_log(LOG_INFO, "Setting up server socket");
 

--- a/src/protocol/kmip_util.c
+++ b/src/protocol/kmip_util.c
@@ -97,7 +97,7 @@ int build_kmip_get_request(KMIP * ctx,
   // something odd.
   *request_len = (size_t) (ctx->index - ctx->buffer);
   *request = (uint8_t *) calloc(*request_len, sizeof(unsigned char));
-  if (request == NULL)
+  if (*request == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the KMIP request buffer.");
     kmyth_clear_and_free(encoding, buffer_total_size);
@@ -265,7 +265,7 @@ int build_kmip_get_response(KMIP * ctx,
   // something odd.
   *response_len = (size_t) (ctx->index - ctx->buffer);
   *response = (uint8_t *) calloc(*response_len, sizeof(unsigned char));
-  if (response == NULL)
+  if (*response == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the KMIP response buffer.");
     kmyth_clear_and_free(encoding, buffer_total_size);

--- a/src/protocol/nsl_util.c
+++ b/src/protocol/nsl_util.c
@@ -6,6 +6,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <fcntl.h>
 
 #include <openssl/ec.h>
 #include <openssl/evp.h>
@@ -738,34 +739,29 @@ int generate_session_key(unsigned char *nonce_a,
 //
 // generate_nonce()
 //
-int generate_nonce(size_t desired_min_nonce_len,
+int generate_nonce(size_t desired_nonce_len,
                    unsigned char **nonce,
                    size_t *nonce_len)
 {
-  size_t size = 1;
-
-  while ((size * sizeof(int)) < desired_min_nonce_len)
-  {
-    size += 1;
+  int urand_fd = open("/dev/urandom", O_RDONLY);
+  if (urand_fd < 0) {
+    kmyth_log(LOG_ERR, "Error opening /dev/urandom");
+    return 1;
   }
 
-  *nonce_len = size * sizeof(int);
-  unsigned int *buffer = calloc(size, sizeof(int));
+  uint8_t *buffer = calloc(desired_nonce_len, 1);
 
   if (NULL == buffer)
   {
     kmyth_log(LOG_ERR, "Failed to allocated the nonce buffer.");
     return 1;
   }
-  unsigned int *index = buffer;
 
-  for (size_t i = 0; i < size; i++)
-  {
-    *index = (unsigned int)rand();
-    index += 1;
-  }
+  read(urand_fd, buffer, desired_nonce_len);
 
   *nonce = (unsigned char *) buffer;
+  *nonce_len = desired_nonce_len;
+
   return 0;
 }
 
@@ -792,6 +788,15 @@ int negotiate_client_session_key(int socket_fd,
   {
     kmyth_log(LOG_ERR, "Failed to generate a nonce.");
     return 1;
+  }
+
+  // DEBUG
+  kmyth_log(LOG_DEBUG, "Generated nonce A: %zd bytes", nonce_a_len);
+  for (size_t i = 0; i < nonce_a_len; i++) {
+    printf("%02x ", nonce_a[i]);
+    if ((i + 1) % 16 == 0) {
+      printf("\n");
+    }
   }
 
   // Conduct NSL to obtain nonce B
@@ -981,6 +986,15 @@ int negotiate_server_session_key(int socket_fd,
   {
     kmyth_log(LOG_ERR, "Failed to generate a nonce.");
     return 1;
+  }
+
+  // DEBUG
+  kmyth_log(LOG_DEBUG, "Generated nonce B: %zd bytes", nonce_b_len);
+  for (size_t i = 0; i < nonce_b_len; i++) {
+    printf("%02x ", nonce_b[i]);
+    if ((i + 1) % 16 == 0) {
+      printf("\n");
+    }
   }
 
   // Conduct NSL to obtain nonce A

--- a/src/protocol/nsl_util.c
+++ b/src/protocol/nsl_util.c
@@ -21,6 +21,7 @@
 #include "memory_util.h"
 
 #define NSL_NONCE_LEN 32
+#define NSL_ID_MAX_LEN 128
 #define NSL_SESSION_KEY_LEN 32
 
 //
@@ -200,40 +201,89 @@ int parse_nonce_request(EVP_PKEY_CTX * ctx,
     return 1;
   }
   unsigned char *index = message;
-
-  // Parse out the nonce.
+  size_t bytes_remaining = message_len;
+  
+  // Parse out and validate the nonce size.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce request message buffer too small.");
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   memcpy(nonce_len, index, sizeof(size_t));
+  if (*nonce_len != NSL_NONCE_LEN) {
+    kmyth_log(LOG_ERR, "Parsed invalid nonce length.");
+    *nonce_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
+  
+  // Allocate buffer for nonce bytes.
   *nonce = calloc(*nonce_len, sizeof(unsigned char));
   if (*nonce == NULL)
   {
-    kmyth_log(LOG_ERR, "Failed to allocate the nonce buffer.");
-
+    kmyth_log(LOG_ERR, "Failed to allocate nonce buffer.");
     *nonce_len = 0;
-
     kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
 
+  // Parse nonce bytes
+  if (bytes_remaining < *nonce_len) {
+    kmyth_log(LOG_ERR, "Nonce request message buffer too small.");
+    *nonce_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*nonce, index, *nonce_len);
   index += *nonce_len;
+  bytes_remaining -= *nonce_len;
 
-  // Parse out the ID.
+  // Parse out and validate ID size.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce request message buffer too small.");
+    kmyth_clear_and_free(*nonce, *nonce_len);
+    *nonce = NULL;
+    *nonce_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   memcpy(id_len, index, sizeof(size_t));
+  if (*id_len > NSL_ID_MAX_LEN) {
+    kmyth_log(LOG_ERR, "Parsed invalid ID length.");
+    kmyth_clear_and_free(*nonce, *nonce_len);
+    *nonce_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
+  
+  // Allocate buffer for ID bytes
   *id = calloc(*id_len, sizeof(unsigned char));
   if (*id == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
-
     kmyth_clear_and_free(*nonce, *nonce_len);
     *nonce = NULL;
     *nonce_len = 0;
-
     *id_len = 0;
-
     kmyth_clear_and_free(message, message_len);
 
+    return 1;
+  }
+
+  // Parse ID bytes
+  if (bytes_remaining != *id_len) {
+    kmyth_log(LOG_ERR, "Nonce request message buffer size error.");
+    kmyth_clear_and_free(*nonce, *nonce_len);
+    *nonce = NULL;
+    *nonce_len = 0;
+    kmyth_clear_and_free(*id, *id_len);
+    *id = NULL;
+    *id_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*id, index, *id_len);

--- a/src/protocol/nsl_util.c
+++ b/src/protocol/nsl_util.c
@@ -24,6 +24,8 @@
 #define NSL_ID_MAX_LEN 128
 #define NSL_SESSION_KEY_LEN 32
 
+#define NSL_RX_BUF_LEN 8192
+
 //
 // encrypt_with_key_pair()
 //
@@ -135,7 +137,21 @@ int build_nonce_request(EVP_PKEY_CTX * ctx,
     return 1;
   }
 
-  // TODO Add a length check for the ID as well.
+  // Validate nonce and ID lengths requested.
+  if (nonce_len != NSL_NONCE_LEN) {
+    kmyth_log(LOG_ERR,
+              "Invalid nonce length - requested: %zd bytes, expected: %zd bytes",
+              nonce_len,
+              NSL_NONCE_LEN);
+    return 1;
+  }
+  if (id_len > NSL_ID_MAX_LEN) {
+    kmyth_log(LOG_ERR,
+              "Invalid ID length - requested: %zd bytes, maximum: %zd bytes",
+              id_len,
+              NSL_ID_MAX_LEN);
+    return 1;
+  }
 
   // Allocate the unencrypted request buffer.
   unsigned char *message = NULL;
@@ -210,8 +226,11 @@ int parse_nonce_request(EVP_PKEY_CTX * ctx,
     return 1;
   }
   memcpy(nonce_len, index, sizeof(size_t));
-  if (*nonce_len != NSL_NONCE_LEN) {
-    kmyth_log(LOG_ERR, "Parsed invalid nonce length.");
+  if (NSL_NONCE_LEN != *nonce_len)
+  {
+    kmyth_log(LOG_ERR,
+              "Unexpected nonce size; received %zd, expected: %zd",
+              *nonce_len, NSL_NONCE_LEN);
     *nonce_len = 0;
     kmyth_clear_and_free(message, message_len);
     return 1;
@@ -251,7 +270,9 @@ int parse_nonce_request(EVP_PKEY_CTX * ctx,
   }
   memcpy(id_len, index, sizeof(size_t));
   if (*id_len > NSL_ID_MAX_LEN) {
-    kmyth_log(LOG_ERR, "Parsed invalid ID length.");
+    kmyth_log(LOG_ERR,
+              "Invalid ID size; received: %zd, maximum: %zd",
+              *id_len, NSL_ID_MAX_LEN);
     kmyth_clear_and_free(*nonce, *nonce_len);
     *nonce_len = 0;
     kmyth_clear_and_free(message, message_len);
@@ -264,7 +285,7 @@ int parse_nonce_request(EVP_PKEY_CTX * ctx,
   *id = calloc(*id_len, sizeof(unsigned char));
   if (*id == NULL)
   {
-    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
+    kmyth_log(LOG_ERR, "Failed to allocate ID buffer.");
     kmyth_clear_and_free(*nonce, *nonce_len);
     *nonce = NULL;
     *nonce_len = 0;
@@ -276,7 +297,7 @@ int parse_nonce_request(EVP_PKEY_CTX * ctx,
 
   // Parse ID bytes
   if (bytes_remaining != *id_len) {
-    kmyth_log(LOG_ERR, "Nonce request message buffer size error.");
+    kmyth_log(LOG_ERR, "Nonce request message buffer size mis-match.");
     kmyth_clear_and_free(*nonce, *nonce_len);
     *nonce = NULL;
     *nonce_len = 0;
@@ -381,14 +402,16 @@ int parse_nonce_response(EVP_PKEY_CTX * ctx,
     return 1;
   }
 
-  // TODO Check and validate the length of the decrypted response message
-  // before proceeding with the parse.
-
   unsigned char *index = message;
+  size_t bytes_remaining = message_len;
 
-  // Parse out the first nonce.
+  // Parse and validate size of first nonce.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer too small.");
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   memcpy(nonce_a_len, index, sizeof(size_t));
-  index += sizeof(size_t);
   if (NSL_NONCE_LEN != *nonce_a_len)
   {
     kmyth_log(LOG_ERR,
@@ -398,75 +421,139 @@ int parse_nonce_response(EVP_PKEY_CTX * ctx,
     kmyth_clear_and_free(message, message_len);
     return 1;
   }
+  index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
+
+  // Allocate buffer for first nonce
   *nonce_a = calloc(*nonce_a_len, sizeof(unsigned char));
   if (*nonce_a == NULL)
   {
-    kmyth_log(LOG_ERR, "Failed to allocate the first nonce buffer.");
-
+    kmyth_log(LOG_ERR, "Failed to allocate buffer for first nonce.");
     *nonce_a_len = 0;
-
     kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
 
+  // Parse first nonce bytes
+  if (bytes_remaining < *nonce_a_len) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer too small.");
+    *nonce_a_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*nonce_a, index, *nonce_a_len);
   index += *nonce_a_len;
+  bytes_remaining -= *nonce_a_len;
 
-  // Parse out the second nonce.
+  // Parse and validate size of second nonce.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer too small.");
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   memcpy(nonce_b_len, index, sizeof(size_t));
-  index += sizeof(size_t);
   if (NSL_NONCE_LEN != *nonce_b_len)
   {
     kmyth_log(LOG_ERR,
               "Unexpected length for nonce B; received: %zd bytes, expected: %zd bytes",
               *nonce_b_len, NSL_NONCE_LEN);
-
-    *nonce_a_len = 0;
-    *nonce_b_len = 0;
-
-    kmyth_clear_and_free(nonce_a, *nonce_a_len);
-    kmyth_clear_and_free(message, message_len);
-
-    return 1;
-  }
-  *nonce_b = calloc(*nonce_b_len, sizeof(unsigned char));
-  if (*nonce_b == NULL)
-  {
-    kmyth_log(LOG_ERR, "Failed to allocate the second nonce buffer.");
-
-    *nonce_b_len = 0;
-
     kmyth_clear_and_free(*nonce_a, *nonce_a_len);
     *nonce_a = NULL;
     *nonce_a_len = 0;
-
+    *nonce_b_len = 0;
     kmyth_clear_and_free(message, message_len);
-
+    return 1;
+  }
+  index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
+  
+  // Allocate buffer for second nonce
+  *nonce_b = calloc(*nonce_b_len, sizeof(unsigned char));
+  if (*nonce_b == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate buffer for second nonce.");
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    *nonce_b_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
+  
+  // Parse second nonce bytes
+  if (bytes_remaining < *nonce_b_len) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer too small.");
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    *nonce_b_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*nonce_b, index, *nonce_b_len);
   index += *nonce_b_len;
+  bytes_remaining -= *nonce_b_len;
 
-  // Parse out the ID.
-  memcpy(id_len, index, sizeof(size_t));
-  index += sizeof(size_t);
-  *id = calloc(*id_len, sizeof(unsigned char));
-  if (*id == NULL)
-  {
-    kmyth_log(LOG_ERR, "Failed to allocate the ID buffer.");
-
+  // Parse and validate size of ID.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer too small.");
     kmyth_clear_and_free(*nonce_a, *nonce_a_len);
     *nonce_a = NULL;
     *nonce_a_len = 0;
-
     kmyth_clear_and_free(*nonce_b, *nonce_b_len);
     *nonce_b = NULL;
     *nonce_b_len = 0;
-
-    *id_len = 0;
-
     kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
+  memcpy(id_len, index, sizeof(size_t));
+  if (*id_len > NSL_ID_MAX_LEN) {
+    kmyth_log(LOG_ERR,
+              "Invalid length for ID; received: %zd bytes, maximum: %zd bytes",
+              *id_len, NSL_ID_MAX_LEN);
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    kmyth_clear_and_free(*nonce_b, *nonce_b_len);
+    *nonce_b = NULL;
+    *nonce_b_len = 0;
+    *id_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
+  index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
 
+  // Allocate ID buffer
+  *id = calloc(*id_len, sizeof(unsigned char));
+  if (*id == NULL)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate ID buffer.");
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    kmyth_clear_and_free(*nonce_b, *nonce_b_len);
+    *nonce_b = NULL;
+    *nonce_b_len = 0;
+    *id_len = 0;
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
+  
+  // Parse ID bytes
+  if (bytes_remaining != *id_len) {
+    kmyth_log(LOG_ERR, "Nonce response message buffer size mis-match.");
+    kmyth_clear_and_free(*nonce_a, *nonce_a_len);
+    *nonce_a = NULL;
+    *nonce_a_len = 0;
+    kmyth_clear_and_free(*nonce_b, *nonce_b_len);
+    *nonce_b = NULL;
+    *nonce_b_len = 0;
+    *id_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*id, index, *id_len);
@@ -841,7 +928,7 @@ int negotiate_client_session_key(int socket_fd,
                                  unsigned char **session_key,
                                  size_t *session_key_len)
 {
-  // Generate client nonce
+  // Generate client nonce locally
   unsigned char *client_nonce = NULL;
   size_t client_nonce_len = 0;
 
@@ -849,7 +936,7 @@ int negotiate_client_session_key(int socket_fd,
 
   if (result)
   {
-    kmyth_log(LOG_ERR, "Failed to generate client nonce.");
+    kmyth_log(LOG_ERR, "Failed to generate local (client) nonce.");
     return 1;
   }
 
@@ -859,31 +946,15 @@ int negotiate_client_session_key(int socket_fd,
     client_nonce_str_ptr += sprintf(client_nonce_str_ptr, "%02X", client_nonce[i]);
   }
   kmyth_log(LOG_DEBUG,
-            "Generated client nonce (%zd bytes): %s",
+            "Generated local (client) nonce (%zd bytes): %s",
             client_nonce_len,
             client_nonce_str);
 
   // Conduct NSL to obtain server nonce
-  unsigned char *server_nonce = NULL;
-  size_t server_nonce_len = 0;
 
+  // Client builds and sends nonce request message
   unsigned char *request = NULL;
   size_t request_len = 0;
-
-  unsigned char *response = calloc(8192, sizeof(unsigned char));
-
-  if (NULL == response)
-  {
-    kmyth_log(LOG_ERR, "Failed to allocate the response buffer.");
-    kmyth_clear_and_free(client_nonce, client_nonce_len);
-    return 1;
-  }
-  size_t response_len = 8192 * sizeof(unsigned char);
-
-  kmyth_log(LOG_DEBUG,
-            "Sending client nonce (%zd bytes) to server.",
-            client_nonce_len);
-
   result = build_nonce_request(public_key_ctx,
                                client_nonce, client_nonce_len,
                                client_id, client_id_len,
@@ -892,35 +963,43 @@ int negotiate_client_session_key(int socket_fd,
   {
     kmyth_log(LOG_ERR, "Failed to build the nonce request.");
     kmyth_clear_and_free(client_nonce, client_nonce_len);
-    kmyth_clear_and_free(response, response_len);
+    kmyth_clear_and_free(request, request_len);
     return 1;
   }
-
   if (write(socket_fd, request, request_len) != request_len)
   {
-    kmyth_log(LOG_ERR, "Failed to fully send nonce request message.");
+    kmyth_log(LOG_ERR, "Error sending nonce request to server.");
     kmyth_clear_and_free(client_nonce, client_nonce_len);
-    kmyth_clear_and_free(response, response_len);
+    kmyth_clear_and_free(request, request_len);
     return 1;
   }
+  kmyth_log(LOG_DEBUG,
+            "Sent nonce request message (%d bytes) to server.",
+            request_len);
+  kmyth_clear_and_free(request, request_len);
+  request = NULL;
+  request_len = 0;
+ 
 
-  kmyth_log(LOG_DEBUG, "Successfully sent client nonce to server.");
-
-  ssize_t read_result = read(socket_fd, response, response_len);
-
+  // Client allocates buffer to receive nonce response message from server
+  unsigned char *response = calloc(NSL_RX_BUF_LEN, sizeof(unsigned char));
+  if (NULL == response)
+  {
+    kmyth_log(LOG_ERR, "Failed to allocate the response buffer.");
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    return 1;
+  }
+  ssize_t read_result = read(socket_fd, response, NSL_RX_BUF_LEN);
   if (read_result <= 0)
   {
     kmyth_log(LOG_ERR, "Failed to read the nonce response message.");
     kmyth_clear_and_free(client_nonce, client_nonce_len);
-    kmyth_clear_and_free(response, response_len);
+    kmyth_clear_and_free(response, NSL_RX_BUF_LEN);
     return 1;
   }
-
-  kmyth_log(LOG_DEBUG, "Received %zd bytes", read_result);
-
-  kmyth_clear_and_free(request, request_len);
-  request = NULL;
-  request_len = 0;
+  kmyth_log(LOG_DEBUG,
+            "Received nonce response message (%zd bytes) from server",
+            read_result);
 
   unsigned char *rcvd_client_nonce = NULL;
   size_t rcvd_client_nonce_len = 0;
@@ -930,12 +1009,15 @@ int negotiate_client_session_key(int socket_fd,
 
   // read_result can safely be cast to a size_t since we've already
   // dealt with the possibility it's negative
+  unsigned char *server_nonce = NULL;
+  size_t server_nonce_len = 0;
+
   result = parse_nonce_response(private_key_ctx,
                                 response, (size_t)read_result,
                                 &rcvd_client_nonce, &rcvd_client_nonce_len,
                                 &server_nonce, &server_nonce_len,
                                 &rcvd_server_id, &rcvd_server_id_len);
-  kmyth_clear_and_free(response, response_len);
+  kmyth_clear_and_free(response, NSL_RX_BUF_LEN);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to parse the nonce response.");
@@ -1006,6 +1088,7 @@ int negotiate_client_session_key(int socket_fd,
 
   kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
 
+  //   - client sends nonce confirmation message
   result = build_nonce_confirmation(public_key_ctx,
                                     server_nonce, server_nonce_len,
                                     &request, &request_len);
@@ -1074,28 +1157,26 @@ int negotiate_server_session_key(int socket_fd,
     server_nonce_str_ptr += sprintf(server_nonce_str_ptr, "%02X", server_nonce[i]);
   }
   kmyth_log(LOG_DEBUG,
-            "Generated client nonce (%zd bytes): %s",
+            "Generated local (server) nonce (%zd bytes): %s",
             server_nonce_len,
             server_nonce_str);
 
   // Conduct NSL to obtain client nonce
-  unsigned char *response = calloc(8192, sizeof(unsigned char));
 
-  if (NULL == response)
+  // Allocate buffer for nonce request message received from client
+  unsigned char *request = calloc(NSL_RX_BUF_LEN, sizeof(unsigned char));
+  if (NULL == request)
   {
-    kmyth_log(LOG_ERR, "Failed to allocate the response buffer.");
+    kmyth_log(LOG_ERR, "Failed to allocate receive buffer for nonce request.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     return 1;
   }
-  size_t response_len = 8192;
-
-  ssize_t read_result = read(socket_fd, response, response_len);
-
+  ssize_t read_result = read(socket_fd, request, NSL_RX_BUF_LEN);
   if (read_result <= 0)
   {
     kmyth_log(LOG_ERR, "Failed to receive the nonce request from client.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(response, response_len);
+    kmyth_clear_and_free(request, NSL_RX_BUF_LEN);
     return 1;
   }
 
@@ -1108,7 +1189,7 @@ int negotiate_server_session_key(int socket_fd,
   // read_result can safely be cast to size_t because we've already
   // dealt with the case that it's negative.
   result = parse_nonce_request(private_key_ctx,
-                               response, (size_t)read_result,
+                               request, (size_t)read_result,
                                &client_nonce, &client_nonce_len,
                                &client_id, &client_id_len);
 
@@ -1119,19 +1200,23 @@ int negotiate_server_session_key(int socket_fd,
                                     "%02X", client_nonce[i]);
   }
   kmyth_log(LOG_DEBUG,
-            "Received client nonce (%zd bytes): %s",
+            "Received remote (client) nonce (%zd bytes): %s",
             client_nonce_len,
             client_nonce_str);
 
-  kmyth_log(LOG_DEBUG, "Received client ID: %.*s", client_id_len, client_id);
+  kmyth_log(LOG_DEBUG, "Received remote (client) ID: %.*s",
+            client_id_len, client_id);
 
   kmyth_clear_and_free(client_id, client_id_len);
-  kmyth_clear_and_free(response, response_len);
-  response = NULL;
-  response_len = 0;
+  kmyth_clear_and_free(request, NSL_RX_BUF_LEN);
 
-  kmyth_log(LOG_DEBUG, "Sending server nonce to client.");
+  kmyth_log(LOG_DEBUG, "Sending nonce response message to client.");
 
+  size_t response_len = server_id_len +
+                        server_nonce_len +
+                        client_nonce_len +
+                        (3 * sizeof(size_t));
+  unsigned char *response = calloc(response_len, sizeof(unsigned char));
   result = build_nonce_response(public_key_ctx,
                                 client_nonce, client_nonce_len,
                                 server_nonce, server_nonce_len,

--- a/src/protocol/nsl_util.c
+++ b/src/protocol/nsl_util.c
@@ -664,15 +664,17 @@ int generate_session_key(unsigned char *nonce_a,
 
   // Setup the message digest context.
   const EVP_MD *type = EVP_shake256();
-
   if (NULL == type)
   {
     kmyth_log(LOG_ERR, "Failed to obtain the SHAKE-256 MD.");
     kmyth_clear_and_free(nonces, nonces_len);
     return 1;
   }
-  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
+  // Set session key length to match digest length of hash
+
+  // Create new message digest context
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
   if (NULL == ctx)
   {
     kmyth_log(LOG_ERR, "Failed to create the MD context.");
@@ -680,8 +682,7 @@ int generate_session_key(unsigned char *nonce_a,
     return 1;
   }
 
-  // Initialize the context and load in the nonces to generate the session
-  // key.
+  // Initialize the context and load in nonces
   int result = EVP_DigestInit_ex(ctx, type, NULL);
 
   if (0 == result)
@@ -692,6 +693,7 @@ int generate_session_key(unsigned char *nonce_a,
     return 1;
   }
 
+  // Hash loaded value to compute message digest
   result = EVP_DigestUpdate(ctx, nonces, len);
   if (0 == result)
   {
@@ -701,17 +703,18 @@ int generate_session_key(unsigned char *nonce_a,
     return 1;
   }
 
-  *key = calloc(EVP_MAX_MD_SIZE, sizeof(unsigned char));
+  // Allocate session key buffer
+  *key_len = (size_t) EVP_MD_get_size(type);
+  *key = calloc(*key_len, sizeof(unsigned char));
   if (NULL == key)
   {
-    kmyth_log(LOG_ERR, "Failed to allocated the key buffer.");
+    kmyth_log(LOG_ERR, "Failed to allocate the key buffer.");
     EVP_MD_CTX_free(ctx);
     kmyth_clear_and_free(nonces, nonces_len);
     return 1;
   }
-  *key_len = EVP_MAX_MD_SIZE * sizeof(unsigned char);
 
-  result = EVP_DigestFinal_ex(ctx, *key, (unsigned int *) key_len);
+  result = EVP_DigestFinalXOF(ctx, *key, (unsigned int) *key_len);
   if (0 == result)
   {
     kmyth_log(LOG_ERR, "Failed to finalize the MD context.");
@@ -732,6 +735,16 @@ int generate_session_key(unsigned char *nonce_a,
     kmyth_clear_and_free(*key, *key_len);
     return 1;
   }
+  
+  char key_str[(2 * *key_len) + 1];
+  char *key_str_ptr = key_str;
+  for (size_t i = 0; i < *key_len; i++) {
+    key_str_ptr += sprintf(key_str_ptr, "%02X", (*key)[i]);
+  }
+  kmyth_log(LOG_DEBUG,
+            "Generated session key (%zd bytes): %s",
+            *key_len,
+            key_str);
 
   return 0;
 }
@@ -771,37 +784,38 @@ int generate_nonce(size_t desired_nonce_len,
 int negotiate_client_session_key(int socket_fd,
                                  EVP_PKEY_CTX * public_key_ctx,
                                  EVP_PKEY_CTX * private_key_ctx,
-                                 unsigned char *id,
-                                 size_t id_len,
-                                 unsigned char *expected_id,
-                                 size_t expected_id_len,
+                                 unsigned char *client_id,
+                                 size_t client_id_len,
+                                 unsigned char *expected_server_id,
+                                 size_t expected_server_id_len,
                                  unsigned char **session_key,
                                  size_t *session_key_len)
 {
-  // Generate nonce A
-  unsigned char *nonce_a = NULL;
-  size_t nonce_a_len = 0;
+  // Generate client nonce
+  unsigned char *client_nonce = NULL;
+  size_t client_nonce_len = 0;
 
-  int result = generate_nonce(NSL_NONCE_LEN, &nonce_a, &nonce_a_len);
+  int result = generate_nonce(NSL_NONCE_LEN, &client_nonce, &client_nonce_len);
 
   if (result)
   {
-    kmyth_log(LOG_ERR, "Failed to generate a nonce.");
+    kmyth_log(LOG_ERR, "Failed to generate client nonce.");
     return 1;
   }
 
-  // DEBUG
-  kmyth_log(LOG_DEBUG, "Generated nonce A: %zd bytes", nonce_a_len);
-  for (size_t i = 0; i < nonce_a_len; i++) {
-    printf("%02x ", nonce_a[i]);
-    if ((i + 1) % 16 == 0) {
-      printf("\n");
-    }
+  char client_nonce_str[(2 * client_nonce_len) + 1];
+  char *client_nonce_str_ptr = client_nonce_str;
+  for (size_t i = 0; i < client_nonce_len; i++) {
+    client_nonce_str_ptr += sprintf(client_nonce_str_ptr, "%02X", client_nonce[i]);
   }
+  kmyth_log(LOG_DEBUG,
+            "Generated client nonce (%zd bytes): %s",
+            client_nonce_len,
+            client_nonce_str);
 
-  // Conduct NSL to obtain nonce B
-  unsigned char *nonce_b = NULL;
-  size_t nonce_b_len = 0;
+  // Conduct NSL to obtain server nonce
+  unsigned char *server_nonce = NULL;
+  size_t server_nonce_len = 0;
 
   unsigned char *request = NULL;
   size_t request_len = 0;
@@ -811,20 +825,23 @@ int negotiate_client_session_key(int socket_fd,
   if (NULL == response)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the response buffer.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
   size_t response_len = 8192 * sizeof(unsigned char);
 
-  kmyth_log(LOG_DEBUG, "Sending nonce A: %zd bytes", nonce_a_len);
+  kmyth_log(LOG_DEBUG,
+            "Sending client nonce (%zd bytes) to server.",
+            client_nonce_len);
 
   result = build_nonce_request(public_key_ctx,
-                               nonce_a, nonce_a_len,
-                               id, id_len, &request, &request_len);
+                               client_nonce, client_nonce_len,
+                               client_id, client_id_len,
+                               &request, &request_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to build the nonce request.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
@@ -832,19 +849,19 @@ int negotiate_client_session_key(int socket_fd,
   if (write(socket_fd, request, request_len) != request_len)
   {
     kmyth_log(LOG_ERR, "Failed to fully send nonce request message.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
 
-  kmyth_log(LOG_DEBUG, "Successfully sent nonce A.");
+  kmyth_log(LOG_DEBUG, "Successfully sent client nonce to server.");
 
   ssize_t read_result = read(socket_fd, response, response_len);
 
   if (read_result <= 0)
   {
     kmyth_log(LOG_ERR, "Failed to read the nonce response message.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
@@ -855,93 +872,106 @@ int negotiate_client_session_key(int socket_fd,
   request = NULL;
   request_len = 0;
 
-  unsigned char *received_nonce_a = NULL;
-  size_t received_nonce_a_len = 0;
+  unsigned char *rcvd_client_nonce = NULL;
+  size_t rcvd_client_nonce_len = 0;
 
-  unsigned char *received_id = NULL;
-  size_t received_id_len = 0;
+  unsigned char *rcvd_server_id = NULL;
+  size_t rcvd_server_id_len = 0;
 
   // read_result can safely be cast to a size_t since we've already
   // dealt with the possibility it's negative
   result = parse_nonce_response(private_key_ctx,
                                 response, (size_t)read_result,
-                                &received_nonce_a, &received_nonce_a_len,
-                                &nonce_b, &nonce_b_len,
-                                &received_id, &received_id_len);
+                                &rcvd_client_nonce, &rcvd_client_nonce_len,
+                                &server_nonce, &server_nonce_len,
+                                &rcvd_server_id, &rcvd_server_id_len);
   kmyth_clear_and_free(response, response_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to parse the nonce response.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
 
-  kmyth_log(LOG_DEBUG, "Received nonce A: %zd bytes", received_nonce_a_len);
-  kmyth_log(LOG_DEBUG, "Received nonce B: %zd bytes", nonce_b_len);
-  kmyth_log(LOG_DEBUG, "Received ID: %.*s", received_id_len, received_id);
+  char rcvd_client_nonce_str[(2 * rcvd_client_nonce_len) + 1];
+  char *rcvd_client_nonce_str_ptr = rcvd_client_nonce_str;
+  for (size_t i = 0; i < rcvd_client_nonce_len; i++) {
+    rcvd_client_nonce_str_ptr += sprintf(rcvd_client_nonce_str_ptr, "%02X", rcvd_client_nonce[i]);
+  }
+  kmyth_log(LOG_DEBUG, "Received client nonce (%zd bytes): %s",
+                       rcvd_client_nonce_len, rcvd_client_nonce_str);
 
-  if (nonce_a_len != received_nonce_a_len)
+  char server_nonce_str[(2 * server_nonce_len) + 1];
+  char *server_nonce_str_ptr = &server_nonce_str[0];
+  for (size_t i = 0; i < server_nonce_len; i++) {
+    server_nonce_str_ptr += sprintf(server_nonce_str_ptr, "%02X", server_nonce[i]);
+  }
+  kmyth_log(LOG_DEBUG, "Received server nonce (%zd bytes): %s",
+                       server_nonce_len, server_nonce_str);
+  
+  kmyth_log(LOG_DEBUG, "Received server ID: %.*s", rcvd_server_id_len, rcvd_server_id);
+
+  if (client_nonce_len != rcvd_client_nonce_len)
   {
-    kmyth_log(LOG_ERR, "The received nonce A length is invalid.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_id, received_id_len);
+    kmyth_log(LOG_ERR, "The received client nonce length is invalid.");
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
     return 1;
   }
-  if (nonce_b_len != nonce_a_len)
+  if (server_nonce_len != client_nonce_len)
   {
-    kmyth_log(LOG_ERR, "The received nonce B length is invalid.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_id, received_id_len);
+    kmyth_log(LOG_ERR, "The received server nonce length (%zd) is invalid.", server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
     return 1;
   }
-  if (strncmp
-      ((const char *) nonce_a, (const char *) received_nonce_a,
-       nonce_a_len) != 0)
+  if (strncmp((const char *) client_nonce,
+              (const char *) rcvd_client_nonce,
+              client_nonce_len) != 0)
   {
-    kmyth_log(LOG_ERR, "The received nonce A is invalid.");
-    kmyth_log(LOG_ERR, "Expected nonce A: %zd bytes", nonce_a_len);
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_id, received_id_len);
+    kmyth_log(LOG_ERR, "The received client nonce is invalid.");
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
     return 1;
   }
 
-  kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+  kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
 
-  if (strncmp
-      ((const char *) received_id, (const char *) expected_id,
-       expected_id_len) != 0)
+  if (strncmp((const char *) rcvd_server_id,
+              (const char *) expected_server_id,
+              expected_server_id_len) != 0)
   {
-    kmyth_log(LOG_ERR, "The received ID is invalid.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_id, received_id_len);
+    kmyth_log(LOG_ERR, "The received server ID (%s) is invalid.", rcvd_server_id);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
     return 1;
   }
 
-  kmyth_clear_and_free(received_id, received_id_len);
+  kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
 
   result = build_nonce_confirmation(public_key_ctx,
-                                    nonce_b, nonce_b_len,
+                                    server_nonce, server_nonce_len,
                                     &request, &request_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to build the nonce confirmation.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
     return 1;
   }
 
   if (write(socket_fd, request, request_len) != request_len)
   {
     kmyth_log(LOG_ERR, "Failed to fully send the nonce confirmation.");
-    kmyth_clear_and_free(nonce_a, nonce_a_len);
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(request, request_len);
     return 1;
   }
@@ -951,11 +981,11 @@ int negotiate_client_session_key(int socket_fd,
   request_len = 0;
 
   // Use nonces to generate shared session key S
-  result = generate_session_key(nonce_a, nonce_a_len,
-                                nonce_b, nonce_b_len,
+  result = generate_session_key(client_nonce, client_nonce_len,
+                                server_nonce, server_nonce_len,
                                 session_key, session_key_len);
-  kmyth_clear_and_free(nonce_a, nonce_a_len);
-  kmyth_clear_and_free(nonce_b, nonce_b_len);
+  kmyth_clear_and_free(client_nonce, client_nonce_len);
+  kmyth_clear_and_free(server_nonce, server_nonce_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to generate the session key.");
@@ -971,16 +1001,16 @@ int negotiate_client_session_key(int socket_fd,
 int negotiate_server_session_key(int socket_fd,
                                  EVP_PKEY_CTX * public_key_ctx,
                                  EVP_PKEY_CTX * private_key_ctx,
-                                 unsigned char *id,
-                                 size_t id_len,
+                                 unsigned char *server_id,
+                                 size_t server_id_len,
                                  unsigned char **session_key,
                                  size_t *session_key_len)
 {
-  // Generate nonce B
-  unsigned char *nonce_b = NULL;
-  size_t nonce_b_len = 0;
+  // Generate server nonce
+  unsigned char *server_nonce = NULL;
+  size_t server_nonce_len = 0;
 
-  int result = generate_nonce(NSL_NONCE_LEN, &nonce_b, &nonce_b_len);
+  int result = generate_nonce(NSL_NONCE_LEN, &server_nonce, &server_nonce_len);
 
   if (result)
   {
@@ -988,22 +1018,23 @@ int negotiate_server_session_key(int socket_fd,
     return 1;
   }
 
-  // DEBUG
-  kmyth_log(LOG_DEBUG, "Generated nonce B: %zd bytes", nonce_b_len);
-  for (size_t i = 0; i < nonce_b_len; i++) {
-    printf("%02x ", nonce_b[i]);
-    if ((i + 1) % 16 == 0) {
-      printf("\n");
-    }
+  char server_nonce_str[(2 * server_nonce_len) + 1];
+  char *server_nonce_str_ptr = server_nonce_str;
+  for (size_t i = 0; i < server_nonce_len; i++) {
+    server_nonce_str_ptr += sprintf(server_nonce_str_ptr, "%02X", server_nonce[i]);
   }
+  kmyth_log(LOG_DEBUG,
+            "Generated client nonce (%zd bytes): %s",
+            server_nonce_len,
+            server_nonce_str);
 
-  // Conduct NSL to obtain nonce A
+  // Conduct NSL to obtain client nonce
   unsigned char *response = calloc(8192, sizeof(unsigned char));
 
   if (NULL == response)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the response buffer.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
     return 1;
   }
   size_t response_len = 8192;
@@ -1012,44 +1043,55 @@ int negotiate_server_session_key(int socket_fd,
 
   if (read_result <= 0)
   {
-    kmyth_log(LOG_ERR, "Failed to receive the nonce request.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
+    kmyth_log(LOG_ERR, "Failed to receive the nonce request from client.");
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
 
-  unsigned char *received_nonce_a = NULL;
-  size_t received_nonce_a_len = 0;
+  unsigned char *client_nonce = NULL;
+  size_t client_nonce_len = 0;
 
-  unsigned char *received_id = NULL;
-  size_t received_id_len = 0;
+  unsigned char *client_id = NULL;
+  size_t client_id_len = 0;
 
   // read_result can safely be cast to size_t because we've already
   // dealt with the case that it's negative.
   result = parse_nonce_request(private_key_ctx,
                                response, (size_t)read_result,
-                               &received_nonce_a, &received_nonce_a_len,
-                               &received_id, &received_id_len);
+                               &client_nonce, &client_nonce_len,
+                               &client_id, &client_id_len);
 
-  kmyth_log(LOG_DEBUG, "Received nonce A: %zd bytes", received_nonce_a_len);
-  kmyth_log(LOG_DEBUG, "Received ID: %.*s", received_id_len, received_id);
+  char client_nonce_str[(2 * client_nonce_len) + 1];
+  char *client_nonce_str_ptr = client_nonce_str;
+  for (size_t i = 0; i < client_nonce_len; i++) {
+    client_nonce_str_ptr += sprintf(client_nonce_str_ptr,
+                                    "%02X", client_nonce[i]);
+  }
+  kmyth_log(LOG_DEBUG,
+            "Received client nonce (%zd bytes): %s",
+            client_nonce_len,
+            client_nonce_str);
 
-  kmyth_clear_and_free(received_id, received_id_len);
+  kmyth_log(LOG_DEBUG, "Received client ID: %.*s", client_id_len, client_id);
+
+  kmyth_clear_and_free(client_id, client_id_len);
   kmyth_clear_and_free(response, response_len);
   response = NULL;
   response_len = 0;
 
-  kmyth_log(LOG_DEBUG, "Sending nonce B: %zd", nonce_b_len);
+  kmyth_log(LOG_DEBUG, "Sending server nonce to client.");
 
   result = build_nonce_response(public_key_ctx,
-                                received_nonce_a, received_nonce_a_len,
-                                nonce_b, nonce_b_len,
-                                id, id_len, &response, &response_len);
+                                client_nonce, client_nonce_len,
+                                server_nonce, server_nonce_len,
+                                server_id, server_id_len,
+                                &response, &response_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to build the nonce response.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
 
@@ -1057,9 +1099,9 @@ int negotiate_server_session_key(int socket_fd,
 
   if (response_len != send_result)
   {
-    kmyth_log(LOG_ERR, "Failed to fully send the nonce response.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+    kmyth_log(LOG_ERR, "Error sending the nonce response.");
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
@@ -1070,7 +1112,8 @@ int negotiate_server_session_key(int socket_fd,
   if (NULL == response)
   {
     kmyth_log(LOG_ERR, "Failed to re-allocate the response buffer.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
   response_len = 8192 * sizeof(unsigned char);
@@ -1079,61 +1122,71 @@ int negotiate_server_session_key(int socket_fd,
   if (read_result <= 0)
   {
     kmyth_log(LOG_ERR, "Failed to receive the nonce confirmation.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
     return 1;
   }
 
-  unsigned char *received_nonce_b = NULL;
-  size_t received_nonce_b_len = 0;
+  unsigned char *rcvd_server_nonce = NULL;
+  size_t rcvd_server_nonce_len = 0;
 
   // read_result can safely be cast to a size_t because we've already
   // dealt with the case it's negative.
   result = parse_nonce_confirmation(private_key_ctx,
                                     response,
                                     (size_t) read_result,
-                                    &received_nonce_b,
-                                    &received_nonce_b_len);
+                                    &rcvd_server_nonce,
+                                    &rcvd_server_nonce_len);
   kmyth_clear_and_free(response, response_len);
   if (result)
   {
-    kmyth_log(LOG_ERR, "Failed to parse the nonce confirmation.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+    kmyth_log(LOG_ERR, "Failed to parse the nonce confirmation message.");
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
-  if (nonce_b_len != received_nonce_b_len)
+  if (server_nonce_len != rcvd_server_nonce_len)
   {
-    kmyth_log(LOG_ERR, "The received nonce B length is invalid.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
-    kmyth_clear_and_free(received_nonce_b, received_nonce_b_len);
+    kmyth_log(LOG_ERR, "Server nonce received from client has invalid size.");
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(rcvd_server_nonce, rcvd_server_nonce_len);
     return 1;
   }
-  if (strncmp
-      ((const char *) nonce_b, (const char *) received_nonce_b,
-       nonce_b_len) != 0)
+  if (strncmp((const char *) server_nonce,
+              (const char *) rcvd_server_nonce,
+              server_nonce_len) != 0)
   {
-    kmyth_log(LOG_ERR, "The received nonce B is invalid.");
-    kmyth_clear_and_free(nonce_b, nonce_b_len);
-    kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
-    kmyth_clear_and_free(received_nonce_b, received_nonce_b_len);
+    kmyth_log(LOG_ERR, "Invalid server nonce received from client.");
+    kmyth_clear_and_free(server_nonce, server_nonce_len);
+    kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(rcvd_server_nonce, rcvd_server_nonce_len);
     return 1;
   }
 
-  kmyth_clear_and_free(received_nonce_b, received_nonce_b_len);
-  kmyth_log(LOG_DEBUG, "Received nonce B: %zd bytes", nonce_b_len);
+  char rcvd_server_nonce_str[(2 * rcvd_server_nonce_len) + 1];
+  char *rcvd_server_nonce_str_ptr = rcvd_server_nonce_str;
+  for (size_t i = 0; i < rcvd_server_nonce_len; i++) {
+    rcvd_server_nonce_str_ptr += sprintf(rcvd_server_nonce_str_ptr,
+                                    "%02X", rcvd_server_nonce[i]);
+  }
+  kmyth_log(LOG_DEBUG,
+            "Received server nonce (%zd bytes): %s",
+            rcvd_server_nonce_len,
+            rcvd_server_nonce_str);
+  kmyth_clear_and_free(rcvd_server_nonce, rcvd_server_nonce_len);
+
 
   // Use nonces to generate shared session key S
-  result = generate_session_key(received_nonce_a,
-                                received_nonce_a_len,
-                                nonce_b,
-                                nonce_b_len,
+  result = generate_session_key(client_nonce,
+                                client_nonce_len,
+                                server_nonce,
+                                server_nonce_len,
                                 session_key,
                                 session_key_len);
-  kmyth_clear_and_free(nonce_b, nonce_b_len);
-  kmyth_clear_and_free(received_nonce_a, received_nonce_a_len);
+  kmyth_clear_and_free(server_nonce, server_nonce_len);
+  kmyth_clear_and_free(client_nonce, client_nonce_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to generate the session key.");

--- a/src/protocol/nsl_util.c
+++ b/src/protocol/nsl_util.c
@@ -129,25 +129,17 @@ int build_nonce_request(EVP_PKEY_CTX * ctx,
                         unsigned char **request,
                         size_t *request_len)
 {
+  // Validate nonce and ID lengths provided as parameters.
   if (NSL_NONCE_LEN != nonce_len)
   {
     kmyth_log(LOG_ERR,
-              "Invalid nonce length provided; received: %zd, expected: %zd",
+              "Invalid nonce length; specified: %zd, expected: %zd",
               nonce_len, NSL_NONCE_LEN);
-    return 1;
-  }
-
-  // Validate nonce and ID lengths requested.
-  if (nonce_len != NSL_NONCE_LEN) {
-    kmyth_log(LOG_ERR,
-              "Invalid nonce length - requested: %zd bytes, expected: %zd bytes",
-              nonce_len,
-              NSL_NONCE_LEN);
     return 1;
   }
   if (id_len > NSL_ID_MAX_LEN) {
     kmyth_log(LOG_ERR,
-              "Invalid ID length - requested: %zd bytes, maximum: %zd bytes",
+              "Invalid ID length; specified: %zd, maximum: %zd",
               id_len,
               NSL_ID_MAX_LEN);
     return 1;
@@ -327,6 +319,29 @@ int build_nonce_response(EVP_PKEY_CTX * ctx,
                          unsigned char **response,
                          size_t *response_len)
 {
+  // Validate nonce and ID lengths provided as parameters.
+  if (NSL_NONCE_LEN != nonce_a_len)
+  {
+    kmyth_log(LOG_ERR,
+              "Invalid first nonce length; specified: %zd, expected: %zd",
+              nonce_a_len, NSL_NONCE_LEN);
+    return 1;
+  }
+  if (NSL_NONCE_LEN != nonce_b_len)
+  {
+    kmyth_log(LOG_ERR,
+              "Invalid second nonce length; specified: %zd, expected: %zd",
+              nonce_b_len, NSL_NONCE_LEN);
+    return 1;
+  }
+  if (id_len > NSL_ID_MAX_LEN) {
+    kmyth_log(LOG_ERR,
+              "Invalid ID length; specified: %zd, maximum: %zd",
+              id_len,
+              NSL_ID_MAX_LEN);
+    return 1;
+  }
+
   // Allocate the unencrypted response buffer.
   unsigned char *message = NULL;
   size_t message_len = id_len +
@@ -572,10 +587,11 @@ int build_nonce_confirmation(EVP_PKEY_CTX * ctx,
                              unsigned char **confirmation,
                              size_t *confirmation_len)
 {
+  // Validate nonce length provided as a parameter.
   if (NSL_NONCE_LEN != nonce_len)
   {
     kmyth_log(LOG_ERR,
-              "Invalid nonce length provided; received: %zd, expected: %zd",
+              "Invalid nonce length; specified: %zd, expected: %zd",
               nonce_len, NSL_NONCE_LEN);
     return 1;
   }
@@ -630,32 +646,55 @@ int parse_nonce_confirmation(EVP_PKEY_CTX * ctx,
   // Decrypt the nonce confirmation.
   unsigned char *message = NULL;
   size_t message_len = 0;
-  int result =
-    decrypt_with_key_pair(ctx,
-                          confirmation,
-                          confirmation_len,
-                          &message,
-                          &message_len);
-
+  int result = decrypt_with_key_pair(ctx,
+                                     confirmation,
+                                     confirmation_len,
+                                     &message,
+                                     &message_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to decrypt the nonce confirmation.");
     return 1;
   }
-  unsigned char *index = message;
 
-  // Parse out the nonce.
+  // Initialize 'index' and 'bytes_remaining' variables for parsing message
+  unsigned char *index = message;
+  size_t bytes_remaining = message_len;
+
+  // Parse and validate size of nonce.
+  if (bytes_remaining < sizeof(size_t)) {
+    kmyth_log(LOG_ERR, "Nonce confirmation message buffer too small.");
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   memcpy(nonce_len, index, sizeof(size_t));
+  if (NSL_NONCE_LEN != *nonce_len)
+  {
+    kmyth_log(LOG_ERR,
+              "Unexpected length for nonce; received: %zd bytes, expected: %zd bytes",
+              *nonce_len, NSL_NONCE_LEN);
+    kmyth_clear_and_free(message, message_len);
+    return 1;
+  }
   index += sizeof(size_t);
+  bytes_remaining -= sizeof(size_t);
+  
+
+  // Allocate the nonce buffer
   *nonce = calloc(*nonce_len, sizeof(unsigned char));
   if (*nonce == NULL)
   {
     kmyth_log(LOG_ERR, "Failed to allocate the nonce buffer.");
-
     *nonce_len = 0;
-
     kmyth_clear_and_free(message, message_len);
-
+    return 1;
+  }
+  
+  // Parse the nonce bytes 
+  if (bytes_remaining < *nonce_len) {
+    kmyth_log(LOG_ERR, "Nonce confirmation message buffer too small.");
+    *nonce_len = 0;
+    kmyth_clear_and_free(message, message_len);
     return 1;
   }
   memcpy(*nonce, index, *nonce_len);
@@ -768,33 +807,35 @@ int generate_session_key(unsigned char *nonce_a,
                          unsigned char **key,
                          size_t *key_len)
 {
+  // Validate the nonce lengths provided as parameters
   if (NSL_NONCE_LEN != nonce_a_len)
   {
     kmyth_log(LOG_ERR,
-              "Invalid nonce A length provided; received: %zd, expected: %zd",
+              "Invalid first nonce length; specified: %zd, expected: %zd",
               nonce_a_len, NSL_NONCE_LEN);
     return 1;
   }
   if (NSL_NONCE_LEN != nonce_b_len)
   {
     kmyth_log(LOG_ERR,
-              "Invalid nonce B length provided; received: %zd, expected: %zd",
+              "Invalid second nonce length; specifieded: %zd, expected: %zd",
               nonce_b_len, NSL_NONCE_LEN);
     return 1;
   }
 
   // Build the combined nonce as the base for key generation.
-  size_t len = nonce_a_len + nonce_b_len;
-  unsigned char *nonces = calloc(len, sizeof(unsigned char));
 
+  // Allocate a buffer to hold the concatenated nonces
+  size_t nonces_len = nonce_a_len + nonce_b_len;
+  unsigned char *nonces = calloc(nonces_len, sizeof(unsigned char));
   if (NULL == nonces)
   {
     kmyth_log(LOG_ERR, "Failed to allocated the nonces buffer.");
     return 1;
   }
-  size_t nonces_len = len * sizeof(unsigned char);
+  
+  // Copy the nonce values into the buffer
   unsigned char *index = nonces;
-
   memcpy(index, nonce_a, nonce_a_len);
   index += nonce_a_len;
   memcpy(index, nonce_b, nonce_b_len);
@@ -807,8 +848,6 @@ int generate_session_key(unsigned char *nonce_a,
     kmyth_clear_and_free(nonces, nonces_len);
     return 1;
   }
-
-  // Set session key length to match digest length of hash
 
   // Create new message digest context
   EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -831,7 +870,7 @@ int generate_session_key(unsigned char *nonce_a,
   }
 
   // Hash loaded value to compute message digest
-  result = EVP_DigestUpdate(ctx, nonces, len);
+  result = EVP_DigestUpdate(ctx, nonces, nonces_len);
   if (0 == result)
   {
     kmyth_log(LOG_ERR, "Failed to update the MD context.");
@@ -841,6 +880,7 @@ int generate_session_key(unsigned char *nonce_a,
   }
 
   // Allocate session key buffer
+  // Set session key length to match digest length of hash
   *key_len = (size_t) EVP_MD_get_size(type);
   *key = calloc(*key_len, sizeof(unsigned char));
   if (NULL == key)
@@ -981,7 +1021,7 @@ int negotiate_client_session_key(int socket_fd,
   request_len = 0;
  
 
-  // Client allocates buffer to receive nonce response message from server
+  // Allocate buffer to receive nonce response message from server
   unsigned char *response = calloc(NSL_RX_BUF_LEN, sizeof(unsigned char));
   if (NULL == response)
   {
@@ -989,6 +1029,8 @@ int negotiate_client_session_key(int socket_fd,
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
+
+  // Read in (receive) nonce response message from server
   ssize_t read_result = read(socket_fd, response, NSL_RX_BUF_LEN);
   if (read_result <= 0)
   {
@@ -1001,22 +1043,20 @@ int negotiate_client_session_key(int socket_fd,
             "Received nonce response message (%zd bytes) from server",
             read_result);
 
-  unsigned char *rcvd_client_nonce = NULL;
-  size_t rcvd_client_nonce_len = 0;
-
-  unsigned char *rcvd_server_id = NULL;
-  size_t rcvd_server_id_len = 0;
-
-  // read_result can safely be cast to a size_t since we've already
-  // dealt with the possibility it's negative
+  // Parse received nonce response message
+  // ( Note: read_result can safely be cast to a size_t
+  //         since already checked that it is not negative)
+  unsigned char *server_id = NULL;
+  size_t server_id_len = 0;
   unsigned char *server_nonce = NULL;
   size_t server_nonce_len = 0;
-
+  unsigned char *rcvd_client_nonce = NULL;
+  size_t rcvd_client_nonce_len = 0;
   result = parse_nonce_response(private_key_ctx,
                                 response, (size_t)read_result,
                                 &rcvd_client_nonce, &rcvd_client_nonce_len,
                                 &server_nonce, &server_nonce_len,
-                                &rcvd_server_id, &rcvd_server_id_len);
+                                &server_id, &server_id_len);
   kmyth_clear_and_free(response, NSL_RX_BUF_LEN);
   if (result)
   {
@@ -1041,57 +1081,68 @@ int negotiate_client_session_key(int socket_fd,
   kmyth_log(LOG_DEBUG, "Received server nonce (%zd bytes): %s",
                        server_nonce_len, server_nonce_str);
   
-  kmyth_log(LOG_DEBUG, "Received server ID: %.*s", rcvd_server_id_len, rcvd_server_id);
+  kmyth_log(LOG_DEBUG, "Received server ID: %.*s", server_id_len, server_id);
 
   if (client_nonce_len != rcvd_client_nonce_len)
   {
-    kmyth_log(LOG_ERR, "The received client nonce length is invalid.");
+    kmyth_log(LOG_ERR, "%s; received: %zd, expected: %zd",
+                       "Received client nonce length is invalid",
+                       rcvd_client_nonce_len,
+                       client_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
+    kmyth_clear_and_free(server_id, server_id_len);
     return 1;
   }
   if (server_nonce_len != client_nonce_len)
   {
-    kmyth_log(LOG_ERR, "The received server nonce length (%zd) is invalid.", server_nonce_len);
+    kmyth_log(LOG_ERR, "%s; received: %zd, expected: %zd",
+                       "Received server nonce length is invalid",
+                       server_nonce_len,
+                       client_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
+    kmyth_clear_and_free(server_id, server_id_len);
     return 1;
   }
   if (strncmp((const char *) client_nonce,
               (const char *) rcvd_client_nonce,
               client_nonce_len) != 0)
   {
-    kmyth_log(LOG_ERR, "The received client nonce is invalid.");
+    kmyth_log(LOG_ERR, "Received/Generated client nonce mis-match.");
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
+    kmyth_clear_and_free(server_id, server_id_len);
     return 1;
   }
 
   kmyth_clear_and_free(rcvd_client_nonce, rcvd_client_nonce_len);
 
-  if (strncmp((const char *) rcvd_server_id,
+  if (strncmp((const char *) server_id,
               (const char *) expected_server_id,
               expected_server_id_len) != 0)
-  {
-    kmyth_log(LOG_ERR, "The received server ID (%s) is invalid.", rcvd_server_id);
+  { 
+    kmyth_log(LOG_ERR,
+              "Invalid server ID; received: %s, expected: %s",
+              server_id,
+              expected_server_id);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
+    kmyth_clear_and_free(server_id, server_id_len);
     return 1;
   }
 
-  kmyth_clear_and_free(rcvd_server_id, rcvd_server_id_len);
+  kmyth_clear_and_free(server_id, server_id_len);
 
   //   - client sends nonce confirmation message
+  unsigned char *confirmation = NULL;
+  size_t confirmation_len = 0;
   result = build_nonce_confirmation(public_key_ctx,
                                     server_nonce, server_nonce_len,
-                                    &request, &request_len);
+                                    &confirmation, &confirmation_len);
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to build the nonce confirmation.");
@@ -1100,18 +1151,18 @@ int negotiate_client_session_key(int socket_fd,
     return 1;
   }
 
-  if (write(socket_fd, request, request_len) != request_len)
+  if (write(socket_fd, confirmation, confirmation_len) != confirmation_len)
   {
     kmyth_log(LOG_ERR, "Failed to fully send the nonce confirmation.");
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(server_nonce, server_nonce_len);
-    kmyth_clear_and_free(request, request_len);
+    kmyth_clear_and_free(confirmation, confirmation_len);
     return 1;
   }
 
-  kmyth_clear_and_free(request, request_len);
-  request = NULL;
-  request_len = 0;
+  kmyth_clear_and_free(confirmation, confirmation_len);
+  confirmation = NULL;
+  confirmation_len = 0;
 
   // Use nonces to generate shared session key S
   result = generate_session_key(client_nonce, client_nonce_len,
@@ -1147,7 +1198,7 @@ int negotiate_server_session_key(int socket_fd,
 
   if (result)
   {
-    kmyth_log(LOG_ERR, "Failed to generate a nonce.");
+    kmyth_log(LOG_ERR, "Failed to generate local (server) nonce.");
     return 1;
   }
 
@@ -1171,6 +1222,8 @@ int negotiate_server_session_key(int socket_fd,
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     return 1;
   }
+
+  // Receive nonce request message from client
   ssize_t read_result = read(socket_fd, request, NSL_RX_BUF_LEN);
   if (read_result <= 0)
   {
@@ -1186,8 +1239,9 @@ int negotiate_server_session_key(int socket_fd,
   unsigned char *client_id = NULL;
   size_t client_id_len = 0;
 
-  // read_result can safely be cast to size_t because we've already
-  // dealt with the case that it's negative.
+  // Parse the nonce request message received from the client
+  // (Note: read_result can safely be cast to size_t because we've already
+  //        checked that it is non-negative)
   result = parse_nonce_request(private_key_ctx,
                                request, (size_t)read_result,
                                &client_nonce, &client_nonce_len,
@@ -1203,20 +1257,14 @@ int negotiate_server_session_key(int socket_fd,
             "Received remote (client) nonce (%zd bytes): %s",
             client_nonce_len,
             client_nonce_str);
-
   kmyth_log(LOG_DEBUG, "Received remote (client) ID: %.*s",
             client_id_len, client_id);
-
   kmyth_clear_and_free(client_id, client_id_len);
   kmyth_clear_and_free(request, NSL_RX_BUF_LEN);
 
-  kmyth_log(LOG_DEBUG, "Sending nonce response message to client.");
-
-  size_t response_len = server_id_len +
-                        server_nonce_len +
-                        client_nonce_len +
-                        (3 * sizeof(size_t));
-  unsigned char *response = calloc(response_len, sizeof(unsigned char));
+  // Construct nonce response message
+  unsigned char *response = NULL;
+  size_t response_len = 0;
   result = build_nonce_response(public_key_ctx,
                                 client_nonce, client_nonce_len,
                                 server_nonce, server_nonce_len,
@@ -1227,53 +1275,63 @@ int negotiate_server_session_key(int socket_fd,
     kmyth_log(LOG_ERR, "Failed to build the nonce response.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
+    kmyth_clear_and_free(response, response_len);
+    response = NULL;
+    response_len = 0;
     return 1;
   }
 
+  // Send nonce response message to client
   ssize_t send_result = write(socket_fd, response, response_len);
-
   if (response_len != send_result)
   {
     kmyth_log(LOG_ERR, "Error sending the nonce response.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     kmyth_clear_and_free(response, response_len);
+    response = NULL;
+    response_len = 0;
     return 1;
   }
-
+  kmyth_log(LOG_DEBUG, "Sent nonce response message to client.");
   kmyth_clear_and_free(response, response_len);
+  response = NULL;
+  response_len = 0;
 
-  response = calloc(8192, sizeof(unsigned char));
-  if (NULL == response)
+  // Allocate receive buffer for nonce confirmation expected from client
+  unsigned char *confirmation = calloc(NSL_RX_BUF_LEN, sizeof(unsigned char));
+  if (NULL == confirmation)
   {
-    kmyth_log(LOG_ERR, "Failed to re-allocate the response buffer.");
+    kmyth_log(LOG_ERR, "Failed to allocate confirmation message receive buffer.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
     return 1;
   }
-  response_len = 8192 * sizeof(unsigned char);
-
-  read_result = read(socket_fd, response, response_len);
+  
+  // Receive (read in) the confirmation message from the client
+  read_result = read(socket_fd, confirmation, NSL_RX_BUF_LEN);
   if (read_result <= 0)
   {
     kmyth_log(LOG_ERR, "Failed to receive the nonce confirmation.");
     kmyth_clear_and_free(server_nonce, server_nonce_len);
     kmyth_clear_and_free(client_nonce, client_nonce_len);
-    kmyth_clear_and_free(response, response_len);
+    kmyth_clear_and_free(confirmation, NSL_RX_BUF_LEN);
+    confirmation = NULL;
     return 1;
   }
 
+  // Parse the received nonce confirmation message
+  // (Note: read_result can safely be cast to a size_t
+  //        because already checked that it is not negative)
   unsigned char *rcvd_server_nonce = NULL;
   size_t rcvd_server_nonce_len = 0;
-
-  // read_result can safely be cast to a size_t because we've already
-  // dealt with the case it's negative.
   result = parse_nonce_confirmation(private_key_ctx,
-                                    response,
+                                    confirmation,
                                     (size_t) read_result,
                                     &rcvd_server_nonce,
                                     &rcvd_server_nonce_len);
-  kmyth_clear_and_free(response, response_len);
+  kmyth_clear_and_free(confirmation, NSL_RX_BUF_LEN);
+  confirmation = NULL;
   if (result)
   {
     kmyth_log(LOG_ERR, "Failed to parse the nonce confirmation message.");


### PR DESCRIPTION
This pull request addresses the memory bugs reported at [Multiple pre-auth memory bugs in NSL session-key negotiation (parse_nonce_request / parse_nonce_response / parse_nonce_confirmation)](https://github.com/NationalSecurityAgency/kmyth/security/advisories/GHSA-8xjr-2jwr-mxpp).

This also includes a lot of general clean-up like renaming variables in an attempt to better clarify client/server roles, whitespace edits, enhanced debug logging messages, and the like.

An nsl-test target was added to simplify running the NSL code as a simple demo/test.

A couple additional minor memory issues were also encountered and addressed.



